### PR TITLE
manage farcasterd children

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,5 +147,7 @@ serde = ["serde_crate", "serde_with", "serde_yaml", "serde_json", "toml",
 tor = ["microservices/tor", "internet2/tor"]
 vendored_openssl = ["microservices/vendored_openssl", "internet2/vendored_openssl"]
 
+integration_test = []
+
 [package.metadata.configure_me]
 spec = "config_spec.toml"

--- a/shell/_swap-cli
+++ b/shell/_swap-cli
@@ -183,6 +183,28 @@ _arguments "${_arguments_options[@]}" \
 '--version[Prints version information]' \
 && ret=0
 ;;
+(pedicide)
+_arguments "${_arguments_options[@]}" \
+'-d+[Data directory path]: :_files -/' \
+'--data-dir=[Data directory path]: :_files -/' \
+'-c+[Path to the configuration file]: :_files' \
+'--config=[Path to the configuration file]: :_files' \
+'*-T+[Use Tor]: :_hosts' \
+'*--tor-proxy=[Use Tor]: :_hosts' \
+'-m+[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
+'--msg-socket=[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
+'-x+[ZMQ socket name/address for daemon control interface]: :_files' \
+'--ctl-socket=[ZMQ socket name/address for daemon control interface]: :_files' \
+'-n+[Blockchain to use]' \
+'--chain=[Blockchain to use]' \
+'*-v[Set verbosity level]' \
+'*--verbose[Set verbosity level]' \
+'-h[Prints help information]' \
+'--help[Prints help information]' \
+'-V[Prints version information]' \
+'--version[Prints version information]' \
+&& ret=0
+;;
 (make)
 _arguments "${_arguments_options[@]}" \
 '-d+[Data directory path]: :_files -/' \
@@ -262,6 +284,7 @@ _swap-cli_commands() {
 "info:General information about the running node" \
 "peers:Lists existing peer connections" \
 "ls:Lists running swaps" \
+"pedicide:Terminate children of farcasterd" \
 "make:Maker creates offer and start listening. Command used to to print a hex representation of the offer that shall be shared with Taker. Additionally it spins up the listener awaiting for connection related to this offer. Example usage: `make Testnet Bitcoin Monero 100000 200 10 10 20 Alice`" \
 "take:Taker accepts offer and connects to Maker's daemon" \
 "help:Prints this message or the help of the given subcommand(s)" \
@@ -309,6 +332,13 @@ _swap-cli__make_commands() {
         
     )
     _describe -t commands 'swap-cli make commands' commands "$@"
+}
+(( $+functions[_swap-cli__pedicide_commands] )) ||
+_swap-cli__pedicide_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'swap-cli pedicide commands' commands "$@"
 }
 (( $+functions[_swap-cli__peers_commands] )) ||
 _swap-cli__peers_commands() {

--- a/shell/_swap-cli.ps1
+++ b/shell/_swap-cli.ps1
@@ -44,6 +44,7 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('info', 'info', [CompletionResultType]::ParameterValue, 'General information about the running node')
             [CompletionResult]::new('peers', 'peers', [CompletionResultType]::ParameterValue, 'Lists existing peer connections')
             [CompletionResult]::new('ls', 'ls', [CompletionResultType]::ParameterValue, 'Lists running swaps')
+            [CompletionResult]::new('pedicide', 'pedicide', [CompletionResultType]::ParameterValue, 'Terminate children of farcasterd')
             [CompletionResult]::new('make', 'make', [CompletionResultType]::ParameterValue, 'Maker creates offer and start listening. Command used to to print a hex representation of the offer that shall be shared with Taker. Additionally it spins up the listener awaiting for connection related to this offer. Example usage: `make Testnet Bitcoin Monero 100000 200 10 10 20 Alice`')
             [CompletionResult]::new('take', 'take', [CompletionResultType]::ParameterValue, 'Taker accepts offer and connects to Maker''s daemon')
             [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Prints this message or the help of the given subcommand(s)')
@@ -161,6 +162,27 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             break
         }
         'swap-cli;ls' {
+            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
+            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Path to the configuration file')
+            [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'Path to the configuration file')
+            [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')
+            [CompletionResult]::new('--tor-proxy', 'tor-proxy', [CompletionResultType]::ParameterName, 'Use Tor')
+            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming lightning messages')
+            [CompletionResult]::new('--msg-socket', 'msg-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming lightning messages')
+            [CompletionResult]::new('-x', 'x', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
+            [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
+            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Blockchain to use')
+            [CompletionResult]::new('--chain', 'chain', [CompletionResultType]::ParameterName, 'Blockchain to use')
+            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
+            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            break
+        }
+        'swap-cli;pedicide' {
             [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Path to the configuration file')

--- a/shell/swap-cli.bash
+++ b/shell/swap-cli.bash
@@ -31,6 +31,9 @@ _swap-cli() {
             make)
                 cmd+="__make"
                 ;;
+            pedicide)
+                cmd+="__pedicide"
+                ;;
             peers)
                 cmd+="__peers"
                 ;;
@@ -47,7 +50,7 @@ _swap-cli() {
 
     case "${cmd}" in
         swap__cli)
-            opts=" -d -c -v -T -m -x -n -h -V  --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --help --version  listen connect ping info peers ls make take help"
+            opts=" -d -c -v -T -m -x -n -h -V  --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --help --version  listen connect ping info peers ls pedicide make take help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -403,6 +406,69 @@ _swap-cli() {
             ;;
         swap__cli__make)
             opts=" -d -c -v -T -m -x -n -h -V  --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --help --version  <network> <arbitrating-blockchain> <accordant-blockchain> <arbitrating-amount> <accordant-amount> <cancel-timelock> <punish-timelock> <fee-strategy> <maker-role> <ip-addr> <port> <overlay> "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                --data-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --tor-proxy)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -T)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --msg-socket)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -m)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ctl-socket)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -x)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --chain)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -n)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        swap__cli__pedicide)
