### PR TITLE
add initiated maker swap to running swaps

### DIFF
--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -332,6 +332,7 @@ impl Runtime {
                         Request::MakeSwap(swap_params.clone()),
                     )?;
                     self.making_swaps.remove(&source);
+                    self.running_swaps.insert(&source);
                 } else if let Some(swap_params) = self.taking_swaps.get(&source)
                 {
                     // Tell swapd swap options and link it with the


### PR DESCRIPTION
after swapd is successfully launched, the swap is removed from making_swaps and
added to running swaps.