### PR TITLE
Fix farcaster-core dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 [[package]]
 name = "farcaster_chains"
 version = "0.1.0"
-source = "git+https://github.com/farcaster-project/farcaster-core?branch=main#7ccfe1bcd1eb1961a2f678e640b0ebc8ce215ab4"
+source = "git+https://github.com/farcaster-project/farcaster-core?rev=7ccfe1bcd1eb1961a2f678e640b0ebc8ce215ab4#7ccfe1bcd1eb1961a2f678e640b0ebc8ce215ab4"
 dependencies = [
  "bitcoin",
  "farcaster_core",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "farcaster_core"
 version = "0.1.0"
-source = "git+https://github.com/farcaster-project/farcaster-core?branch=main#7ccfe1bcd1eb1961a2f678e640b0ebc8ce215ab4"
+source = "git+https://github.com/farcaster-project/farcaster-core?rev=7ccfe1bcd1eb1961a2f678e640b0ebc8ce215ab4#7ccfe1bcd1eb1961a2f678e640b0ebc8ce215ab4"
 dependencies = [
  "hex",
  "internet2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ required-features = ["server"]
 # Farcaster crates
 # farcaster_core = { path = "../core/core"}
 # farcaster_chains = { path = "../core/chains"}
-farcaster_core = { version = "0.1.0", git = "https://github.com/farcaster-project/farcaster-core", branch = "main" }
-farcaster_chains = { version = "0.1.0", git = "https://github.com/farcaster-project/farcaster-core", branch = "main" }
+farcaster_core = { git = "https://github.com/farcaster-project/farcaster-core", rev = "7ccfe1bcd1eb1961a2f678e640b0ebc8ce215ab4" }
+farcaster_chains = { git = "https://github.com/farcaster-project/farcaster-core", rev = "7ccfe1bcd1eb1961a2f678e640b0ebc8ce215ab4" }
 
 # LNP/BP crates
 amplify = "3"
@@ -85,8 +85,8 @@ zmq = "0.9"
 [build-dependencies]
 # farcaster_core = { path = "../core/core"}
 # farcaster_chains = { path = "../core/chains"}
-farcaster_core = { version = "0.1.0", git = "https://github.com/farcaster-project/farcaster-core", branch = "main" }
-farcaster_chains = { version = "0.1.0", git = "https://github.com/farcaster-project/farcaster-core", branch = "main" }
+farcaster_core = { git = "https://github.com/farcaster-project/farcaster-core", rev = "7ccfe1bcd1eb1961a2f678e640b0ebc8ce215ab4" }
+farcaster_chains = { git = "https://github.com/farcaster-project/farcaster-core", rev = "7ccfe1bcd1eb1961a2f678e640b0ebc8ce215ab4" }
 amplify = "3"
 amplify_derive = "2.4.3"
 lnpbp = { version = "0.4", features = ["all"] }


### PR DESCRIPTION
 Fix `farcaster-core` dependencies to commit https://github.com/farcaster-project/farcaster-core/commit/7ccfe1bcd1eb1961a2f678e640b0ebc8ce215ab4.

This is done because `farcaster-core` will have some big refactoring and will be unstable for some time.

**This should not break the current build (I tested) as it uses the same commit (see Cargo.lock diff) as before, but doing `cargo update` will not update the revision for core anymore, and thus become safe.**