+            opts=" -d -c -v -T -m -x -n -h -V  --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --help --version  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -70,6 +70,11 @@ impl Exec for Command {
                 runtime.report_response()?;
             }
 
+            Command::Pedicide => {
+                runtime.request(ServiceId::Farcasterd, Request::Pedicide)?;
+                runtime.report_response()?;
+            }
+
             Command::Listen {
                 ip_addr,
                 port,

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -103,6 +103,9 @@ pub enum Command {
     /// Lists running swaps
     Ls,
 
+    /// Terminate children of farcasterd
+    Pedicide,
+
     /// Maker creates offer and start listening. Command used to to print a hex
     /// representation of the offer that shall be shared with Taker.
     /// Additionally it spins up the listener awaiting for connection related to

--- a/src/farcasterd/mod.rs
+++ b/src/farcasterd/mod.rs
@@ -19,3 +19,4 @@ mod runtime;
 #[cfg(feature = "shell")]
 pub use opts::Opts;
 pub use runtime::run;
+pub use runtime::launch;

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -600,9 +600,12 @@ impl Runtime {
                     );
                     let resp = self.listen(addr);
                     match resp {
-                        Ok(_) => info!("Connection daemon {} for incoming LN peer connections on {}",
-                                       "listens".ended(), addr_str),
-                        Err(ref err) => error!("{}", err.err())
+                        Ok(_) => info!(
+                            "Connection daemon {} for incoming LN peer connections on {}",
+                            "listens".ended(),
+                            addr_str
+                        ),
+                        Err(ref err) => error!("{}", err.err()),
                     }
                     senders.send_to(
                         ServiceBus::Ctl,
@@ -834,20 +837,17 @@ impl Runtime {
             Request::Pedicide => {
                 let res = self.pedicide();
                 if res.values().any(|result| result.is_err()) {
-                    let msg = format!(
-                        "Failed to kill some child processes: {:?}",
-                        res
-                    );
-                    notify_cli
-                        .push((Some(source.clone()), Request::Failure(Failure {code: 1, info: msg})));
-                }
-                else {
-                    let msg = format!(
-                        "Successfully killed all child processes: {:?}",
-                        res
-                    );
-                    notify_cli
-                        .push((Some(source.clone()), Request::Success(OptionDetails(Some(msg)))));
+                    let msg = format!("Failed to kill some child processes: {:?}", res);
+                    notify_cli.push((
+                        Some(source.clone()),
+                        Request::Failure(Failure { code: 1, info: msg }),
+                    ));
+                } else {
+                    let msg = format!("Successfully killed all child processes: {:?}", res);
+                    notify_cli.push((
+                        Some(source.clone()),
+                        Request::Success(OptionDetails(Some(msg))),
+                    ));
                 }
             }
 
@@ -909,8 +909,7 @@ impl Runtime {
 
         // Start swapd
         let child = launch("swapd", &[swap_req.temporary_channel_id.to_hex()])?;
-        let msg =
-            format!("New instance of swapd launched with PID {}", child.id());
+        let msg = format!("New instance of swapd launched with PID {}", child.id());
         self.child_processes.push(child);
         info!("{}", msg);
         Ok(())
@@ -928,10 +927,7 @@ impl Runtime {
                 "peerd",
                 &["--listen", &ip.to_string(), "--port", &port.to_string()],
             )?;
-            let msg = format!(
-                "New instance of peerd launched with PID {}",
-                child.id()
-            );
+            let msg = format!("New instance of peerd launched with PID {}", child.id());
             self.child_processes.push(child);
             info!("{}", msg);
             Ok(msg)
@@ -975,7 +971,10 @@ impl Runtime {
     }
 
     pub fn pedicide(&mut self) -> HashMap<u32, io::Result<()>> {
-        self.child_processes.iter_mut().map(|child| (child.id(), child.kill())).collect()
+        self.child_processes
+            .iter_mut()
+            .map(|child| (child.id(), child.kill()))
+            .collect()
     }
 }
 

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -1009,7 +1009,13 @@ pub fn launch(
     );
 
     let mut cmd = process::Command::new(bin_path);
+    
+    #[cfg(feature = "integration_test")]
+    cmd.args(args);
+
+    #[cfg(not(feature = "integration_test"))]
     cmd.args(std::env::args().skip(1)).args(args);
+
     trace!("Executing `{:?}`", cmd);
     cmd.spawn().map_err(|err| {
         error!("Error launching {}: {}", name, err);

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -889,7 +889,7 @@ impl Runtime {
         }
 
         // Start swapd
-        let child = launch("swapd", &[swap_req.temporary_channel_id.to_hex()], true)?;
+        let child = launch("swapd", &[swap_req.temporary_channel_id.to_hex()])?;
         let msg = format!("New instance of swapd launched with PID {}", child.id());
         info!("{}", msg);
         Ok(())
@@ -906,7 +906,6 @@ impl Runtime {
             let child = launch(
                 "peerd",
                 &["--listen", &ip.to_string(), "--port", &port.to_string()],
-                true,
             )?;
             let msg = format!("New instance of peerd launched with PID {}", child.id());
             info!("{}", msg);
@@ -927,7 +926,7 @@ impl Runtime {
             )));
         }
         // Start peerd
-        let child = launch("peerd", &["--connect", &node_addr.to_string()], true);
+        let child = launch("peerd", &["--connect", &node_addr.to_string()]);
 
         // in case it can't connect wait for it to crash
         std::thread::sleep(Duration::from_secs_f32(0.5));
@@ -967,7 +966,6 @@ fn launch_swapd(
             public_offer.to_string(),
             negotiation_role.to_string(),
         ],
-        true,
     )?;
     let msg = format!("New instance of swapd launched with PID {}", child.id());
     info!("{}", msg);
@@ -993,7 +991,6 @@ fn launch_swapd(
 pub fn launch(
     name: &str,
     args: impl IntoIterator<Item = impl AsRef<OsStr>>,
-    use_cmd_args: bool,
 ) -> io::Result<process::Child> {
     let mut bin_path = std::env::current_exe().map_err(|err| {
         error!("Unable to detect binary directory: {}", err);
@@ -1012,11 +1009,7 @@ pub fn launch(
     );
 
     let mut cmd = process::Command::new(bin_path);
-    if use_cmd_args {
-        cmd.args(std::env::args().skip(1)).args(args);
-    } else {
-        cmd.args(args);
-    }
+    cmd.args(std::env::args().skip(1)).args(args);
     trace!("Executing `{:?}`", cmd);
     cmd.spawn().map_err(|err| {
         error!("Error launching {}: {}", name, err);

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -983,6 +983,7 @@ fn launch_swapd(
             swap_id,
         },
     );
+    
     debug!("Awaiting for swapd to connect...");
 
     Ok(msg)

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -1009,7 +1009,7 @@ pub fn launch(
     );
 
     let mut cmd = process::Command::new(bin_path);
-    
+
     #[cfg(feature = "integration_test")]
     cmd.args(args);
 
@@ -1017,8 +1017,21 @@ pub fn launch(
     cmd.args(std::env::args().skip(1)).args(args);
 
     trace!("Executing `{:?}`", cmd);
-    cmd.spawn().map_err(|err| {
-        error!("Error launching {}: {}", name, err);
-        err
-    })
+    match cmd.spawn() {
+        Ok(child) => {
+            println!(
+                "Successfully launched child {:?} with PID {:?}",
+                name, child.id()
+            );
+            Ok(child)
+        }
+        Err(err) => {
+            error!("Error launching {}: {}", name, err);
+            Err(err)
+        }
+    }
+    // cmd.spawn().map_err(|err| {
+    //     error!("Error launching {}: {}", name, err);
+    //     err
+    // })
 }

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -877,7 +877,7 @@ impl Runtime {
         for (respond_to, resp) in notify_cli.into_iter() {
             if let Some(respond_to) = respond_to {
                 len += 1;
-                println!("{}", len);
+                debug!("notifications to cli: {}", len);
                 info!(
                     "Respond to {} -> Response {}",
                     respond_to.amount(),
@@ -885,6 +885,7 @@ impl Runtime {
                 );
                 senders.send_to(ServiceBus::Ctl, ServiceId::Farcasterd, respond_to, resp)?;
             }
+            debug!("processed all cli notifications");
         }
 
         Ok(())

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -833,7 +833,7 @@ impl Runtime {
 
             Request::Pedicide => {
                 let res = self.pedicide();
-                if res.iter().any(|(_, result)| result.is_err()) {
+                if res.values().any(|result| result.is_err()) {
                     let msg = format!(
                         "Failed to kill some child processes: {:?}",
                         res
@@ -974,7 +974,7 @@ impl Runtime {
         Ok(msg)
     }
 
-    pub fn pedicide(&mut self) -> Vec<(u32, io::Result<()>)> {
+    pub fn pedicide(&mut self) -> HashMap<u32, io::Result<()>> {
         self.child_processes.iter_mut().map(|child| (child.id(), child.kill())).collect()
     }
 }

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -988,7 +988,7 @@ fn launch_swapd(
     Ok(msg)
 }
 
-fn launch(
+pub fn launch(
     name: &str,
     args: impl IntoIterator<Item = impl AsRef<OsStr>>,
 ) -> io::Result<process::Child> {

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -218,6 +218,11 @@ pub enum Request {
     #[display("fund_swap({0})")]
     FundSwap(OutPoint),
 
+    // Can be issued from `cli` to `lnpd`
+    #[api(type = 206)]
+    #[display("pedicide()")]
+    Pedicide,
+
     // Responses to CLI
     // ----------------
     #[api(type = 1002)]

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -33,7 +33,13 @@ fn spawn_swap() {
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
 
-    opts = Opts::parse_from(vec!["swap-cli", "make", "Testnet", "Bitcoin", "Monero", "101", "100", "10", "30", "20", "Alice", "0.0.0.0", "9376"].into_iter());
+    opts = Opts::parse_from(
+        vec![
+            "swap-cli", "make", "Testnet", "Bitcoin", "Monero", "101", "100",
+            "10", "30", "20", "Alice", "0.0.0.0", "9376",
+        ]
+        .into_iter(),
+    );
     opts.command
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
@@ -43,4 +49,22 @@ fn spawn_swap() {
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
 
     farcasterd.kill().expect("Couldn't kill farcasterd");
+    let ps_out = std::process::Command::new("ps")
+        .args(&["-e"])
+        .output()
+        .expect("failed to execute process")
+        .stdout;
+
+    let ps_out_grep = std::process::Command::new("grep")
+        .args(&[
+            "-e",
+            "'farcasterd\\|peerd'",
+            std::str::from_utf8(&ps_out).unwrap(),
+        ])
+        .output()
+        .unwrap_or_else(|e| panic!("failed to execute process: {}", e))
+        .stdout;
+
+    // fails if there are any lingering `farcasterd`s or `peerd`s, so this test is a false-negative if any are running independent of the test
+    assert_eq!("", std::str::from_utf8(&ps_out_grep).unwrap());
 }

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -1,4 +1,6 @@
 // #![cfg(feature = "integration_test")]
+#[macro_use]
+extern crate log;
 
 use clap::Clap;
 use farcaster_node::rpc::Client;
@@ -12,7 +14,7 @@ fn spawn_swap() {
     use farcaster_node::{cli::Opts, farcasterd::launch};
     let mut opts = Opts::parse_from(vec!["swap-cli", "make"].into_iter());
     opts.process();
-    println!("{:?}", opts);
+    info!("opts: {:?}", opts);
     let config: Config = opts.shared.clone().into();
 
     let mut client = Client::with(config.clone(), config.chain.clone())
@@ -28,7 +30,7 @@ fn spawn_swap() {
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
 
-    println!("executing command: {:?}", opts.command);
+    info!("executing command: {:?}", opts.command);
     opts.command
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -12,7 +12,7 @@ use microservices::shell::Exec;
 #[test]
 fn spawn_swap() {
     use farcaster_node::{cli::Opts, farcasterd::launch};
-    let mut opts = Opts::parse_from(vec!["swap-cli", "make"].into_iter());
+    let mut opts = Opts::parse_from(vec!["swap-cli", "-d", "tests/.farcaster_node", "make"].into_iter());
     opts.process();
     info!("opts: {:?}", opts);
     let config: Config = opts.shared.clone().into();
@@ -21,7 +21,7 @@ fn spawn_swap() {
         .expect("Error running client");
 
     let mut farcasterd =
-        launch("../farcasterd", std::vec::Vec::<&str>::new()).unwrap();
+        launch("../farcasterd", &["-d", "tests/.farcaster_node"]).unwrap();
 
     use std::{thread, time};
     thread::sleep(time::Duration::from_secs_f32(0.5));
@@ -37,7 +37,7 @@ fn spawn_swap() {
 
     opts = Opts::parse_from(
         vec![
-            "swap-cli", "make", "Testnet", "Bitcoin", "Monero", "101", "100",
+            "swap-cli", "-d", "tests/.farcaster_node", "make", "Testnet", "Bitcoin", "Monero", "101", "100",
             "10", "30", "20", "Alice", "0.0.0.0", "9376",
         ]
         .into_iter(),

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -8,8 +8,9 @@ use microservices::shell::Exec;
 
 #[test]
 fn spawn_swap() {
-    use farcaster_node::farcasterd::{launch, Opts};
-    let mut opts = Opts::parse_from(vec![""].into_iter());
+    use farcaster_node::farcasterd::{launch};
+    use farcaster_node::cli::Opts;
+    let mut opts = Opts::parse_from(vec!["swap-cli", "make"].into_iter());
     opts.process();
     println!("{:?}", opts);
     let config: Config = opts.shared.clone().into();
@@ -22,4 +23,10 @@ fn spawn_swap() {
     Command::Ls
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
+
+    println!("executing command: {:?}", opts.command);
+    opts.command
+        .exec(&mut client)
+        .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
+
 }

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -1,0 +1,24 @@
+use clap::Clap;
+use farcaster_node::rpc::Client;
+use farcaster_node::{Config, LogStyle};
+
+use farcaster_node::cli::Command;
+use microservices::shell::Exec;
+
+#[test]
+fn spawn_swap() {
+    use farcaster_node::farcasterd::{launch, Opts};
+    let mut opts = Opts::parse_from(vec![""].into_iter());
+    opts.process();
+    println!("{:?}", opts);
+    let config: Config = opts.shared.clone().into();
+
+    let mut client = Client::with(config.clone(), config.chain.clone())
+        .expect("Error running client");
+
+    let _child = launch("../farcasterd", std::vec::Vec::<&str>::new());
+
+    Command::Ls
+        .exec(&mut client)
+        .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
+}

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -17,7 +17,7 @@ fn spawn_swap() {
     let mut client = Client::with(config.clone(), config.chain.clone())
         .expect("Error running client");
 
-    let _child = launch("../farcasterd", std::vec::Vec::<&str>::new());
+    launch("../farcasterd", std::vec::Vec::<&str>::new()).unwrap();
 
     Command::Ls
         .exec(&mut client)

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -33,6 +33,10 @@ fn spawn_swap() {
     opts.command
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
+    
+    Command::Pedicide
+        .exec(&mut client)
+        .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
 
     farcasterd.kill();
 }

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -34,7 +34,7 @@ fn spawn_swap() {
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
 
-    opts = Opts::parse_from(vec!["swap-cli", "make", "Mainnet"].into_iter());
+    opts = Opts::parse_from(vec!["swap-cli", "make", "Testnet", "Bitcoin", "Monero", "101", "100", "10", "30", "20", "Alice", "0.0.0.0", "9376"].into_iter());
     opts.command
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -1,4 +1,5 @@
-#![cfg(feature = "integration_test")]
+// #![cfg(feature = "integration_test")]
+
 use clap::Clap;
 use farcaster_node::rpc::Client;
 use farcaster_node::{Config, LogStyle};

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -9,7 +9,7 @@ use microservices::shell::Exec;
 
 #[test]
 fn spawn_swap() {
-    use farcaster_node::farcasterd::{launch};
+    use farcaster_node::farcasterd::launch;
     use farcaster_node::cli::Opts;
     let mut opts = Opts::parse_from(vec!["swap-cli", "make"].into_iter());
     opts.process();
@@ -19,7 +19,7 @@ fn spawn_swap() {
     let mut client = Client::with(config.clone(), config.chain.clone())
         .expect("Error running client");
 
-    launch("../farcasterd", std::vec::Vec::<&str>::new()).unwrap();
+    let mut farcasterd = launch("../farcasterd", std::vec::Vec::<&str>::new()).unwrap();
 
     Command::Ls
         .exec(&mut client)
@@ -30,4 +30,5 @@ fn spawn_swap() {
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
 
+    farcasterd.kill();
 }

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -16,7 +16,7 @@ fn spawn_swap() {
     let mut client = Client::with(config.clone(), config.chain.clone())
         .expect("Error running client");
 
-    let _child = launch("../farcasterd", std::vec::Vec::<&str>::new());
+    launch("../farcasterd", std::vec::Vec::<&str>::new(), false).unwrap();
 
     Command::Ls
         .exec(&mut client)

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -9,8 +9,7 @@ use microservices::shell::Exec;
 
 #[test]
 fn spawn_swap() {
-    use farcaster_node::cli::Opts;
-    use farcaster_node::farcasterd::launch;
+    use farcaster_node::{cli::Opts, farcasterd::launch};
     let mut opts = Opts::parse_from(vec!["swap-cli", "make"].into_iter());
     opts.process();
     println!("{:?}", opts);
@@ -38,10 +37,10 @@ fn spawn_swap() {
     opts.command
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
-    
+
     Command::Pedicide
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
 
-    farcasterd.kill();
+    farcasterd.kill().expect("Couldn't kill farcasterd");
 }

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -33,6 +33,11 @@ fn spawn_swap() {
     opts.command
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
+
+    opts = Opts::parse_from(vec!["swap-cli", "make", "Mainnet"].into_iter());
+    opts.command
+        .exec(&mut client)
+        .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
     
     Command::Pedicide
         .exec(&mut client)

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -12,7 +12,13 @@ use microservices::shell::Exec;
 #[test]
 fn spawn_swap() {
     use farcaster_node::{cli::Opts, farcasterd::launch};
-    let mut opts = Opts::parse_from(vec!["swap-cli", "-d", "tests/.farcaster_node", "make"].into_iter());
+    let data_dir = vec!["-d", "tests/.farcaster_node"];
+    let mut opts = Opts::parse_from(
+        vec!["swap-cli"]
+            .into_iter()
+            .chain(data_dir.clone())
+            .chain(vec!["make"]),
+    );
     opts.process();
     info!("opts: {:?}", opts);
     let config: Config = opts.shared.clone().into();
@@ -20,8 +26,7 @@ fn spawn_swap() {
     let mut client = Client::with(config.clone(), config.chain.clone())
         .expect("Error running client");
 
-    let mut farcasterd =
-        launch("../farcasterd", &["-d", "tests/.farcaster_node"]).unwrap();
+    let mut farcasterd = launch("../farcasterd", data_dir.clone()).unwrap();
 
     use std::{thread, time};
     thread::sleep(time::Duration::from_secs_f32(0.5));
@@ -36,11 +41,13 @@ fn spawn_swap() {
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));
 
     opts = Opts::parse_from(
-        vec![
-            "swap-cli", "-d", "tests/.farcaster_node", "make", "Testnet", "Bitcoin", "Monero", "101", "100",
-            "10", "30", "20", "Alice", "0.0.0.0", "9376",
-        ]
-        .into_iter(),
+        vec!["swap-cli"]
+            .into_iter()
+            .chain(data_dir.clone())
+            .chain(vec![
+                "make", "Testnet", "Bitcoin", "Monero", "101", "100", "10",
+                "30", "20", "Alice", "0.0.0.0", "9376",
+            ]),
     );
     opts.command
         .exec(&mut client)
@@ -68,5 +75,6 @@ fn spawn_swap() {
         .stdout;
 
     // fails if there are any lingering `farcasterd`s or `peerd`s, so this test is a false-negative if any are running independent of the test
-    assert_eq!("", std::str::from_utf8(&ps_out_grep).unwrap());
+    assert_eq!(ps_out_grep.len(), 0);
+
 }

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -17,7 +17,7 @@ fn spawn_swap() {
     let mut client = Client::with(config.clone(), config.chain.clone())
         .expect("Error running client");
 
-    launch("../farcasterd", std::vec::Vec::<&str>::new(), false).unwrap();
+    let _child = launch("../farcasterd", std::vec::Vec::<&str>::new());
 
     Command::Ls
         .exec(&mut client)

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -21,6 +21,9 @@ fn spawn_swap() {
 
     let mut farcasterd = launch("../farcasterd", std::vec::Vec::<&str>::new()).unwrap();
 
+    use std::{thread, time};
+    thread::sleep(time::Duration::from_millis(500));
+
     Command::Ls
         .exec(&mut client)
         .unwrap_or_else(|err| eprintln!("{} {}", "error:".err(), err.err()));

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -22,7 +22,7 @@ fn spawn_swap() {
     let mut farcasterd = launch("../farcasterd", std::vec::Vec::<&str>::new()).unwrap();
 
     use std::{thread, time};
-    thread::sleep(time::Duration::from_millis(500));
+    thread::sleep(time::Duration::from_secs_f32(0.5));
 
     Command::Ls
         .exec(&mut client)

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "integration_test")]
 use clap::Clap;
 use farcaster_node::rpc::Client;
 use farcaster_node::{Config, LogStyle};

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -9,8 +9,8 @@ use microservices::shell::Exec;
 
 #[test]
 fn spawn_swap() {
-    use farcaster_node::farcasterd::launch;
     use farcaster_node::cli::Opts;
+    use farcaster_node::farcasterd::launch;
     let mut opts = Opts::parse_from(vec!["swap-cli", "make"].into_iter());
     opts.process();
     println!("{:?}", opts);
@@ -19,7 +19,8 @@ fn spawn_swap() {
     let mut client = Client::with(config.clone(), config.chain.clone())
         .expect("Error running client");
 
-    let mut farcasterd = launch("../farcasterd", std::vec::Vec::<&str>::new()).unwrap();
+    let mut farcasterd =
+        launch("../farcasterd", std::vec::Vec::<&str>::new()).unwrap();
 
     use std::{thread, time};
     thread::sleep(time::Duration::from_secs_f32(0.5));


### PR DESCRIPTION
builds on #27 to kill child processes of `farcasterd` at the end of tests before killing `farcasterd`. 