### PR TITLE
integration test framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,5 +147,7 @@ serde = ["serde_crate", "serde_with", "serde_yaml", "serde_json", "toml",
 tor = ["microservices/tor", "internet2/tor"]
 vendored_openssl = ["microservices/vendored_openssl", "internet2/vendored_openssl"]
 
+integration_test = []
+
 [package.metadata.configure_me]
 spec = "config_spec.toml"

--- a/src/farcasterd/mod.rs
+++ b/src/farcasterd/mod.rs
@@ -19,3 +19,4 @@ mod runtime;
 #[cfg(feature = "shell")]
 pub use opts::Opts;
 pub use runtime::run;
+pub use runtime::launch;

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -1009,7 +1009,13 @@ pub fn launch(
     );
 
     let mut cmd = process::Command::new(bin_path);
+    
+    #[cfg(feature = "integration_test")]
+    cmd.args(args);
+
+    #[cfg(not(feature = "integration_test"))]
     cmd.args(std::env::args().skip(1)).args(args);
+
     trace!("Executing `{:?}`", cmd);
     cmd.spawn().map_err(|err| {
         error!("Error launching {}: {}", name, err);

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -889,7 +889,7 @@ impl Runtime {
         }
 
         // Start swapd
-        let child = launch("swapd", &[swap_req.temporary_channel_id.to_hex()], true)?;
+        let child = launch("swapd", &[swap_req.temporary_channel_id.to_hex()])?;
         let msg = format!("New instance of swapd launched with PID {}", child.id());
         info!("{}", msg);
         Ok(())
@@ -906,7 +906,6 @@ impl Runtime {
             let child = launch(
                 "peerd",
                 &["--listen", &ip.to_string(), "--port", &port.to_string()],
-                true,
             )?;
             let msg = format!("New instance of peerd launched with PID {}", child.id());
             info!("{}", msg);
@@ -927,7 +926,7 @@ impl Runtime {
             )));
         }
         // Start peerd
-        let child = launch("peerd", &["--connect", &node_addr.to_string()], true);
+        let child = launch("peerd", &["--connect", &node_addr.to_string()]);
 
         // in case it can't connect wait for it to crash
         std::thread::sleep(Duration::from_secs_f32(0.5));
@@ -967,7 +966,6 @@ fn launch_swapd(
             public_offer.to_string(),
             negotiation_role.to_string(),
         ],
-        true,
     )?;
     let msg = format!("New instance of swapd launched with PID {}", child.id());
     info!("{}", msg);
