### PR TITLE
remove integration_feature conditional from farcasterd::runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,6 +630,7 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 [[package]]
 name = "farcaster_chains"
 version = "0.1.0"
+source = "git+https://github.com/farcaster-project/farcaster-core?branch=main#7ccfe1bcd1eb1961a2f678e640b0ebc8ce215ab4"
 dependencies = [
  "bitcoin",
  "farcaster_core",
@@ -642,6 +643,7 @@ dependencies = [
 [[package]]
 name = "farcaster_core"
 version = "0.1.0"
+source = "git+https://github.com/farcaster-project/farcaster-core?branch=main#7ccfe1bcd1eb1961a2f678e640b0ebc8ce215ab4"
 dependencies = [
  "hex",
  "internet2",

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -1066,10 +1066,6 @@ pub fn launch(
 
     let mut cmd = process::Command::new(bin_path);
 
-    #[cfg(feature = "integration_test")]
-    cmd.args(args);
-
-    #[cfg(not(feature = "integration_test"))]
     cmd.args(std::env::args().skip(1)).args(args);
 
     trace!("Executing `{:?}`", cmd);


### PR DESCRIPTION
rebreaks argument parsing for tests, but unbreaks binaries built with `--all-features` as reported by frix, so overall win ¯\\_(ツ)_/¯