### PR TITLE
Farcasterd retrieve key from wallet before launching peerd

### DIFF
--- a/shell/_peerd
+++ b/shell/_peerd
@@ -24,6 +24,7 @@ _peerd() {
 '-o+[Overlay peer communications through different transport protocol]: :(tcp zmq http websocket smtp)' \
 '--overlay=[Overlay peer communications through different transport protocol]: :(tcp zmq http websocket smtp)' \
 '--peer-secret-key=[]' \
+'--wallet-token=[]' \
 '-d+[Data directory path]: :_files -/' \
 '--data-dir=[Data directory path]: :_files -/' \
 '-c+[Path to the configuration file]: :_files' \

--- a/shell/_peerd.ps1
+++ b/shell/_peerd.ps1
@@ -29,6 +29,7 @@ Register-ArgumentCompleter -Native -CommandName 'peerd' -ScriptBlock {
             [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'Overlay peer communications through different transport protocol')
             [CompletionResult]::new('--overlay', 'overlay', [CompletionResultType]::ParameterName, 'Overlay peer communications through different transport protocol')
             [CompletionResult]::new('--peer-secret-key', 'peer-secret-key', [CompletionResultType]::ParameterName, 'peer-secret-key')
+            [CompletionResult]::new('--wallet-token', 'wallet-token', [CompletionResultType]::ParameterName, 'wallet-token')
             [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Path to the configuration file')

--- a/shell/peerd.bash
+++ b/shell/peerd.bash
@@ -20,7 +20,7 @@ _peerd() {
 
     case "${cmd}" in
         peerd)
-            opts=" -L -C -p -o -d -c -v -T -m -x -n -h -V  --listen --connect --port --overlay --peer-secret-key --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --help --version  "
+            opts=" -L -C -p -o -d -c -v -T -m -x -n -h -V  --listen --connect --port --overlay --peer-secret-key --wallet-token --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --help --version  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -60,6 +60,10 @@ _peerd() {
                     return 0
                     ;;
                 --peer-secret-key)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --wallet-token)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/src/bin/farcasterd.rs
+++ b/src/bin/farcasterd.rs
@@ -35,7 +35,7 @@ use bitcoin::secp256k1::rand::RngCore;
 
 use clap::Clap;
 
-use farcaster_node::farcasterd::{self, Opts};
+use farcaster_node::{farcasterd::{self, Opts}, rpc::request::Token};
 use farcaster_node::Config;
 
 fn main() {
@@ -53,10 +53,10 @@ fn main() {
 
     let mut dest = [0u8; 16];
     thread_rng().fill_bytes(&mut dest);
-    let walletd_token = dest.to_hex();
+    let wallet_token = Token(dest.to_hex());
 
     debug!("Starting runtime ...");
-    farcasterd::run(config, walletd_token).expect("Error running farcasterd runtime");
+    farcasterd::run(config, wallet_token).expect("Error running farcasterd runtime");
 
     unreachable!()
 }

--- a/src/bin/peerd.rs
+++ b/src/bin/peerd.rs
@@ -102,7 +102,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
 use bitcoin::secp256k1::PublicKey;
-use farcaster_node::peerd::{self, Opts};
+use farcaster_node::{peerd::{self, Opts}, rpc::request::Token};
 use farcaster_node::{Config, LogStyle};
 use internet2::{session, FramingProtocol, NodeAddr, RemoteNodeAddr, RemoteSocketAddr};
 use microservices::peer::PeerConnection;
@@ -179,7 +179,7 @@ fn main() {
 
     let local_node = opts.peer_key_opts.local_node();
     let local_id = local_node.node_id();
-
+    let wallet_token = Token(opts.wallet_token.wallet_token.clone());
     info!(
         "{}: {}",
         "Local node id".bright_green_bold(),
@@ -265,6 +265,7 @@ fn main() {
         local_socket,
         remote_socket,
         connect,
+        wallet_token,
     )
     .expect("Error running peerd runtime");
 

--- a/src/bin/walletd.rs
+++ b/src/bin/walletd.rs
@@ -31,7 +31,7 @@ extern crate log;
 
 use clap::Clap;
 
-use farcaster_node::walletd::{self, Opts};
+use farcaster_node::{rpc::request::Token, walletd::{self, Opts}};
 use farcaster_node::{Config, LogStyle};
 
 fn main() {
@@ -45,11 +45,10 @@ fn main() {
     debug!("MSG RPC socket {}", &config.msg_endpoint);
     debug!("CTL RPC socket {}", &config.ctl_endpoint);
 
-    let walletd_token = opts.walletd_token.walletd_token;
-    info!("received token: {}", walletd_token);
+    let wallet_token = Token(opts.token.wallet_token);
+    info!("received token: {}", wallet_token);
 
     let node_id = opts.key_opts.node_secrets().node_id();
-
 
     info!(
         "{}: {}",
@@ -59,7 +58,7 @@ fn main() {
 
 
     debug!("Starting runtime ...");
-    walletd::run(config, walletd_token, opts.key_opts.node_secrets(), node_id)
+    walletd::run(config, wallet_token, opts.key_opts.node_secrets(), node_id)
         .expect("Error running syncerd runtime");
 
     unreachable!()

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -12,7 +12,7 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-use std::str::FromStr;
+use std::{str::FromStr, thread::sleep};
 use std::{convert::TryFrom, time::Duration};
 
 use internet2::{NodeAddr, RemoteSocketAddr, ToNodeAddr};
@@ -124,7 +124,7 @@ impl Exec for Command {
                     maker_role,
                 };
                 let remote_addr = RemoteSocketAddr::with_ip_addr(overlay, ip_addr, port);
-                let proto_offer = request::ProtoPublicOffer { offer, remote_addr };
+                let proto_offer = request::ProtoPublicOffer { offer, remote_addr, peer_secret_key: None };
                 runtime.request(ServiceId::Farcasterd, Request::MakeOffer(proto_offer))?;
                 // report success of failure of the request to cli
                 runtime.report_progress()?;
@@ -145,7 +145,7 @@ impl Exec for Command {
                 info!("{:?}", &public_offer);
 
                 // pass offer to farcasterd to initiate the swap
-                runtime.request(ServiceId::Farcasterd, Request::TakeOffer(public_offer))?;
+                runtime.request(ServiceId::Farcasterd, Request::TakeOffer(public_offer.into()))?;
                 // report success of failure of the request to cli
                 runtime.report_progress()?;
             }

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -13,7 +13,12 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-use crate::{Senders, rpc::request::{Keys, LaunchSwap, PubOffer, RequestId, Token}, swapd::swap_id, walletd::NodeSecrets};
+use crate::{
+    rpc::request::{Keys, LaunchSwap, PubOffer, RequestId, Token},
+    swapd::swap_id,
+    walletd::NodeSecrets,
+    Senders,
+};
 use amplify::Wrapper;
 use request::{Commit, Params};
 use std::ffi::OsStr;
@@ -28,7 +33,10 @@ use std::{
 };
 use std::{convert::TryFrom, thread::sleep};
 
-use bitcoin::secp256k1::{self, rand::{thread_rng, RngCore}};
+use bitcoin::secp256k1::{
+    self,
+    rand::{thread_rng, RngCore},
+};
 use bitcoin::{
     hashes::hex::ToHex,
     secp256k1::{PublicKey, SecretKey},
@@ -41,9 +49,7 @@ use microservices::rpc::Failure;
 
 use farcaster_core::swap::SwapId;
 
-use crate::rpc::request::{
-    IntoProgressOrFalure, Msg, NodeInfo, OptionDetails, GetKeys, RuntimeContext,
-};
+use crate::rpc::request::{GetKeys, IntoProgressOrFalure, Msg, NodeInfo, OptionDetails};
 use crate::rpc::{request, Request, ServiceBus};
 use crate::{Config, Error, LogStyle, Service, ServiceId};
 
@@ -67,7 +73,7 @@ use std::str::FromStr;
 pub fn run(config: Config, wallet_token: Token) -> Result<(), Error> {
     let _walletd = launch(
         "walletd",
-        &["--wallet-token", &wallet_token.to_string().clone()],
+        &["--wallet-token", &wallet_token.to_string()],
     )?;
     let runtime = Runtime {
         identity: ServiceId::Farcasterd,
@@ -799,7 +805,8 @@ impl Runtime {
                 and then proceed with parent request"
         );
         let req_id = RequestId::rand();
-        self.pending_requests.insert(req_id.clone(), (request, source));
+        self.pending_requests
+            .insert(req_id.clone(), (request, source));
         let wallet_token = GetKeys(self.wallet_token.clone(), req_id);
         senders.send_to(
             ServiceBus::Ctl,

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -106,7 +106,7 @@ pub struct Runtime {
     making_swaps: HashMap<ServiceId, request::InitSwap>,
     taking_swaps: HashMap<ServiceId, request::InitSwap>,
     making_offers: HashSet<PublicOffer<BtcXmr>>,
-    node_ids: Vec<PublicKey>, // TODO HashSet<SwapId, PublicKey>
+    node_ids: HashSet<PublicKey>, // TODO is it possible? HashMap<SwapId, PublicKey>
     wallet_token: Token,
     pending_requests: HashMap<request::RequestId, (Request, ServiceId)>,
 }
@@ -147,8 +147,8 @@ impl Runtime {
         senders.send_to(ServiceBus::Ctl, self.identity(), ServiceId::Wallet, message)?;
         Ok(())
     }
-    fn node_ids(&self) -> &Vec<PublicKey> {
-        self.node_ids.as_ref()
+    fn node_ids(&self) -> Vec<PublicKey> {
+        self.node_ids.iter().cloned().collect()
     }
 
     fn known_swap_id(&self, source: ServiceId) -> Result<SwapId, Error> {
@@ -389,7 +389,7 @@ impl Runtime {
                 );
                 if let Some((request, source)) = self.pending_requests.remove(&id) {
                     // storing node_id
-                    self.node_ids.push(pk);
+                    self.node_ids.insert(pk);
                     trace!("Received expected peer keys, injecting key in request");
                     let req = if let Request::MakeOffer(mut req) = request {
                         req.peer_secret_key = Some(sk);

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -647,8 +647,8 @@ impl Runtime {
                             Some(source.clone()),
                             Request::Success(OptionDetails(Some(offer_registered))),
                         ));
+                        senders.send_to(ServiceBus::Ctl, source, ServiceId::Wallet, request)?;
                     }
-                    senders.send_to(ServiceBus::Ctl, source, ServiceId::Wallet, request)?;
                 }
             }
             req => {

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -242,7 +242,7 @@ impl Runtime {
                     }
                     ServiceId::Wallet => {
                         info!("Walletd registered - getting secrets");
-                        self.get_secret(senders, None)?
+                        self.get_secret(senders)?
                     }
                     ServiceId::Peer(connection_id) => {
                         if self.connections.insert(connection_id.clone()) {
@@ -745,10 +745,9 @@ impl Runtime {
     fn get_secret(
         &mut self,
         senders: &mut esb::SenderList<ServiceBus, ServiceId>,
-        context: Option<RuntimeContext>,
     ) -> Result<(), Error> {
         info!("node secrets not available yet - fetching and looping back.");
-        let get_secret = PeerSecret(self.walletd_token.clone(), context);
+        let get_secret = PeerSecret(self.walletd_token.clone());
         senders
             .send_to(
                 ServiceBus::Ctl,

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -13,10 +13,9 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-use crate::{Senders, rpc::request::{Keypair, LaunchSwap, Token}, swapd::swap_id, walletd::NodeSecrets};
+use crate::{Senders, rpc::request::{Keypair, LaunchSwap, PubOffer, RequestId, Token}, swapd::swap_id, walletd::NodeSecrets};
 use amplify::Wrapper;
 use request::{Commit, Params};
-use std::convert::TryFrom;
 use std::ffi::OsStr;
 use std::hash::Hash;
 use std::io;
@@ -27,9 +26,13 @@ use std::{
     collections::{HashMap, HashSet},
     io::Read,
 };
+use std::{convert::TryFrom, thread::sleep};
 
-use bitcoin::secp256k1;
-use bitcoin::{hashes::hex::ToHex, secp256k1::SecretKey};
+use bitcoin::secp256k1::{self, rand::{thread_rng, RngCore}};
+use bitcoin::{
+    hashes::hex::ToHex,
+    secp256k1::{PublicKey, SecretKey},
+};
 use internet2::{NodeAddr, RemoteSocketAddr, ToNodeAddr, TypedEnum};
 use lnp::{message, Messages, TempChannelId as TempSwapId, LIGHTNING_P2P_DEFAULT_PORT};
 use lnpbp::Chain;
@@ -62,10 +65,12 @@ use farcaster_core::{
 use std::str::FromStr;
 
 pub fn run(config: Config, wallet_token: Token) -> Result<(), Error> {
-    let _walletd = launch("walletd", &["--wallet-token", &wallet_token.to_string().clone()])?;
+    let _walletd = launch(
+        "walletd",
+        &["--wallet-token", &wallet_token.to_string().clone()],
+    )?;
     let runtime = Runtime {
         identity: ServiceId::Farcasterd,
-        node_id: None,
         chain: config.chain.clone(),
         listens: none!(),
         started: SystemTime::now(),
@@ -75,9 +80,9 @@ pub fn run(config: Config, wallet_token: Token) -> Result<(), Error> {
         making_swaps: none!(),
         taking_swaps: none!(),
         making_offers: none!(),
-        // wallets: none!(),
-        peerd_secret_key: none!(),
+        peerd_keys: none!(),
         wallet_token,
+        pending_requests: none!(),
     };
 
     let broker = true;
@@ -86,7 +91,6 @@ pub fn run(config: Config, wallet_token: Token) -> Result<(), Error> {
 
 pub struct Runtime {
     identity: ServiceId,
-    node_id: Option<secp256k1::PublicKey>,
     chain: Chain,
     listens: HashSet<RemoteSocketAddr>,
     started: SystemTime,
@@ -96,9 +100,9 @@ pub struct Runtime {
     making_swaps: HashMap<ServiceId, request::InitSwap>,
     taking_swaps: HashMap<ServiceId, request::InitSwap>,
     making_offers: HashSet<PublicOffer<BtcXmr>>,
-    // wallets: HashMap<SwapId, Wallet>,
-    peerd_secret_key: Option<SecretKey>,
+    peerd_keys: Vec<PublicKey>, // TODO HashSet<SwapId, PublicKey>
     wallet_token: Token,
+    pending_requests: HashMap<request::RequestId, (Request, ServiceId)>,
 }
 
 impl esb::Handler<ServiceBus> for Runtime {
@@ -137,16 +141,8 @@ impl Runtime {
         senders.send_to(ServiceBus::Ctl, self.identity(), ServiceId::Wallet, message)?;
         Ok(())
     }
-    fn peerd_secret_key(&self) -> Result<SecretKey, Error> {
-        if let Some(peerd_secret_key) = self.peerd_secret_key {
-            Ok(peerd_secret_key)
-        } else {
-            Err(Error::Farcaster("peerd_secret_key is none".to_string()))
-        }
-    }
-    fn node_id(&self) -> Result<bitcoin::secp256k1::PublicKey, Error> {
-        self.node_id
-            .ok_or_else(|| Error::Farcaster("node_id is none".to_string()))
+    fn node_ids(&self) -> &Vec<PublicKey> {
+        self.peerd_keys.as_ref()
     }
 
     fn known_swap_id(&self, source: ServiceId) -> Result<SwapId, Error> {
@@ -226,8 +222,6 @@ impl Runtime {
                     source.bright_green_bold(),
                     "connected".bright_green_bold()
                 );
-
-
                 match &source {
                     ServiceId::Farcasterd => {
                         error!(
@@ -236,8 +230,7 @@ impl Runtime {
                         );
                     }
                     ServiceId::Wallet => {
-                        info!("Walletd registered - getting secrets");
-                        self.get_secret(senders)?
+                        info!("Walletd functional");
                     }
                     ServiceId::Peer(connection_id) => {
                         if self.connections.insert(connection_id.clone()) {
@@ -380,7 +373,7 @@ impl Runtime {
                 self.known_swap_id(source.clone())?;
                 self.send_walletd(senders, request)?
             }
-            Request::Keypair(Keypair(sk, pk)) => {
+            Request::Keypair(Keypair(sk, pk, id)) => {
                 info!(
                     "received peerd keys \n \
                      secret: {} \n \
@@ -388,8 +381,27 @@ impl Runtime {
                     sk.addr(),
                     pk.addr()
                 );
-                self.peerd_secret_key = Some(sk);
-                self.node_id = Some(pk);
+                if let Some((request, source)) = self.pending_requests.remove(&id) {
+                    // storing node_id
+                    self.peerd_keys.push(pk);
+                    trace!("Received expected peer keys, injecting key in request");
+                    let req = if let Request::MakeOffer(mut req) = request {
+                        req.peer_secret_key = Some(sk);
+                        Ok(Request::MakeOffer(req))
+                    } else if let Request::TakeOffer(mut req) = request {
+                        req.peer_secret_key = Some(sk);
+                        Ok(Request::TakeOffer(req))
+                    } else {
+                        Err(Error::Farcaster(s!(
+                            "Unexpected request: calling back from Keypair handling"
+                        )))
+                    }?;
+                    trace!("Procede executing pending request");
+                    // recurse with request containing key
+                    self.handle_rpc_ctl(senders, source, req)?
+                } else {
+                    error!("Received unexpected peer keys");
+                }
             }
             Request::GetInfo => {
                 senders.send_to(
@@ -397,7 +409,7 @@ impl Runtime {
                     ServiceId::Farcasterd, // source
                     source,                // destination
                     Request::NodeInfo(NodeInfo {
-                        node_id: self.node_id()?,
+                        node_id: self.node_ids().clone(),
                         listens: self.listens.iter().cloned().collect(),
                         uptime: SystemTime::now()
                             .duration_since(self.started)
@@ -431,62 +443,63 @@ impl Runtime {
                 )?;
             }
 
-            Request::Listen(addr) => {
-                let addr_str = addr.addr();
-                if self.listens.contains(&addr) {
-                    let msg = format!("Listener on {} already exists, ignoring request", addr);
-                    warn!("{}", msg.err());
-                    report_to.push((
-                        Some(source.clone()),
-                        Request::Failure(Failure { code: 1, info: msg }),
-                    ));
-                } else {
-                    let resp = self.listen(&addr);
-                    self.listens.insert(addr);
-                    info!(
-                        "{} for incoming LN peer connections on {}",
-                        "Starting listener".bright_blue_bold(),
-                        addr_str
-                    );
-                    match resp {
-                        Ok(_) => info!(
-                            "Connection daemon {} for incoming LN peer connections on {}",
-                            "listens".bright_green_bold(),
-                            addr_str
-                        ),
-                        Err(ref err) => error!("{}", err.err()),
-                    }
+            // Request::Listen(addr) => {
+            //     let addr_str = addr.addr();
+            //     if self.listens.contains(&addr) {
+            //         let msg = format!("Listener on {} already exists, ignoring request", addr);
+            //         warn!("{}", msg.err());
+            //         report_to.push((
+            //             Some(source.clone()),
+            //             Request::Failure(Failure { code: 1, info: msg }),
+            //         ));
+            //     } else {
+            //         let (_, sk) = self.peerd_keys()?;
+            //         let resp = self.listen(&addr, sk);
+            //         self.listens.insert(addr);
+            //         info!(
+            //             "{} for incoming LN peer connections on {}",
+            //             "Starting listener".bright_blue_bold(),
+            //             addr_str
+            //         );
+            //         match resp {
+            //             Ok(_) => info!(
+            //                 "Connection daemon {} for incoming LN peer connections on {}",
+            //                 "listens".bright_green_bold(),
+            //                 addr_str
+            //             ),
+            //             Err(ref err) => error!("{}", err.err()),
+            //         }
 
-                    senders.send_to(
-                        ServiceBus::Ctl,
-                        ServiceId::Farcasterd,
-                        source.clone(),
-                        resp.into_progress_or_failure(),
-                    )?;
-                    report_to.push((
-                        Some(source.clone()),
-                        Request::Success(OptionDetails::with(format!(
-                            "Node {} listens for connections on {}",
-                            self.node_id()?,
-                            addr
-                        ))),
-                    ));
-                }
-            }
+            //         senders.send_to(
+            //             ServiceBus::Ctl,
+            //             ServiceId::Farcasterd,
+            //             source.clone(),
+            //             resp.into_progress_or_failure(),
+            //         )?;
+            //         report_to.push((
+            //             Some(source.clone()),
+            //             Request::Success(OptionDetails::with(format!(
+            //                 "Node {} listens for connections on {}",
+            //                 self.node_ids()[0], // FIXME
+            //                 addr
+            //             ))),
+            //         ));
+            //     }
+            // }
 
-            Request::ConnectPeer(addr) => {
-                info!(
-                    "{} to remote peer {}",
-                    "Connecting".bright_blue_bold(),
-                    addr.bright_blue_italic()
-                );
-                let resp = self.connect_peer(source.clone(), &addr);
-                match resp {
-                    Ok(_) => {}
-                    Err(ref err) => error!("{}", err.err()),
-                }
-                report_to.push((Some(source.clone()), resp.into_progress_or_failure()));
-            }
+            // Request::ConnectPeer(addr) => {
+            //     info!(
+            //         "{} to remote peer {}",
+            //         "Connecting".bright_blue_bold(),
+            //         addr.bright_blue_italic()
+            //     );
+            //     let resp = self.connect_peer(source.clone(), &addr);
+            //     match resp {
+            //         Ok(_) => {}
+            //         Err(ref err) => error!("{}", err.err()),
+            //     }
+            //     report_to.push((Some(source.clone()), resp.into_progress_or_failure()));
+            // }
 
             // Request::OpenSwapWith(request::CreateSwap {
             //     swap_req,
@@ -508,25 +521,43 @@ impl Runtime {
             //         resp.into_progress_or_failure(),
             //     ));
             // }
-            Request::MakeOffer(request::ProtoPublicOffer { offer, remote_addr }) => {
-                if !self.listens.contains(&remote_addr) {
-                    self.listens.insert(remote_addr);
-                    info!(
-                        "{} for incoming LN peer connections on {}",
-                        "Starting listener".bright_blue_bold(),
-                        remote_addr.bright_blue_bold()
-                    );
-                    let resp = self.listen(&remote_addr);
-                    match resp {
-                        Ok(_) => info!(
-                            "Connection daemon {} for incoming LN peer connections on {}",
-                            "listens".bright_green_bold(),
-                            remote_addr
-                        ),
-                        Err(ref err) => error!("{}", err.err()),
+            Request::MakeOffer(request::ProtoPublicOffer {
+                offer,
+                remote_addr,
+                peer_secret_key,
+            }) => {
+                let resp = match (self.listens.contains(&remote_addr), peer_secret_key) {
+                    (false, None) => {
+                        trace!("Push MakeOffer to pending_requests and requesting a secret from Wallet");
+                        return self.get_secret(senders, source, request);
                     }
-
-                    report_to.push((
+                    (false, Some(sk)) => {
+                        self.listens.insert(remote_addr);
+                        info!(
+                            "{} for incoming LN peer connections on {}",
+                            "Starting listener".bright_blue_bold(),
+                            remote_addr.bright_blue_bold()
+                        );
+                        self.listen(&remote_addr, sk)
+                    }
+                    (true, _) => {
+                        info!("Already listening on {}", &remote_addr);
+                        let msg = format!("Already listening on {}", &remote_addr);
+                        Ok(msg)
+                    }
+                };
+                match resp {
+                    Ok(_) => info!(
+                        "Connection daemon {} for incoming LN peer connections on {}",
+                        "listens".bright_green_bold(),
+                        remote_addr
+                    ),
+                    Err(err) => {
+                        error!("{}", err.err());
+                        return Err(err);
+                    }
+                }
+                report_to.push((
                         Some(source.clone()),
                         resp.into_progress_or_failure()
                         // Request::Progress(format!(
@@ -534,13 +565,9 @@ impl Runtime {
                         //     self.node_id, remote_addr
                         // )),
                     ));
-                } else {
-                    info!("Already listening on {}", &remote_addr);
-                    let msg = format!("Already listening on {}", &remote_addr);
-                    report_to.push((Some(source.clone()), Request::Progress(msg)));
-                }
+
                 let peer = internet2::RemoteNodeAddr {
-                    node_id: self.node_id()?,
+                    node_id: self.node_ids()[0], // FIXME shouldnt be 0 here
                     remote_addr: remote_addr.clone(),
                 };
                 let public_offer = offer.clone().to_public_v1(peer);
@@ -579,7 +606,10 @@ impl Runtime {
                 }
             }
 
-            Request::TakeOffer(public_offer) => {
+            Request::TakeOffer(request::PubOffer {
+                public_offer,
+                peer_secret_key,
+            }) => {
                 if self.making_offers.contains(&public_offer) {
                     let msg = format!(
                         "Offer {} already exists, ignoring request",
@@ -601,32 +631,37 @@ impl Runtime {
                         .ok_or_else(|| internet2::presentation::Error::InvalidEndpoint)?;
 
                     // Connect
-                    let peer_connected_is_ok = if !self.connections.contains(&peer) {
-                        info!(
-                            "{} to remote peer {}",
-                            "Connecting".bright_blue_bold(),
-                            peer.bright_blue_italic()
-                        );
-                        let peer_connected = self.connect_peer(source.clone(), &peer);
+                    let peer_connected_is_ok =
+                        match (self.connections.contains(&peer), peer_secret_key) {
+                            (false, None) => return self.get_secret(senders, source, request),
+                            (false, Some(sk)) => {
+                                info!(
+                                    "{} to remote peer {}",
+                                    "Connecting".bright_blue_bold(),
+                                    peer.bright_blue_italic()
+                                );
+                                let peer_connected = self.connect_peer(source.clone(), &peer, sk);
 
-                        let peer_connected_is_ok = peer_connected.is_ok();
+                                let peer_connected_is_ok = peer_connected.is_ok();
 
-                        report_to.push((
-                            Some(source.clone()),
-                            peer_connected.into_progress_or_failure(),
-                        ));
-                        peer_connected_is_ok
-                    } else {
-                        let msg = format!(
-                            "Already connected to remote peer {}",
-                            peer.bright_blue_italic()
-                        );
+                                report_to.push((
+                                    Some(source.clone()),
+                                    peer_connected.into_progress_or_failure(),
+                                ));
+                                peer_connected_is_ok
+                            }
+                            (true, _) => {
+                                let msg = format!(
+                                    "Already connected to remote peer {}",
+                                    peer.bright_blue_italic()
+                                );
 
-                        warn!("{}", &msg);
+                                warn!("{}", &msg);
 
-                        report_to.push((Some(source.clone()), Request::Progress(msg)));
-                        true
-                    };
+                                report_to.push((Some(source.clone()), Request::Progress(msg)));
+                                true
+                            }
+                        };
 
                     if peer_connected_is_ok {
                         let offer_registered = format!(
@@ -642,13 +677,20 @@ impl Runtime {
                             Some(source.clone()),
                             Request::Success(OptionDetails(Some(offer_registered))),
                         ));
+                        // reconstruct original request, by drop peer_secret_key
+                        // from offer
+                        let request = Request::TakeOffer(PubOffer {
+                            public_offer,
+                            peer_secret_key: None,
+                        });
                         senders.send_to(ServiceBus::Ctl, source, ServiceId::Wallet, request)?;
                     }
                 }
             }
             req => {
                 error!("Currently unsupported request: {}", req.err());
-                unimplemented!()},
+                unimplemented!()
+            }
         }
 
         let mut len = 0;
@@ -669,14 +711,13 @@ impl Runtime {
         Ok(())
     }
 
-    fn listen(&mut self, addr: &RemoteSocketAddr) -> Result<String, Error> {
+    fn listen(&mut self, addr: &RemoteSocketAddr, sk: SecretKey) -> Result<String, Error> {
         if let &RemoteSocketAddr::Ftcp(inet) = addr {
             let socket_addr = SocketAddr::try_from(inet)?;
             let ip = socket_addr.ip();
             let port = socket_addr.port();
 
             debug!("Instantiating peerd...");
-            // Start peerd
             let child = launch(
                 "peerd",
                 &[
@@ -685,9 +726,9 @@ impl Runtime {
                     "--port",
                     &port.to_string(),
                     "--peer-secret-key",
-                    &format!("{:x}", self.peerd_secret_key()?),
+                    &format!("{:x}", sk),
                     "--wallet-token",
-                    &self.wallet_token.to_string(),
+                    &self.wallet_token.clone().to_string(),
                 ],
             )?;
             let msg = format!("New instance of peerd launched with PID {}", child.id());
@@ -700,7 +741,12 @@ impl Runtime {
         }
     }
 
-    fn connect_peer(&mut self, source: ServiceId, node_addr: &NodeAddr) -> Result<String, Error> {
+    fn connect_peer(
+        &mut self,
+        source: ServiceId,
+        node_addr: &NodeAddr,
+        sk: SecretKey,
+    ) -> Result<String, Error> {
         debug!("Instantiating peerd...");
         if self.connections.contains(&node_addr) {
             return Err(Error::Other(format!(
@@ -708,6 +754,7 @@ impl Runtime {
                 node_addr
             )))?;
         }
+
         // Start peerd
         let child = launch(
             "peerd",
@@ -715,9 +762,9 @@ impl Runtime {
                 "--connect",
                 &node_addr.to_string(),
                 "--peer-secret-key",
-                &format!("{:x}", self.peerd_secret_key()?),
+                &format!("{:x}", sk),
                 "--wallet-token",
-                &self.wallet_token.to_string(),
+                &format!("{}", self.wallet_token.clone().to_string()),
             ],
         );
 
@@ -744,17 +791,23 @@ impl Runtime {
     fn get_secret(
         &mut self,
         senders: &mut esb::SenderList<ServiceBus, ServiceId>,
+        source: ServiceId,
+        request: Request,
     ) -> Result<(), Error> {
-        info!("node secrets not available yet - fetching and looping back.");
-        let get_secret = PeerSecret(self.wallet_token.clone());
-        senders
-            .send_to(
-                ServiceBus::Ctl,
-                ServiceId::Farcasterd,
-                ServiceId::Wallet,
-                Request::PeerSecret(get_secret),
-            )
-            .map_err(Error::from)
+        trace!(
+            "Peer keys not available yet - waiting to receive them on Request::Keypair\
+                and then proceed with parent request"
+        );
+        let req_id = RequestId::rand();
+        self.pending_requests.insert(req_id.clone(), (request, source));
+        let wallet_token = PeerSecret(self.wallet_token.clone(), req_id);
+        senders.send_to(
+            ServiceBus::Ctl,
+            ServiceId::Farcasterd,
+            ServiceId::Wallet,
+            Request::PeerSecret(wallet_token),
+        )?;
+        Ok(())
     }
 }
 

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -80,7 +80,7 @@ pub fn run(config: Config, wallet_token: Token) -> Result<(), Error> {
         making_swaps: none!(),
         taking_swaps: none!(),
         making_offers: none!(),
-        peerd_keys: none!(),
+        node_ids: none!(),
         wallet_token,
         pending_requests: none!(),
     };
@@ -100,7 +100,7 @@ pub struct Runtime {
     making_swaps: HashMap<ServiceId, request::InitSwap>,
     taking_swaps: HashMap<ServiceId, request::InitSwap>,
     making_offers: HashSet<PublicOffer<BtcXmr>>,
-    peerd_keys: Vec<PublicKey>, // TODO HashSet<SwapId, PublicKey>
+    node_ids: Vec<PublicKey>, // TODO HashSet<SwapId, PublicKey>
     wallet_token: Token,
     pending_requests: HashMap<request::RequestId, (Request, ServiceId)>,
 }
@@ -142,7 +142,7 @@ impl Runtime {
         Ok(())
     }
     fn node_ids(&self) -> &Vec<PublicKey> {
-        self.peerd_keys.as_ref()
+        self.node_ids.as_ref()
     }
 
     fn known_swap_id(&self, source: ServiceId) -> Result<SwapId, Error> {
@@ -383,7 +383,7 @@ impl Runtime {
                 );
                 if let Some((request, source)) = self.pending_requests.remove(&id) {
                     // storing node_id
-                    self.peerd_keys.push(pk);
+                    self.node_ids.push(pk);
                     trace!("Received expected peer keys, injecting key in request");
                     let req = if let Request::MakeOffer(mut req) = request {
                         req.peer_secret_key = Some(sk);
@@ -409,7 +409,7 @@ impl Runtime {
                     ServiceId::Farcasterd, // source
                     source,                // destination
                     Request::NodeInfo(NodeInfo {
-                        node_id: self.node_ids().clone(),
+                        node_ids: self.node_ids().clone(),
                         listens: self.listens.iter().cloned().collect(),
                         uptime: SystemTime::now()
                             .duration_since(self.started)

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -13,7 +13,7 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-use crate::{Senders, rpc::request::{Keypair, LaunchSwap, PubOffer, RequestId, Token}, swapd::swap_id, walletd::NodeSecrets};
+use crate::{Senders, rpc::request::{Keys, LaunchSwap, PubOffer, RequestId, Token}, swapd::swap_id, walletd::NodeSecrets};
 use amplify::Wrapper;
 use request::{Commit, Params};
 use std::ffi::OsStr;
@@ -42,7 +42,7 @@ use microservices::rpc::Failure;
 use farcaster_core::swap::SwapId;
 
 use crate::rpc::request::{
-    IntoProgressOrFalure, Msg, NodeInfo, OptionDetails, PeerSecret, RuntimeContext,
+    IntoProgressOrFalure, Msg, NodeInfo, OptionDetails, GetKeys, RuntimeContext,
 };
 use crate::rpc::{request, Request, ServiceBus};
 use crate::{Config, Error, LogStyle, Service, ServiceId};
@@ -373,7 +373,7 @@ impl Runtime {
                 self.known_swap_id(source.clone())?;
                 self.send_walletd(senders, request)?
             }
-            Request::Keypair(Keypair(sk, pk, id)) => {
+            Request::Keys(Keys(sk, pk, id)) => {
                 info!(
                     "received peerd keys \n \
                      secret: {} \n \
@@ -800,12 +800,12 @@ impl Runtime {
         );
         let req_id = RequestId::rand();
         self.pending_requests.insert(req_id.clone(), (request, source));
-        let wallet_token = PeerSecret(self.wallet_token.clone(), req_id);
+        let wallet_token = GetKeys(self.wallet_token.clone(), req_id);
         senders.send_to(
             ServiceBus::Ctl,
             ServiceId::Farcasterd,
             ServiceId::Wallet,
-            Request::PeerSecret(wallet_token),
+            Request::GetKeys(wallet_token),
         )?;
         Ok(())
     }

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -572,8 +572,14 @@ impl Runtime {
                         // )),
                     ));
 
+
+                let node_ids = self.node_ids();
+                if node_ids.len() != 1 {
+                        error!("{}", "Currently node supports only 1 node id");
+                        return Ok(())
+                }
                 let peer = internet2::RemoteNodeAddr {
-                    node_id: self.node_ids()[0], // FIXME shouldnt be 0 here
+                    node_id: node_ids[0], // checked above
                     remote_addr: remote_addr.clone(),
                 };
                 let public_offer = offer.clone().to_public_v1(peer);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ extern crate serde_with;
 pub mod cli;
 #[cfg(feature = "_rpc")]
 mod config;
-mod error;
+pub mod error;
 #[cfg(feature = "shell")]
 pub mod opts;
 #[cfg(feature = "_rpc")]

--- a/src/peerd/opts.rs
+++ b/src/peerd/opts.rs
@@ -13,7 +13,7 @@
 // If not, see <https://opensource.org/licenses/MIT>.
 
 use clap::{AppSettings, ArgGroup, Clap, ValueHint};
-use std::net::IpAddr;
+use std::{io, net::IpAddr};
 use std::path::PathBuf;
 use std::{fs, io::Read};
 
@@ -85,6 +85,9 @@ pub struct Opts {
     #[clap(flatten)]
     pub peer_key_opts: PeerKeyOpts,
 
+    /// WalletToken configuration
+    #[clap(flatten)]
+    pub wallet_token: TokenString,
     /// These params can be read also from the configuration file, not just
     /// command-line args or environment variables
     #[clap(flatten)]
@@ -97,11 +100,29 @@ impl Opts {
     }
 }
 
+
 /// Node key configuration
 #[derive(Clap, Clone, PartialEq, Eq, Debug)]
 pub struct PeerKeyOpts {
     #[clap(long)]
     pub peer_secret_key: String,
+}
+
+/// WalletToken configuration
+#[derive(Clap, Clone, PartialEq, Eq, Debug)]
+pub struct TokenString {
+    #[clap(long)]
+    pub wallet_token: String,
+}
+
+impl FromStr for TokenString {
+    type Err = io::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(TokenString {
+            wallet_token: s.to_string(),
+        })
+    }
 }
 
 use bitcoin::secp256k1::{rand::thread_rng, SecretKey};

--- a/src/peerd/runtime.rs
+++ b/src/peerd/runtime.rs
@@ -128,6 +128,7 @@ pub struct ListenerRuntime {
 }
 
 impl ListenerRuntime {
+    /// send msgs over bridge from remote to local runtime
     fn send_over_bridge(
         &mut self,
         req: <Unmarshaller<Msg> as Unmarshall>::Data,

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -179,22 +179,6 @@ pub struct NodeId(pub bitcoin::secp256k1::PublicKey);
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
 #[strict_encoding_crate(lnpbp::strict_encoding)]
-#[display("runtime context")]
-pub enum RuntimeContext {
-    GetInfo,
-    ConnectPeer(NodeAddr),
-    Listen(RemoteSocketAddr),
-    MakeOffer(ProtoPublicOffer),
-    TakeOffer(PublicOffer<BtcXmr>),
-}
-
-#[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
-#[display("secret")]
-pub struct Secret(pub NodeSecrets, pub Option<RuntimeContext>);
-
-#[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("{public_offer}")]
 pub struct PubOffer {
     pub public_offer: PublicOffer<BtcXmr>,
@@ -332,10 +316,6 @@ pub enum Request {
     #[api(type = 29)]
     #[display("launch_swap({0})")]
     LaunchSwap(LaunchSwap),
-
-    #[api(type = 40)]
-    #[display("loopback")]
-    Loopback(RuntimeContext),
 
     #[api(type = 28)]
     #[display("keys({0})")]

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -20,14 +20,14 @@ use lazy_static::lazy_static;
 use lightning_encoding::{strategies::AsStrict, LightningDecode, LightningEncode};
 #[cfg(feature = "serde")]
 use serde_with::{DisplayFromStr, DurationSeconds, Same};
-use std::iter::FromIterator;
-use std::time::Duration;
 use std::{collections::BTreeMap, convert::TryInto};
 use std::{
     fmt::{self, Debug, Display, Formatter},
     io,
     marker::PhantomData,
 };
+use std::{iter::FromIterator, str::FromStr};
+use std::{num::ParseIntError, time::Duration};
 
 use bitcoin::{
     secp256k1::{self, SecretKey},
@@ -176,10 +176,15 @@ pub enum RuntimeContext {
 #[display("secret")]
 pub struct Secret(pub NodeSecrets, pub Option<RuntimeContext>);
 
+#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, PartialEq, Eq)]
+#[strict_encoding_crate(lnpbp::strict_encoding)]
+#[display("{0}")]
+pub struct Token(pub String);
+
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
 #[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("get secret")]
-pub struct PeerSecret(pub String);
+pub struct PeerSecret(pub Token);
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
 #[strict_encoding_crate(lnpbp::strict_encoding)]

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -496,7 +496,7 @@ pub struct InitSwap {
 #[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(NodeInfo::to_yaml_string)]
 pub struct NodeInfo {
-    pub node_id: Vec<secp256k1::PublicKey>,
+    pub node_ids: Vec<secp256k1::PublicKey>,
     pub listens: Vec<RemoteSocketAddr>,
     #[serde_as(as = "DurationSeconds")]
     pub uptime: Duration,

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -195,7 +195,7 @@ pub struct Secret(pub NodeSecrets, pub Option<RuntimeContext>);
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
 #[strict_encoding_crate(lnpbp::strict_encoding)]
-#[display("puboffer")]
+#[display("{public_offer}")]
 pub struct PubOffer {
     pub public_offer: PublicOffer<BtcXmr>,
     pub peer_secret_key: Option<SecretKey>,
@@ -217,7 +217,7 @@ pub struct Token(pub String);
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
 #[strict_encoding_crate(lnpbp::strict_encoding)]
-#[display("get secret")]
+#[display("get keys(token({0}), req_id({1}))")]
 pub struct GetKeys(pub Token, pub RequestId);
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
@@ -242,7 +242,7 @@ pub struct TakeCommit {
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq)]
 #[strict_encoding_crate(lnpbp::strict_encoding)]
-#[display("keypair(sk:{0},pk:{1})")]
+#[display("keypair(sk:({0}),pk:({1})),id:({2})")]
 pub struct Keys(
     pub bitcoin::secp256k1::SecretKey,
     pub bitcoin::secp256k1::PublicKey,
@@ -326,11 +326,11 @@ pub enum Request {
     GetNodeId,
 
     #[api(type = 32)]
-    #[display("nodeid")]
+    #[display("nodeid({0})")]
     NodeId(NodeId),
 
     #[api(type = 30)]
-    #[display("getsecret({0})")]
+    #[display("get_keys({0})")]
     GetKeys(GetKeys),
 
     #[api(type = 29)]

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -218,7 +218,7 @@ pub struct Token(pub String);
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
 #[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("get secret")]
-pub struct PeerSecret(pub Token, pub RequestId);
+pub struct GetKeys(pub Token, pub RequestId);
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
 #[strict_encoding_crate(lnpbp::strict_encoding)]
@@ -243,7 +243,7 @@ pub struct TakeCommit {
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq)]
 #[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("keypair(sk:{0},pk:{1})")]
-pub struct Keypair(
+pub struct Keys(
     pub bitcoin::secp256k1::SecretKey,
     pub bitcoin::secp256k1::PublicKey,
     pub RequestId,
@@ -330,11 +330,11 @@ pub enum Request {
     NodeId(NodeId),
 
     #[api(type = 30)]
-    #[display("getsecret")]
-    PeerSecret(PeerSecret),
+    #[display("getsecret({0})")]
+    GetKeys(GetKeys),
 
     #[api(type = 29)]
-    #[display("launch_swap")]
+    #[display("launch_swap({0})")]
     LaunchSwap(LaunchSwap),
 
     #[api(type = 40)]
@@ -342,8 +342,8 @@ pub enum Request {
     Loopback(RuntimeContext),
 
     #[api(type = 28)]
-    #[display("peer_secret")]
-    Keypair(Keypair),
+    #[display("keys({0})")]
+    Keys(Keys),
 
     #[api(type = 5)]
     #[display("send_message({0})")]
@@ -385,12 +385,12 @@ pub enum Request {
 
     // Can be issued from `cli` to `lnpd`
     #[api(type = 203)]
-    #[display("take_swap(...)")]
+    #[display("take_swap({0})")]
     TakeSwap(InitSwap),
 
     // Can be issued from `cli` to `lnpd`
     #[api(type = 204)]
-    #[display("make_swap(...)")]
+    #[display("make_swap({0})")]
     MakeSwap(InitSwap),
 
     #[api(type = 199)]

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -321,10 +321,6 @@ pub enum Request {
     #[display("send_message({0})")]
     PeerMessage(Messages),
 
-    #[api(type = 31)]
-    #[display("getnodeid")]
-    GetNodeId,
-
     #[api(type = 32)]
     #[display("nodeid({0})")]
     NodeId(NodeId),

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -179,7 +179,7 @@ pub struct Secret(pub NodeSecrets, pub Option<RuntimeContext>);
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
 #[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("get secret")]
-pub struct PeerSecret(pub String, pub Option<RuntimeContext>);
+pub struct PeerSecret(pub String);
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
 #[strict_encoding_crate(lnpbp::strict_encoding)]

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -303,12 +303,8 @@ impl Runtime {
                                 Ok(State::Alice(AliceState::RevealA))
                             }
                             State::Bob(BobState::CommitB) => Ok(State::Bob(BobState::RevealB)),
-                            State::Alice(AliceState::RevealA) => {
-                                Ok(State::Alice(AliceState::RevealA))
-                            }
-                            State::Bob(BobState::RevealB) => Ok(State::Bob(BobState::RevealB)),
                             _ => Err(Error::Farcaster(
-                                "Must be on Commit state (maker) or reveal state (taker)"
+                                "Must be on Commit state"
                                     .to_string(),
                             )),
                         }?;

--- a/src/walletd/opts.rs
+++ b/src/walletd/opts.rs
@@ -12,7 +12,7 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-use crate::opts::FARCASTER_NODE_KEY_FILE;
+use crate::{opts::FARCASTER_NODE_KEY_FILE};
 use clap::{AppSettings, Clap, ValueHint};
 use std::path::PathBuf;
 use std::{fs, io::Read};
@@ -33,7 +33,7 @@ pub struct Opts {
 
     /// Walletd token
     #[clap(flatten)]
-    pub walletd_token: WalletdToken,
+    pub token: WalletToken,
 
     /// These params can be read also from the configuration file, not just
     /// command-line args or environment variables
@@ -66,9 +66,9 @@ pub struct KeyOpts {
 }
 
 #[derive(Clap, Clone, PartialEq, Eq, Debug)]
-pub struct WalletdToken {
+pub struct WalletToken {
     #[clap(short, long, env = "FARCASTER_WALLETD_TOKEN", default_value = "")]
-    pub walletd_token: String,
+    pub wallet_token: String,
 }
 
 use bitcoin::secp256k1::{

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -537,7 +537,7 @@ impl Runtime {
                     }
                 };
             }
-            Request::PeerSecret(request::PeerSecret(walletd_token, context)) => {
+            Request::PeerSecret(request::PeerSecret(walletd_token)) => {
                 if walletd_token != self.walletd_token {
                     Err(Error::InvalidToken)?
                 }

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -555,10 +555,6 @@ impl Runtime {
                     )),
                 )?
             }
-            Request::GetNodeId => {
-                let node_id = NodeId(self.node_id.clone());
-                self.send_farcasterd(senders, Request::NodeId(node_id))?
-            }
 
             // Request::Loopback(request) => match request {
             //     RuntimeContext::GetInfo => self.send_farcasterd(senders, Request::GetInfo)?,

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -265,9 +265,9 @@ impl Runtime {
                     }
                 }?
             }
-            Request::Params(params) => {
+            Request::Params(role) => {
                 let swap_id = swap_id(source.clone())?;
-                match params {
+                match role {
                     // getting paramaters from counterparty alice routed through
                     // swapd, thus im bob on this swap
                     Params::Alice(params) => {

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::rpc::{
-    request::{self, Keys, Msg, Params, Reveal, RuntimeContext, Token},
+    request::{self, Keys, Msg, Params, Reveal, Token},
     Request, ServiceBus,
 };
 use crate::swapd::swap_id;
@@ -556,21 +556,6 @@ impl Runtime {
                 )?
             }
 
-            // Request::Loopback(request) => match request {
-            //     RuntimeContext::GetInfo => self.send_farcasterd(senders, Request::GetInfo)?,
-            //     RuntimeContext::MakeOffer(offer) => {
-            //         self.send_farcasterd(senders, Request::MakeOffer(offer))?
-            //     }
-            //     RuntimeContext::TakeOffer(offer) => {
-            //         self.send_farcasterd(senders, Request::TakeOffer(offer))?
-            //     }
-            //     RuntimeContext::Listen(addr) => {
-            //         self.send_farcasterd(senders, Request::Listen(addr))?
-            //     }
-            //     RuntimeContext::ConnectPeer(addr) => {
-            //         self.send_farcasterd(senders, Request::ConnectPeer(addr))?
-            //     }
-            // },
             _ => {
                 error!(
                     "Request {:?} is not supported by the CTL interface",

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -4,10 +4,7 @@ use std::{
     str::FromStr,
 };
 
-use crate::rpc::{
-    request::{self, Keypair, Msg, Params, Reveal, RuntimeContext},
-    Request, ServiceBus,
-};
+use crate::rpc::{Request, ServiceBus, request::{self, Keypair, Msg, Params, Reveal, RuntimeContext, Token}};
 use crate::swapd::swap_id;
 use crate::walletd::NodeSecrets;
 use crate::LogStyle;
@@ -34,13 +31,13 @@ use request::{LaunchSwap, NodeId};
 
 pub fn run(
     config: Config,
-    walletd_token: String,
+    wallet_token: Token,
     node_secrets: NodeSecrets,
     node_id: bitcoin::secp256k1::PublicKey,
 ) -> Result<(), Error> {
     let runtime = Runtime {
         identity: ServiceId::Wallet,
-        walletd_token,
+        wallet_token,
         node_secrets,
         node_id,
         wallets: none!(),
@@ -52,7 +49,7 @@ pub fn run(
 
 pub struct Runtime {
     identity: ServiceId,
-    walletd_token: String,
+    wallet_token: Token,
     node_secrets: NodeSecrets,
     node_id: bitcoin::secp256k1::PublicKey,
     wallets: HashMap<SwapId, Wallet>,
@@ -537,8 +534,8 @@ impl Runtime {
                     }
                 };
             }
-            Request::PeerSecret(request::PeerSecret(walletd_token)) => {
-                if walletd_token != self.walletd_token {
+            Request::PeerSecret(request::PeerSecret(wallet_token)) => {
+                if wallet_token != self.wallet_token {
                     Err(Error::InvalidToken)?
                 }
                 info!("sent Secret request to farcasterd");

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::rpc::{
-    request::{self, Keypair, Msg, Params, Reveal, RuntimeContext, Token},
+    request::{self, Keys, Msg, Params, Reveal, RuntimeContext, Token},
     Request, ServiceBus,
 };
 use crate::swapd::swap_id;
@@ -540,7 +540,7 @@ impl Runtime {
                     }
                 };
             }
-            Request::PeerSecret(request::PeerSecret(wallet_token, request_id)) => {
+            Request::GetKeys(request::GetKeys(wallet_token, request_id)) => {
                 // eprintln!("inside PeerSecret handler");
                 if wallet_token != self.wallet_token {
                     Err(Error::InvalidToken)?
@@ -548,7 +548,7 @@ impl Runtime {
                 info!("sent Secret request to farcasterd");
                 self.send_farcasterd(
                     senders,
-                    Request::Keypair(Keypair(
+                    Request::Keys(Keys(
                         self.node_secrets.peerd_secret_key,
                         self.node_secrets.node_id(),
                         request_id,


### PR DESCRIPTION
Added  general mechanism for doing callbacks, such as: 
```
MakeOffer (orig req) -> return GetKeys (req) -> 
                                                         (rep) Keys -> continue MakeOffer (orig req)
```
Mechanism uses early return to exit original request, into the fallback path
requesting the keys, uses a RequestId to identify what pending_request to call
back, using recursion to continue the pending_requests following up receiving Keys back from wallet, such that the return is from the original request -- just proceding with execution