@@ -993,7 +991,6 @@ fn launch_swapd(
 pub fn launch(
     name: &str,
     args: impl IntoIterator<Item = impl AsRef<OsStr>>,
-    use_cmd_args: bool,
 ) -> io::Result<process::Child> {
     let mut bin_path = std::env::current_exe().map_err(|err| {
         error!("Unable to detect binary directory: {}", err);
@@ -1012,11 +1009,7 @@ pub fn launch(
     );
 
     let mut cmd = process::Command::new(bin_path);
-    if use_cmd_args {
-        cmd.args(std::env::args().skip(1)).args(args);
-    } else {
-        cmd.args(args);
-    }
+    cmd.args(std::env::args().skip(1)).args(args);
     trace!("Executing `{:?}`", cmd);
     cmd.spawn().map_err(|err| {
         error!("Error launching {}: {}", name, err);

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -983,6 +983,7 @@ fn launch_swapd(
             swap_id,
         },
     );
+    
     debug!("Awaiting for swapd to connect...");
 
     Ok(msg)

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -1009,7 +1009,7 @@ pub fn launch(
     );
 
     let mut cmd = process::Command::new(bin_path);
-    
+
     #[cfg(feature = "integration_test")]
     cmd.args(args);
 
@@ -1017,8 +1017,21 @@ pub fn launch(
     cmd.args(std::env::args().skip(1)).args(args);
 
     trace!("Executing `{:?}`", cmd);
-    cmd.spawn().map_err(|err| {
-        error!("Error launching {}: {}", name, err);
-        err
-    })
+    match cmd.spawn() {
+        Ok(child) => {
+            println!(
+                "Successfully launched child {:?} with PID {:?}",
+                name, child.id()
+            );
+            Ok(child)
+        }
+        Err(err) => {
+            error!("Error launching {}: {}", name, err);
+            Err(err)
+        }
+    }
+    // cmd.spawn().map_err(|err| {
+    //     error!("Error launching {}: {}", name, err);
+    //     err
+    // })
 }

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -988,7 +988,7 @@ fn launch_swapd(
     Ok(msg)
 }
 
-fn launch(
+pub fn launch(
     name: &str,
     args: impl IntoIterator<Item = impl AsRef<OsStr>>,
 ) -> io::Result<process::Child> {

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -8,8 +8,9 @@ use microservices::shell::Exec;
 
 #[test]
 fn spawn_swap() {
-    use farcaster_node::farcasterd::{launch, Opts};
-    let mut opts = Opts::parse_from(vec![""].into_iter());
+    use farcaster_node::farcasterd::{launch};
+    use farcaster_node::cli::Opts;
+    let mut opts = Opts::parse_from(vec!["swap-cli", "make"].into_iter());
     opts.process();
     println!("{:?}", opts);
     let config: Config = opts.shared.clone().into();
@@ -22,4 +23,10 @@ fn spawn_swap() {
     Command::Ls
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
+
+    println!("executing command: {:?}", opts.command);
+    opts.command
+        .exec(&mut client)
+        .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
+
 }

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -1,0 +1,24 @@
+use clap::Clap;
+use farcaster_node::rpc::Client;
+use farcaster_node::{Config, LogStyle};
+
+use farcaster_node::cli::Command;
+use microservices::shell::Exec;
+
+#[test]
+fn spawn_swap() {
+    use farcaster_node::farcasterd::{launch, Opts};
+    let mut opts = Opts::parse_from(vec![""].into_iter());
+    opts.process();
+    println!("{:?}", opts);
+    let config: Config = opts.shared.clone().into();
+
+    let mut client = Client::with(config.clone(), config.chain.clone())
+        .expect("Error running client");
+
+    let _child = launch("../farcasterd", std::vec::Vec::<&str>::new());
+
+    Command::Ls
+        .exec(&mut client)
+        .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
+}

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -17,7 +17,7 @@ fn spawn_swap() {
     let mut client = Client::with(config.clone(), config.chain.clone())
         .expect("Error running client");
 
-    let _child = launch("../farcasterd", std::vec::Vec::<&str>::new());
+    launch("../farcasterd", std::vec::Vec::<&str>::new()).unwrap();
 
     Command::Ls
         .exec(&mut client)

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -1,4 +1,5 @@
-#![cfg(feature = "integration_test")]
+// #![cfg(feature = "integration_test")]
+
 use clap::Clap;
 use farcaster_node::rpc::Client;
 use farcaster_node::{Config, LogStyle};

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -9,7 +9,7 @@ use microservices::shell::Exec;
 
 #[test]
 fn spawn_swap() {
-    use farcaster_node::farcasterd::{launch};
+    use farcaster_node::farcasterd::launch;
     use farcaster_node::cli::Opts;
     let mut opts = Opts::parse_from(vec!["swap-cli", "make"].into_iter());
     opts.process();
@@ -19,7 +19,7 @@ fn spawn_swap() {
     let mut client = Client::with(config.clone(), config.chain.clone())
         .expect("Error running client");
 
-    launch("../farcasterd", std::vec::Vec::<&str>::new()).unwrap();
+    let mut farcasterd = launch("../farcasterd", std::vec::Vec::<&str>::new()).unwrap();
 
     Command::Ls
         .exec(&mut client)
@@ -30,4 +30,5 @@ fn spawn_swap() {
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
 
+    farcasterd.kill();
 }

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -16,7 +16,7 @@ fn spawn_swap() {
     let mut client = Client::with(config.clone(), config.chain.clone())
         .expect("Error running client");
 
-    let _child = launch("../farcasterd", std::vec::Vec::<&str>::new());
+    launch("../farcasterd", std::vec::Vec::<&str>::new(), false).unwrap();
 
     Command::Ls
         .exec(&mut client)

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -17,7 +17,7 @@ fn spawn_swap() {
     let mut client = Client::with(config.clone(), config.chain.clone())
         .expect("Error running client");
 
-    launch("../farcasterd", std::vec::Vec::<&str>::new(), false).unwrap();
+    let _child = launch("../farcasterd", std::vec::Vec::<&str>::new());
 
     Command::Ls
         .exec(&mut client)

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -21,6 +21,9 @@ fn spawn_swap() {
 
     let mut farcasterd = launch("../farcasterd", std::vec::Vec::<&str>::new()).unwrap();
 
+    use std::{thread, time};
+    thread::sleep(time::Duration::from_millis(500));
+
     Command::Ls
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -22,7 +22,7 @@ fn spawn_swap() {
     let mut farcasterd = launch("../farcasterd", std::vec::Vec::<&str>::new()).unwrap();
 
     use std::{thread, time};
-    thread::sleep(time::Duration::from_millis(500));
+    thread::sleep(time::Duration::from_secs_f32(0.5));
 
     Command::Ls
         .exec(&mut client)

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "integration_test")]
 use clap::Clap;
 use farcaster_node::rpc::Client;
 use farcaster_node::{Config, LogStyle};

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -9,8 +9,8 @@ use microservices::shell::Exec;
 
 #[test]
 fn spawn_swap() {
-    use farcaster_node::farcasterd::launch;
     use farcaster_node::cli::Opts;
+    use farcaster_node::farcasterd::launch;
     let mut opts = Opts::parse_from(vec!["swap-cli", "make"].into_iter());
     opts.process();
     println!("{:?}", opts);
@@ -19,7 +19,8 @@ fn spawn_swap() {
     let mut client = Client::with(config.clone(), config.chain.clone())
         .expect("Error running client");
 
-    let mut farcasterd = launch("../farcasterd", std::vec::Vec::<&str>::new()).unwrap();
+    let mut farcasterd =
+        launch("../farcasterd", std::vec::Vec::<&str>::new()).unwrap();
 
     use std::{thread, time};
     thread::sleep(time::Duration::from_secs_f32(0.5));


### PR DESCRIPTION
So far, this starts a cli and a farcaster daemon, then creates an offer from the defaults. Kills `farcasterd` to clean up the test, but does not kill its children yet. I'll open up a separate PR for the management of children.