### PR TITLE
Bump dependencies for bitcoin 0.27 upgrade in core.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,12 +887,12 @@ checksum = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 [[package]]
 name = "farcaster_core"
 version = "0.1.0"
-source = "git+https://github.com/Lederstrumpf/farcaster-core?rev=c343cb67398b08935df3fc54c7c4740bb04445ee#c343cb67398b08935df3fc54c7c4740bb04445ee"
+source = "git+https://github.com/farcaster-project/farcaster-core?branch=main#6f531852c42591cb02f118265c13d84cac4d49c5"
 dependencies = [
  "amplify",
  "bincode",
  "bitcoin 0.27.1",
- "bitcoin_hashes 0.9.7",
+ "bitcoin_hashes 0.10.0",
  "bitvec",
  "curve25519-dalek",
  "ecdsa_fun",
@@ -1711,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "monero"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68106ed713fc19d2b169ce5a2510927950e466e7032704af5b61cc2f7b59763d"
+checksum = "0e65ccebd4c656eb7df22ea1132fd212be0986af9ea3c3bb489121137a76ea76"
 dependencies = [
  "base58-monero",
  "curve25519-dalek",
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "monero-rpc"
 version = "0.1.0"
-source = "git+https://github.com/TheCharlatan/monero-rpc-rs?branch=changes#aaa3a4cc943547ddb9500b5ee32308fd0847902d"
+source = "git+https://github.com/Lederstrumpf/monero-rpc-rs?branch=changes#5e7f230920aee8f599e2e77d58db0d9dee179837"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -28,13 +28,15 @@ dependencies = [
 
 [[package]]
 name = "amplify"
-version = "3.7.1"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9b1af9b1bce6079e2c058fe1d0f0488e4e7370eca5c983b86aa43c11def6b0"
+checksum = "a8e62f231427205466fa4a9be272c5524e0781d724917f370d0ffeca95d1a9b2"
 dependencies = [
  "amplify_derive",
  "amplify_num",
+ "amplify_syn",
  "parse_arg",
+ "rand 0.8.4",
  "serde 1.0.127",
  "serde_json",
  "serde_yaml",
@@ -44,44 +46,34 @@ dependencies = [
 
 [[package]]
 name = "amplify_derive"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1ea2f56cff58c81c39934fd0aef3aeb3377a1ae252ba7fda41ab335e00c79d"
+checksum = "403008693dd8333254c9cf0f977890f23c4ceaa9975721cc52b79551a72ff7f2"
 dependencies = [
  "amplify_syn",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
-]
-
-[[package]]
-name = "amplify_derive_helpers"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9076b2ac55f9451a0b7f36921d1c7d3a4c8822c3cbf6ecb5eece6fab90c7fc22"
-dependencies = [
- "proc-macro2 1.0.28",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "amplify_num"
-version = "0.1.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a0b9009be0d79a4d38db02d2c8cc0abb8255ff79e7685940340622cdbd0a2f"
+checksum = "bc2f04ef9ef18297ed29418a8c5a93569ae07934234a423fd77b68a9dbd1e491"
 dependencies = [
  "serde 1.0.127",
 ]
 
 [[package]]
 name = "amplify_syn"
-version = "1.1.4"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf296f37a25aa9511edecc6a713361370a857d0dccd808407d7972a66cc91d6a"
+checksum = "da24db1445cc7bc3842fa072c2d51fe5b25b812b6a572d65842a4c72e87221ac"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -89,16 +81,6 @@ name = "anyhow"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
-
-[[package]]
-name = "arrayvec"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06f59fe10306bb78facd90d28c2038ad23ffaaefa85bac43c8a434cde383334f"
-dependencies = [
- "nodrop",
- "odds",
-]
 
 [[package]]
 name = "arrayvec"
@@ -136,22 +118,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
 
 [[package]]
+name = "base58"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
+
+[[package]]
 name = "base58-monero"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465ba1f408efdef4d9379bdfa7340899b63e472d50c7fb666480ccfd5a893e53"
 dependencies = [
  "thiserror",
-]
-
-[[package]]
-name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
 ]
 
 [[package]]
@@ -176,10 +154,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64-compat"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a8d4d2746f89841e49230dd26917df1876050f95abafafbe34f47cb534b88d7"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "bech32"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
+
+[[package]]
+name = "bech32"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
 
 [[package]]
 name = "bincode"
@@ -196,8 +189,20 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6742ec672d3f12506f4ac5c0d853926ff1f94e675f60ffd3224039972bf663f1"
 dependencies = [
- "bech32",
- "bitcoin_hashes",
+ "bech32 0.7.3",
+ "bitcoin_hashes 0.9.7",
+ "secp256k1",
+ "serde 1.0.127",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a41df6ad9642c5c15ae312dd3d074de38fd3eb7cc87ad4ce10f90292a83fe4d"
+dependencies = [
+ "bech32 0.8.1",
+ "bitcoin_hashes 0.10.0",
  "secp256k1",
  "serde 1.0.127",
 ]
@@ -212,26 +217,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoincore-rpc"
-version = "0.13.0"
+name = "bitcoin_hashes"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d708433972bf78bd5f909d1d288f9ac1cceeab1460edb954e962f83e1f440a3"
+checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
+dependencies = [
+ "serde 1.0.127",
+]
+
+[[package]]
+name = "bitcoin_hd"
+version = "0.5.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114520db0f1a2c796823a50bcefb5710c0ceee43a6aef8c4ed8851cf80bead6"
+dependencies = [
+ "amplify",
+ "bitcoin 0.27.1",
+ "lazy_static",
+ "miniscript",
+ "regex",
+ "slip132 0.5.0-beta.1",
+ "strict_encoding",
+]
+
+[[package]]
+name = "bitcoin_scripts"
+version = "0.5.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "448b2e4f1135a96da109a6a0470984f029608fe9cdada6ae626e7900b6f72bee"
+dependencies = [
+ "amplify",
+ "bitcoin 0.27.1",
+ "miniscript",
+ "strict_encoding",
+]
+
+[[package]]
+name = "bitcoincore-rpc"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b8d99d58466295cb2bf72c6959b784d59f8f0d6977458d2ba3eb75c834f36c3"
 dependencies = [
  "bitcoincore-rpc-json",
  "jsonrpc",
- "log 0.4.14",
+ "log",
  "serde 1.0.127",
  "serde_json",
 ]
 
 [[package]]
 name = "bitcoincore-rpc-json"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977e55a945ab1e3c446dea93267876703c15e07c7d6eeb1dfa1766b3190c560f"
+checksum = "dce91de73c61f5776cf938bfa88378c5b404a70e3369b761dacbe6024fea79dd"
 dependencies = [
- "bitcoin",
- "hex 0.3.2",
+ "bitcoin 0.27.1",
  "serde 1.0.127",
  "serde_json",
 ]
@@ -243,15 +283,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "block-buffer"
-version = "0.7.3"
+name = "bitvec"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
 dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -260,29 +300,21 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.4",
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
 name = "block-padding"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
-]
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -362,14 +394,14 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+checksum = "fcd70aa5597dbc42f7217a543f9ef2768b2ef823ba29036072d30e1d88e98406"
 dependencies = [
  "atty",
  "bitflags",
@@ -377,46 +409,32 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "os_str_bytes",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
  "textwrap",
- "unicode-width",
  "vec_map",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+checksum = "0b5bb0d655624a0b8770d1c178fb8ffcb1f91cc722cb08f451e3dc72465421ac"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "clap_generate"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf420f8b687b628d2915ccfd43a660c437a170432e3fbcb66944e8717a0d68f"
+checksum = "2d9b1abef93569f290952eff3c4a0a92d6767bb5158db095b4dc9a512b1c3643"
 dependencies = [
  "clap",
-]
-
-[[package]]
-name = "client_side_validation"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fbcc681ab39919398f924b998d939d818e732608c72d20da4c9e39b9769453"
-dependencies = [
- "amplify",
- "amplify_derive",
- "bitcoin_hashes",
- "grin_secp256k1zkp",
- "strict_encoding",
 ]
 
 [[package]]
@@ -446,6 +464,18 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "commit_verify"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "118b75f31b135bdc1dd3a61ddd7203df945b0a4cc2bc5af95b66385d489786a5"
+dependencies = [
+ "amplify",
+ "bitcoin_hashes 0.10.0",
+ "rand 0.7.3",
+ "strict_encoding",
 ]
 
 [[package]]
@@ -491,6 +521,12 @@ dependencies = [
  "unicode-segmentation",
  "void",
 ]
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -575,12 +611,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array 0.12.4",
- "subtle 1.0.0",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -590,10 +626,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
+ "digest",
  "rand_core 0.5.1",
  "serde 1.0.127",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -604,7 +640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "574d8b2cd0bae5434fd50d53280f8299d95557a978686555880aaf5b8f4f81e9"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
+ "digest",
  "rand_core 0.6.3",
  "serde 1.0.127",
  "subtle-ng",
@@ -613,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.10.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -623,27 +659,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.10.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "strsim 0.9.3",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.10.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
 dependencies = [
  "darling_core",
- "quote 1.0.9",
- "syn 1.0.74",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -658,44 +694,49 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.15.0"
+version = "0.99.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
+checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
 dependencies = [
- "lazy_static",
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "regex",
+ "convert_case",
+ "proc-macro2",
+ "quote",
  "rustc_version",
- "syn 0.15.44",
+ "syn",
 ]
 
 [[package]]
 name = "descriptor-wallet"
-version = "0.4.1"
+version = "0.5.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39adbc7eccd5b6a2bc598730d0e197ac8e089aea212aabe77b6facb8cb6d40d5"
+checksum = "41605132eecd353ee23d080d4ad2979c4d43eae5c3b1456fff123faebeb627e0"
 dependencies = [
  "amplify",
- "amplify_derive",
- "bitcoin",
+ "bitcoin 0.27.1",
+ "bitcoin_hd",
+ "bitcoin_scripts",
  "chrono",
- "lazy_static",
+ "commit_verify",
  "miniscript",
- "regex",
- "serde 1.0.127",
- "serde_with",
- "slip132",
+ "psbt",
+ "slip132 0.5.0-beta.1",
  "strict_encoding",
 ]
 
 [[package]]
-name = "digest"
-version = "0.8.1"
+name = "descriptors"
+version = "0.5.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+checksum = "b8d2cf0de937fbfeb3c7fdbf8c02b5a709384d8cfda9255fa22701ee5d743a14"
 dependencies = [
- "generic-array 0.12.4",
+ "amplify",
+ "bitcoin 0.27.1",
+ "bitcoin_hd",
+ "bitcoin_scripts",
+ "lazy_static",
+ "miniscript",
+ "regex",
+ "strict_encoding",
 ]
 
 [[package]]
@@ -704,7 +745,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -778,7 +819,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde 1.0.127",
- "sha2 0.9.5",
+ "sha2",
  "zeroize",
 ]
 
@@ -790,17 +831,29 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "electrum-client"
-version = "0.7.0"
-source = "git+https://github.com/TheCharlatan/rust-electrum-client?branch=verboseTransactionGet#c488f4ae895d81bbf4cf77bc59aedaf29aff1548"
+version = "0.8.0"
+source = "git+https://github.com/Lederstrumpf/rust-electrum-client?branch=verboseTransactionGetRebased#7f6139290ace70b5904550bcaa6fb96bcb689f96"
 dependencies = [
- "bitcoin",
- "log 0.4.14",
+ "bitcoin 0.27.1",
+ "log",
  "rustls",
  "serde 1.0.127",
  "serde_json",
  "socks",
  "webpki",
  "webpki-roots",
+]
+
+[[package]]
+name = "encoding_derive_helpers"
+version = "1.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8af9b20816ac9126945a6ecc1e248c4a1edfeada329839cdca9c96581174bebb"
+dependencies = [
+ "amplify",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -820,7 +873,7 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.14",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -832,30 +885,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 
 [[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
 name = "farcaster_core"
 version = "0.1.0"
-source = "git+https://github.com/farcaster-project/farcaster-core?branch=main#adc6dbceeda0bf50482f76b38c01e267e900af4d"
+source = "git+https://github.com/Lederstrumpf/farcaster-core?rev=c343cb67398b08935df3fc54c7c4740bb04445ee#c343cb67398b08935df3fc54c7c4740bb04445ee"
 dependencies = [
  "amplify",
  "bincode",
- "bitcoin",
+ "bitcoin 0.27.1",
+ "bitcoin_hashes 0.9.7",
+ "bitvec",
  "curve25519-dalek",
  "ecdsa_fun",
  "fixed-hash",
- "hex 0.4.3",
+ "hex",
  "inet2_addr",
  "lightning_encoding",
  "monero",
+ "rand 0.7.3",
  "rand 0.8.4",
  "rand_chacha 0.3.1",
+ "secp256kfun",
  "serde 1.0.127",
- "sha2 0.9.5",
+ "sha2",
+ "sha3",
  "strict_encoding",
  "strict_encoding_derive",
  "thiserror",
@@ -869,8 +921,8 @@ dependencies = [
  "amplify",
  "amplify_derive",
  "base64 0.12.3",
- "bech32",
- "bitcoin",
+ "bech32 0.7.3",
+ "bitcoin 0.27.1",
  "bitcoincore-rpc",
  "chrono",
  "clap",
@@ -883,13 +935,13 @@ dependencies = [
  "electrum-client",
  "env_logger",
  "farcaster_core",
- "hex 0.4.3",
+ "hex",
  "internet2",
  "lazy_static",
  "lightning_encoding",
  "lnp-core",
  "lnpbp",
- "log 0.4.14",
+ "log",
  "microservices",
  "monero",
  "monero-rpc",
@@ -900,7 +952,9 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "shellexpand",
- "slip132",
+ "slip132 0.3.3",
+ "strict_encoding",
+ "strict_encoding_derive",
  "sysinfo",
  "tokio",
  "toml 0.5.8",
@@ -953,7 +1007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -961,6 +1015,12 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "funty"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "futures"
@@ -1018,9 +1078,9 @@ checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
  "autocfg 1.0.1",
  "proc-macro-hack",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1058,22 +1118,13 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "serde 1.0.127",
  "typenum",
- "version_check 0.9.3",
+ "version_check",
 ]
 
 [[package]]
@@ -1096,22 +1147,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "grin_secp256k1zkp"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af3c4c4829b3e2e7ee1d9a542833e4244912fbb887fabe44682558159b068a7"
-dependencies = [
- "arrayvec 0.3.25",
- "cc",
- "libc",
- "rand 0.5.6",
- "rustc-serialize",
- "serde 1.0.127",
- "serde_json",
- "zeroize",
 ]
 
 [[package]]
@@ -1159,12 +1194,6 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
-
-[[package]]
-name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
@@ -1177,12 +1206,12 @@ checksum = "21e4590e13640f19f249fe3e4eca5113bc4289f2497710378190e7f4bd96f45b"
 
 [[package]]
 name = "hmac"
-version = "0.7.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
- "digest 0.8.1",
+ "digest",
 ]
 
 [[package]]
@@ -1230,25 +1259,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.10.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
-dependencies = [
- "base64 0.9.3",
- "httparse",
- "language-tags",
- "log 0.3.9",
- "mime 0.2.6",
- "num_cpus",
- "time",
- "traitobject",
- "typeable",
- "unicase",
- "url 1.7.2",
-]
-
-[[package]]
-name = "hyper"
 version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
@@ -1278,7 +1288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.11",
+ "hyper",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -1289,17 +1299,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -1324,12 +1323,11 @@ dependencies = [
 
 [[package]]
 name = "inet2_addr"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d17de954f78b83e7327701a1be5e67878691eaabf6b3d83c8f07db800759b0c"
+checksum = "9f89fa2e353307efcfa7b415a08a80abc87c31ec102aaf212ed76e8161a1ce7d"
 dependencies = [
  "amplify",
- "amplify_derive",
  "ed25519-dalek",
  "parse_arg",
  "serde 1.0.127",
@@ -1343,14 +1341,14 @@ dependencies = [
 
 [[package]]
 name = "inet2_derive"
-version = "0.4.1"
+version = "0.5.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c62ffe0c3f4e7c0e557a7e2833daf409555e547e977d6712f640835c83a14c"
+checksum = "affbe6f9f5efd90c4350e44e8a4a565f82880dddb263ff31141b099bbbc443dc"
 dependencies = [
  "amplify",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1373,12 +1371,12 @@ dependencies = [
 
 [[package]]
 name = "internet2"
-version = "0.3.10"
-source = "git+https://github.com/zkao/rust-internet2?branch=farcaster#11de2056015a74542f57da62f999e055b060b9bb"
+version = "0.5.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcfeffd7926baa75c53530042bcfb9826f602d4685c00a800d0df6b0937e4aa"
 dependencies = [
  "amplify",
- "amplify_derive",
- "bitcoin",
+ "bitcoin 0.27.1",
  "chacha20poly1305",
  "inet2_addr",
  "inet2_derive",
@@ -1386,9 +1384,8 @@ dependencies = [
  "lightning_encoding",
  "serde 1.0.127",
  "serde_with",
- "serde_with_macros",
  "strict_encoding",
- "url 2.2.2",
+ "url",
  "zmq",
 ]
 
@@ -1415,11 +1412,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436f3455a8a4e9c7b14de9f1206198ee5d0bdc2db1b560339d2141093d7dd389"
+checksum = "ad24d69a8a0698db8ffb9048e937e8ae3ee3bc45772a5d7b6979b1d2d5b6a9f7"
 dependencies = [
- "hyper 0.10.16",
+ "base64-compat",
  "serde 1.0.127",
  "serde_derive",
  "serde_json",
@@ -1434,7 +1431,7 @@ dependencies = [
  "futures",
  "futures-executor",
  "futures-util",
- "log 0.4.14",
+ "log",
  "serde 1.0.127",
  "serde_derive",
  "serde_json",
@@ -1445,12 +1442,6 @@ name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
-
-[[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
@@ -1464,7 +1455,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
- "arrayvec 0.5.2",
+ "arrayvec",
  "bitflags",
  "cfg-if",
  "ryu",
@@ -1479,29 +1470,30 @@ checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "lightning_encoding"
-version = "0.4.0-beta.1"
+version = "0.5.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5afb64e0b91319373c7030726cce1144b8e425a05f6ccdd39295c4da8fdad60"
+checksum = "99ebfaac212cb60c0ad1fa4a5760aaa356f44814ed609e98eb48ee683135fcc5"
 dependencies = [
  "amplify",
- "amplify_derive",
- "bitcoin",
+ "bitcoin 0.27.1",
+ "chrono",
  "descriptor-wallet",
  "lightning_encoding_derive",
+ "lnpbp",
  "strict_encoding",
 ]
 
 [[package]]
 name = "lightning_encoding_derive"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483bbbb5309dec107fca8f16811e01184b2b10497c7d1933de446204742169de"
+checksum = "3cc5449b552f69a6cf6f1c580c0444018f9b592edf0119cf66cc3fc3caf62744"
 dependencies = [
- "amplify",
- "amplify_derive_helpers",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "amplify_syn",
+ "encoding_derive_helpers",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1522,17 +1514,18 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lnp-core"
-version = "0.3.1"
-source = "git+https://github.com/zkao/lnp-core?branch=farcaster#f4741fab43ee9773a1c2b3898b27da45f4cfe090"
+version = "0.4.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180fd7dd18c1d322345bed6a9446f0d610ee05d6ddab15593d9cfe6925698144"
 dependencies = [
  "amplify",
- "amplify_derive",
- "bitcoin",
+ "bitcoin 0.27.1",
  "descriptor-wallet",
  "internet2",
  "lazy_static",
  "lightning_encoding",
  "lnpbp",
+ "secp256k1",
  "serde 1.0.127",
  "serde_with",
  "strict_encoding",
@@ -1540,27 +1533,63 @@ dependencies = [
 
 [[package]]
 name = "lnpbp"
-version = "0.4.0"
+version = "0.5.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82895efc2bfbd69b26e60650a22839536ff0cfc2d2301cba76502ed51cf21f83"
+checksum = "781512b4dd9cac6a6555641ee039bb3331770d611a13a338b32989e2244c93c8"
 dependencies = [
  "amplify",
- "amplify_derive",
- "bech32",
- "bitcoin",
- "bitcoin_hashes",
- "client_side_validation",
+ "base58",
+ "base64-compat",
+ "clap",
+ "lnpbp_bech32",
+ "lnpbp_chain",
+ "lnpbp_elgamal",
+ "serde 1.0.127",
+ "serde_json",
+ "serde_with",
+ "serde_yaml",
+]
+
+[[package]]
+name = "lnpbp_bech32"
+version = "0.5.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1704592421601743c153264084606c84b965864de13a16186255410b77dd48a0"
+dependencies = [
+ "amplify",
+ "bech32 0.8.1",
+ "bitcoin_hashes 0.10.0",
  "deflate",
- "descriptor-wallet",
  "inflate",
- "lazy_static",
- "lightning_encoding",
- "miniscript",
  "serde 1.0.127",
  "serde_with",
- "serde_with_macros",
  "strict_encoding",
- "strict_encoding_derive",
+]
+
+[[package]]
+name = "lnpbp_chain"
+version = "0.5.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd576752574588559929feedd78b2405b2371f605c194712895dbbd33a419be6"
+dependencies = [
+ "amplify",
+ "bitcoin 0.27.1",
+ "bitcoin_hashes 0.10.0",
+ "lazy_static",
+ "serde 1.0.127",
+ "serde_with",
+ "strict_encoding",
+]
+
+[[package]]
+name = "lnpbp_elgamal"
+version = "0.5.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cbc5996e87bf3b7f6bc157c72b791510ed1f1fc717cd689f8d06c020aa50ad"
+dependencies = [
+ "amplify",
+ "bitcoin_hashes 0.10.0",
+ "secp256k1",
 ]
 
 [[package]]
@@ -1570,15 +1599,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 dependencies = [
  "scopeguard",
-]
-
-[[package]]
-name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.14",
 ]
 
 [[package]]
@@ -1633,32 +1653,23 @@ dependencies = [
 
 [[package]]
 name = "microservices"
-version = "0.3.10"
-source = "git+https://github.com/zkao/rust-internet2?branch=farcaster#11de2056015a74542f57da62f999e055b060b9bb"
+version = "0.5.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9bab278af135e56ad7fa62a0589680ba0de52c749bb865467fe09324d0b9bf"
 dependencies = [
  "amplify",
- "amplify_derive",
  "clap",
  "config",
  "env_logger",
  "internet2",
  "lightning_encoding",
  "lnp-core",
- "log 0.4.14",
+ "log",
  "serde 1.0.127",
  "serde_with",
  "strict_encoding",
  "toml 0.5.8",
  "zmq",
-]
-
-[[package]]
-name = "mime"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-dependencies = [
- "log 0.3.9",
 ]
 
 [[package]]
@@ -1669,12 +1680,11 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniscript"
-version = "5.1.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f455be59a359d50370c4f587afbc5739c862e684c5afecae80ab93e7474b4e"
+checksum = "d69450033bf162edf854d4aacaff82ca5ef34fa81f6cf69e1c81a103f0834997"
 dependencies = [
- "bitcoin",
- "serde 1.0.127",
+ "bitcoin 0.27.1",
 ]
 
 [[package]]
@@ -1684,7 +1694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
- "log 0.4.14",
+ "log",
  "miow",
  "ntapi",
  "winapi 0.3.9",
@@ -1708,7 +1718,7 @@ dependencies = [
  "base58-monero",
  "curve25519-dalek",
  "fixed-hash",
- "hex 0.4.3",
+ "hex",
  "hex-literal",
  "sealed",
  "serde 1.0.127",
@@ -1725,7 +1735,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "fixed-hash",
- "hex 0.4.3",
+ "hex",
  "http",
  "jsonrpc-core",
  "monero",
@@ -1744,7 +1754,7 @@ checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.14",
+ "log",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -1767,12 +1777,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,7 +1784,7 @@ checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "lexical-core",
  "memchr",
- "version_check 0.9.3",
+ "version_check",
 ]
 
 [[package]]
@@ -1831,22 +1835,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "odds"
-version = "0.2.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eae0151b9dacf24fcc170d9995e511669a082856a91f958a2fe380bfab3fb22"
-
-[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
-
-[[package]]
-name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
@@ -1875,15 +1867,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
-name = "openssl-src"
-version = "111.15.0+1.1.1k"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a5f6ae2ac04393b217ea9f700cd04fa9bf3d93fae2872069f3d15d908af70a"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,16 +1875,15 @@ dependencies = [
  "autocfg 1.0.1",
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
 
 [[package]]
 name = "os_str_bytes"
-version = "2.4.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+checksum = "6acbef58a60fe69ab50510a55bc8cdd4d6cf2283d27ad338f54cb52747a9cf2d"
 
 [[package]]
 name = "parking_lot"
@@ -1942,15 +1924,18 @@ checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-
-[[package]]
-name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1993,10 +1978,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
- "version_check 0.9.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
 ]
 
 [[package]]
@@ -2005,9 +1990,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "version_check 0.9.3",
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -2024,20 +2009,23 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
- "unicode-xid 0.2.2",
+ "unicode-xid",
+]
+
+[[package]]
+name = "psbt"
+version = "0.5.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f927e04bb493b4863357db70741c60183aeaf16ecb501088d0f79cc1886ab21f"
+dependencies = [
+ "amplify",
+ "bitcoin 0.27.1",
+ "bitcoin_scripts",
+ "descriptors",
 ]
 
 [[package]]
@@ -2048,34 +2036,18 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
- "proc-macro2 1.0.28",
+ "proc-macro2",
 ]
 
 [[package]]
-name = "rand"
-version = "0.5.6"
+name = "radium"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "winapi 0.3.9",
-]
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
@@ -2356,22 +2328,22 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "hyper 0.14.11",
+ "hyper",
  "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
- "log 0.4.14",
- "mime 0.3.16",
+ "log",
+ "mime",
  "native-tls",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project-lite",
  "serde 1.0.127",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "url 2.2.2",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2412,16 +2384,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-
-[[package]]
 name = "rustc_version"
-version = "0.2.3"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
  "semver",
 ]
@@ -2433,23 +2399,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
 dependencies = [
  "base64 0.10.1",
- "log 0.4.14",
+ "log",
  "ring",
  "sct",
  "webpki",
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "schannel"
@@ -2484,9 +2450,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "636b9882a0f4cc2039488df89a10eb4b7976d4b6c1917fc0518f3f0f5e2c72ca"
 dependencies = [
  "heck",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2515,7 +2481,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34697f9a5a65f6ff9c2e86f6ff0b092dbdf3e4bd2a4f2ca5450710389187e07f"
 dependencies = [
- "digest 0.9.0",
+ "digest",
  "rand_core 0.6.3",
  "secp256k1",
  "secp256kfun_parity_backend",
@@ -2558,18 +2524,21 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
 ]
 
 [[package]]
 name = "semver-parser"
-version = "0.7.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -2615,9 +2584,9 @@ version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2664,25 +2633,26 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.5.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bac272128fb3b1e98872dca27a05c18d8b78b9bd089d3edb7b5871501b50bce"
+checksum = "062b87e45d8f26714eacfaef0ed9a583e2bfd50ebd96bdd3c200733bd5758e2c"
 dependencies = [
- "hex 0.4.3",
+ "hex",
+ "rustversion",
  "serde 1.0.127",
  "serde_with_macros",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "1.2.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c747a9ab2e833b807f74f6b6141530655010bfa9c9c06d5508bce75c8f8072f"
+checksum = "98c1fcca18d55d1763e1c16873c4bde0ac3ef75179a28c7b372917e0494625be"
 dependencies = [
  "darling",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2698,47 +2668,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
-
-[[package]]
-name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
 name = "sha2"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if",
  "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
- "block-buffer 0.7.3",
- "byte-tools",
- "digest 0.8.1",
+ "block-buffer",
+ "digest",
  "keccak",
- "opaque-debug 0.2.3",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -2757,8 +2708,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f66b1d91d54eea2c30682d3dc5d9d4ba72538e968343b99d66e9f4ddc4a9fa7b"
 dependencies = [
  "curve25519-dalek-ng",
- "digest 0.9.0",
- "generic-array 0.14.4",
+ "digest",
+ "generic-array",
  "rand_core 0.6.3",
  "secp256kfun",
  "serde 1.0.127",
@@ -2793,9 +2744,20 @@ checksum = "296e95fcf964943e0a16730184a929e9476615e31fb7fbcdc6476d99b2690cac"
 dependencies = [
  "amplify",
  "amplify_derive",
- "bitcoin",
+ "bitcoin 0.26.2",
  "serde 1.0.127",
  "serde_with",
+]
+
+[[package]]
+name = "slip132"
+version = "0.5.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15b225c202a005ad8e570b757cf1c0b3ce97da187a1e518bfe3c5d7e683c3d8"
+dependencies = [
+ "amplify",
+ "bitcoin 0.27.1",
+ "strict_encoding",
 ]
 
 [[package]]
@@ -2840,13 +2802,13 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strict_encoding"
-version = "1.2.3"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ce0326ae6d9d511b3c73b8a5e1ce024d218bf747dc6ec544fe2c68f19aaff7"
+checksum = "441080358b7382cf0b4766e4253a77e1ee7ad17139a4f0b950993074acfb63dc"
 dependencies = [
  "amplify",
- "amplify_derive",
- "bitcoin",
+ "bitcoin 0.27.1",
+ "bitcoin_hashes 0.10.0",
  "chrono",
  "miniscript",
  "strict_encoding_derive",
@@ -2854,14 +2816,14 @@ dependencies = [
 
 [[package]]
 name = "strict_encoding_derive"
-version = "1.0.0"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89347dfd57ea3160e6de4d7b21b3236b8a40800c1760ebfcfe9d69e3634e8955"
+checksum = "4cf87ccd517175354f494683b69b7703664cf49e6b82e78ff53e42bea0c17401"
 dependencies = [
- "amplify",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "amplify_syn",
+ "encoding_derive_helpers",
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -2876,21 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
@@ -2906,24 +2856,13 @@ checksum = "8049cf85f0e715d6af38dde439cb0ccb91f67fb9f5f63c80f8b43e48356e1a3f"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
-dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "unicode-xid 0.2.2",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2932,10 +2871,10 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
- "unicode-xid 0.2.2",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2953,6 +2892,12 @@ dependencies = [
  "rayon",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -2979,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 dependencies = [
  "unicode-width",
 ]
@@ -3001,9 +2946,9 @@ version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3066,9 +3011,9 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3090,7 +3035,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "log 0.4.14",
+ "log",
  "pin-project-lite",
  "tokio",
 ]
@@ -3112,22 +3057,20 @@ dependencies = [
 
 [[package]]
 name = "torut"
-version = "0.1.10"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b2cdfcb8b9dccc90fd618101a6f0a5a1f9e23e36956da9a2fe0abee901b04cc"
+checksum = "ecb506186a6ad032c4b50bd92c35307a32f95146e7d07ee28b93cc1410dfc384"
 dependencies = [
  "base32",
- "base64 0.10.1",
+ "base64 0.13.0",
  "derive_more",
  "ed25519-dalek",
- "hex 0.4.3",
+ "hex",
  "hmac",
- "openssl",
  "rand 0.7.3",
  "serde 1.0.127",
  "serde_derive",
- "sha1",
- "sha2 0.8.2",
+ "sha2",
  "sha3",
  "tokio",
 ]
@@ -3156,9 +3099,9 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3171,22 +3114,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-
-[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-
-[[package]]
-name = "typeable"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
 name = "typenum"
@@ -3195,13 +3126,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
-name = "unicase"
-version = "1.4.2"
+name = "ucd-trie"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
-dependencies = [
- "version_check 0.1.5",
-]
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"
@@ -3235,12 +3163,6 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
@@ -3251,8 +3173,8 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.1",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -3263,25 +3185,14 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.3",
+ "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -3307,12 +3218,6 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-
-[[package]]
-name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
@@ -3329,7 +3234,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.14",
+ "log",
  "try-lock",
 ]
 
@@ -3365,10 +3270,10 @@ checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.14",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3390,7 +3295,7 @@ version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
- "quote 1.0.9",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3400,9 +3305,9 @@ version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3505,6 +3410,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3528,9 +3442,9 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
  "synstructure",
 ]
 
@@ -3551,7 +3465,7 @@ checksum = "aad98a7a617d608cd9e1127147f630d24af07c7cd95ba1533246d96cbdd76c66"
 dependencies = [
  "bitflags",
  "libc",
- "log 0.4.14",
+ "log",
  "zmq-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,7 +840,7 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 [[package]]
 name = "farcaster_core"
 version = "0.1.0"
-source = "git+https://github.com/farcaster-project/farcaster-core?branch=main#a99cebd8bbf4586839c773b3f6763732783521bf"
+source = "git+https://github.com/farcaster-project/farcaster-core?branch=main#adc6dbceeda0bf50482f76b38c01e267e900af4d"
 dependencies = [
  "amplify",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ required-features = ["server"]
 [dependencies]
 # Farcaster crates
 # farcaster_core = { path = "../farcaster-core", features = ["serde"] }
-farcaster_core = { git = "https://github.com/Lederstrumpf/farcaster-core", rev = "c343cb67398b08935df3fc54c7c4740bb04445ee", features = ["serde"] }
+farcaster_core = { git = "https://github.com/farcaster-project/farcaster-core", branch = "main", features = ["serde"] }
 
 hex = "^0.4.3"
 
@@ -53,11 +53,11 @@ slip132 = "0.3"
 # lnp-core =  { path = "../ext/lnp-core" }
 # internet2 = { path = "../ext/rust-internet2" }
 lnp-core = "0.4.0-beta.3"
-strict_encoding = "=1.7.4"
-strict_encoding_derive = "=1.7.4"
+strict_encoding = "1.7.4"
+strict_encoding_derive = "1.7.4"
 internet2 = "0.5.0-alpha.2"
 bitcoin = "0.27"
-monero = "0.14"
+monero = "0.15"
 # Rust language
 lazy_static = "1.4"
 chrono = "0.4"
@@ -88,12 +88,12 @@ tokio = { version = "1.9.0", features = ["full"] }
 # Coin clients
 electrum-client = { git = "https://github.com/Lederstrumpf/rust-electrum-client", branch = "verboseTransactionGetRebased" }
 bitcoincore-rpc = "0.14.0"
-monero-rpc = { git = "https://github.com/TheCharlatan/monero-rpc-rs", branch = "changes" }
+monero-rpc = { git = "https://github.com/Lederstrumpf/monero-rpc-rs", branch = "changes" }
 # monero-rpc = { path = "../monero-rpc-rs/" }
 
 [build-dependencies]
 # farcaster_core = { path = "../farcaster-core", features = ["serde"]}
-farcaster_core = { git = "https://github.com/Lederstrumpf/farcaster-core", rev = "c343cb67398b08935df3fc54c7c4740bb04445ee", features = ["serde"] }
+farcaster_core = { git = "https://github.com/farcaster-project/farcaster-core", branch = "main", features = ["serde"] }
 
 serde_yaml = { version = "0.8", optional = true }
 toml = { version = "0.5", optional = true }
@@ -105,7 +105,7 @@ lightning_encoding = "0.5.0-beta.3"
 # Bitcoin
 bitcoin = "0.27"
 # Monero
-monero = "0.14"
+monero = "0.15"
 # lnp-core =  { path = "../ext/lnp-core" }
 # internet2 = { path = "../ext/rust-internet2" }
 lnp-core = "0.4.0-beta.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ required-features = ["server"]
 [dependencies]
 # Farcaster crates
 # farcaster_core = { path = "../farcaster-core", features = ["serde"] }
-farcaster_core = { git = "https://github.com/farcaster-project/farcaster-core", branch = "main", features = ["serde"] }
+farcaster_core = { git = "https://github.com/Lederstrumpf/farcaster-core", rev = "c343cb67398b08935df3fc54c7c4740bb04445ee", features = ["serde"] }
 
 hex = "^0.4.3"
 
@@ -84,14 +84,14 @@ zmq = "0.9"
 # Async
 tokio = { version = "1.9.0", features = ["full"] }
 # Coin clients
-electrum-client = { git = "https://github.com/TheCharlatan/rust-electrum-client", branch = "verboseTransactionGet" }
+electrum-client = { git = "https://github.com/Lederstrumpf/rust-electrum-client", branch = "verboseTransactionGetRebased" }
 bitcoincore-rpc = "0.13.0"
 monero-rpc = { git = "https://github.com/TheCharlatan/monero-rpc-rs", branch = "changes" }
 # monero-rpc = { path = "../monero-rpc-rs/" }
 
 [build-dependencies]
 # farcaster_core = { path = "../farcaster-core", features = ["serde"]}
-farcaster_core = { git = "https://github.com/farcaster-project/farcaster-core", branch = "main", features = ["serde"] }
+farcaster_core = { git = "https://github.com/Lederstrumpf/farcaster-core", rev = "c343cb67398b08935df3fc54c7c4740bb04445ee", features = ["serde"] }
 
 serde_yaml = { version = "0.8", optional = true }
 toml = { version = "0.5", optional = true }
@@ -114,7 +114,7 @@ clap_generate = "3.0.0-beta.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 shellexpand = "2"
 configure_me_codegen = "0.4"
-electrum-client = { git = "https://github.com/TheCharlatan/rust-electrum-client", branch = "verboseTransactionGet" }
+electrum-client = { git = "https://github.com/Lederstrumpf/rust-electrum-client", branch = "verboseTransactionGetRebased" }
 
 [dependencies.microservices]
 # path = '../ext/rust-internet2'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,8 @@ monero = "0.14"
 # lnp-core =  { path = "../ext/lnp-core" }
 # internet2 = { path = "../ext/rust-internet2" }
 lnp-core = "0.4.0-beta.3"
+strict_encoding = "=1.7.4"
+strict_encoding_derive = "=1.7.4"
 internet2 = "0.5.0-alpha.2"
 lazy_static = "1.4"
 clap = "3.0.0-beta.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,14 +47,16 @@ hex = "^0.4.3"
 # LNP/BP crates
 amplify = "3"
 amplify_derive = "2"
-lightning_encoding = "0.4.0-beta.1"
-lnpbp = {version = "0.4", features = ["all"]}
+lightning_encoding = "0.5.0-beta.3"
+lnpbp = {version = "0.5.0-beta.3", features = ["all"]}
 slip132 = "0.3"
 # lnp-core =  { path = "../ext/lnp-core" }
 # internet2 = { path = "../ext/rust-internet2" }
-lnp-core = { git = "https://github.com/zkao/lnp-core", branch = "farcaster", optional = true }
-internet2 = { git = "https://github.com/zkao/rust-internet2", branch = "farcaster" }
-bitcoin = "0.26"
+lnp-core = "0.4.0-beta.3"
+strict_encoding = "=1.7.4"
+strict_encoding_derive = "=1.7.4"
+internet2 = "0.5.0-alpha.2"
+bitcoin = "0.27"
 monero = "0.14"
 # Rust language
 lazy_static = "1.4"
@@ -63,7 +65,7 @@ nix = { version = "0.19", optional = true }
 regex = { version = "1.5", optional = true }
 # Serialization & parsing
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
-serde_with = { version = "1.5", optional = true }
+serde_with = { version = "1.8", optional = true }
 serde_json = { version = "1", optional = true }
 serde_yaml = { version = "0.8", optional = true }
 sysinfo = { version = "0.18.2" }
@@ -73,7 +75,7 @@ base64 = { version = "0.12", optional = true }
 # Congig & logging
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 env_logger = "0.7"
-clap = { version = "3.0.0-beta.2", optional = true }
+clap = { version = "3.0.0-beta.4", optional = true }
 settings = { version = "0.10", package = "config", optional = true }
 configure_me = { version = "0.4", optional = true }
 dotenv = { version = "0.15", optional = true }
@@ -85,7 +87,7 @@ zmq = "0.9"
 tokio = { version = "1.9.0", features = ["full"] }
 # Coin clients
 electrum-client = { git = "https://github.com/Lederstrumpf/rust-electrum-client", branch = "verboseTransactionGetRebased" }
-bitcoincore-rpc = "0.13.0"
+bitcoincore-rpc = "0.14.0"
 monero-rpc = { git = "https://github.com/TheCharlatan/monero-rpc-rs", branch = "changes" }
 # monero-rpc = { path = "../monero-rpc-rs/" }
 
@@ -98,19 +100,19 @@ toml = { version = "0.5", optional = true }
 
 amplify = "3"
 amplify_derive = "2"
-lnpbp = { version = "0.4", features = ["all"] }
-lightning_encoding = "0.4.0-beta.1"
+lnpbp = { version = "0.5.0-beta.3", features = ["all"] }
+lightning_encoding = "0.5.0-beta.3"
 # Bitcoin
-bitcoin = "0.26"
+bitcoin = "0.27"
 # Monero
 monero = "0.14"
 # lnp-core =  { path = "../ext/lnp-core" }
 # internet2 = { path = "../ext/rust-internet2" }
-lnp-core = { git = "https://github.com/zkao/lnp-core", branch = "farcaster", optional = true }
-internet2 = { git = "https://github.com/zkao/rust-internet2", branch = "farcaster" }
+lnp-core = "0.4.0-beta.3"
+internet2 = "0.5.0-alpha.2"
 lazy_static = "1.4"
-clap = "3.0.0-beta.2"
-clap_generate = "3.0.0-beta.2"
+clap = "3.0.0-beta.4"
+clap_generate = "3.0.0-beta.4"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 shellexpand = "2"
 configure_me_codegen = "0.4"
@@ -118,15 +120,15 @@ electrum-client = { git = "https://github.com/Lederstrumpf/rust-electrum-client"
 
 [dependencies.microservices]
 # path = '../ext/rust-internet2'
-git = 'https://github.com/zkao/rust-internet2.git'
-branch = 'farcaster'
+name = "rust-internet2"
+version = "0.5.0-alpha.1"
 default-features = false
 features = ['peer']
 
 [build-dependencies.microservices]
 # path = '../ext/rust-internet2'
-git = 'https://github.com/zkao/rust-internet2.git'
-branch = 'farcaster'
+name = "rust-internet2"
+version = "0.5.0-alpha.1"
 default-features = false
 features = ['peer']
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ features = ['peer']
 # 5. Simple cli utility app: `shell`
 [features]
 default = ["server", "cli"]
-all = ["server", "cli", "serde", "tor", "vendored_openssl"]
+all = ["server", "cli", "serde", "tor"]
 
 # Server is a standalone application that runs daemon
 server = ["node", "shell", "microservices/server", "nix"]
@@ -179,7 +179,6 @@ serde = ["serde_crate", "serde_with", "serde_yaml", "serde_json", "toml",
     "amplify/serde", "internet2/serde", "microservices/serde",
     "lnpbp/serde", "lnp-core/serde" ]
 tor = ["microservices/tor", "internet2/tor"]
-vendored_openssl = ["microservices/vendored_openssl", "internet2/vendored_openssl"]
 
 integration_test = ["regex"]
 

--- a/shell/_farcasterd
+++ b/shell/_farcasterd
@@ -19,8 +19,8 @@ _farcasterd() {
 '--data-dir=[Data directory path]: :_files -/' \
 '-c+[Path to the configuration file]: :_files' \
 '--config=[Path to the configuration file]: :_files' \
-'*-T+[Use Tor]: :_hosts' \
-'*--tor-proxy=[Use Tor]: :_hosts' \
+'-T+[Use Tor]: :_hosts' \
+'--tor-proxy=[Use Tor]: :_hosts' \
 '-m+[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '--msg-socket=[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '-x+[ZMQ socket name/address for daemon control interface]: :_files' \
@@ -30,21 +30,19 @@ _farcasterd() {
 '--electrum-server=[Electrum server to use]' \
 '--monero-daemon=[Monero daemon to use]' \
 '--monero-rpc-wallet=[Monero rpc wallet to use]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
 && ret=0
     
 }
 
 (( $+functions[_farcasterd_commands] )) ||
 _farcasterd_commands() {
-    local commands; commands=(
-        
-    )
+    local commands; commands=()
     _describe -t commands 'farcasterd commands' commands "$@"
 }
 

--- a/shell/_farcasterd.ps1
+++ b/shell/_farcasterd.ps1
@@ -35,12 +35,12 @@ Register-ArgumentCompleter -Native -CommandName 'farcasterd' -ScriptBlock {
             [CompletionResult]::new('--electrum-server', 'electrum-server', [CompletionResultType]::ParameterName, 'Electrum server to use')
             [CompletionResult]::new('--monero-daemon', 'monero-daemon', [CompletionResultType]::ParameterName, 'Monero daemon to use')
             [CompletionResult]::new('--monero-rpc-wallet', 'monero-rpc-wallet', [CompletionResultType]::ParameterName, 'Monero rpc wallet to use')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
             break
         }
     })

--- a/shell/_peerd
+++ b/shell/_peerd
@@ -15,8 +15,8 @@ _peerd() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" \
-'*-L+[Start daemon in listening mode binding the provided local address]: :_hosts' \
-'*--listen=[Start daemon in listening mode binding the provided local address]: :_hosts' \
+'-L+[Start daemon in listening mode binding the provided local address]: :_hosts' \
+'--listen=[Start daemon in listening mode binding the provided local address]: :_hosts' \
 '-C+[Connect to a remote peer with the provided address after start]' \
 '--connect=[Connect to a remote peer with the provided address after start]' \
 '-p+[Customize port used by lightning peer network]' \
@@ -29,8 +29,8 @@ _peerd() {
 '--data-dir=[Data directory path]: :_files -/' \
 '-c+[Path to the configuration file]: :_files' \
 '--config=[Path to the configuration file]: :_files' \
-'*-T+[Use Tor]: :_hosts' \
-'*--tor-proxy=[Use Tor]: :_hosts' \
+'-T+[Use Tor]: :_hosts' \
+'--tor-proxy=[Use Tor]: :_hosts' \
 '-m+[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '--msg-socket=[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '-x+[ZMQ socket name/address for daemon control interface]: :_files' \
@@ -40,21 +40,19 @@ _peerd() {
 '--electrum-server=[Electrum server to use]' \
 '--monero-daemon=[Monero daemon to use]' \
 '--monero-rpc-wallet=[Monero rpc wallet to use]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
 && ret=0
     
 }
 
 (( $+functions[_peerd_commands] )) ||
 _peerd_commands() {
-    local commands; commands=(
-        
-    )
+    local commands; commands=()
     _describe -t commands 'peerd commands' commands "$@"
 }
 

--- a/shell/_peerd.ps1
+++ b/shell/_peerd.ps1
@@ -45,12 +45,12 @@ Register-ArgumentCompleter -Native -CommandName 'peerd' -ScriptBlock {
             [CompletionResult]::new('--electrum-server', 'electrum-server', [CompletionResultType]::ParameterName, 'Electrum server to use')
             [CompletionResult]::new('--monero-daemon', 'monero-daemon', [CompletionResultType]::ParameterName, 'Monero daemon to use')
             [CompletionResult]::new('--monero-rpc-wallet', 'monero-rpc-wallet', [CompletionResultType]::ParameterName, 'Monero rpc wallet to use')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
             break
         }
     })

--- a/shell/_swap-cli
+++ b/shell/_swap-cli
@@ -19,8 +19,8 @@ _swap-cli() {
 '--data-dir=[Data directory path]: :_files -/' \
 '-c+[Path to the configuration file]: :_files' \
 '--config=[Path to the configuration file]: :_files' \
-'*-T+[Use Tor]: :_hosts' \
-'*--tor-proxy=[Use Tor]: :_hosts' \
+'-T+[Use Tor]: :_hosts' \
+'--tor-proxy=[Use Tor]: :_hosts' \
 '-m+[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '--msg-socket=[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '-x+[ZMQ socket name/address for daemon control interface]: :_files' \
@@ -30,12 +30,12 @@ _swap-cli() {
 '--electrum-server=[Electrum server to use]' \
 '--monero-daemon=[Monero daemon to use]' \
 '--monero-rpc-wallet=[Monero rpc wallet to use]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
 ":: :_swap-cli_commands" \
 "*::: :->swap-cli" \
 && ret=0
@@ -57,8 +57,8 @@ _arguments "${_arguments_options[@]}" \
 '--data-dir=[Data directory path]: :_files -/' \
 '-c+[Path to the configuration file]: :_files' \
 '--config=[Path to the configuration file]: :_files' \
-'*-T+[Use Tor]: :_hosts' \
-'*--tor-proxy=[Use Tor]: :_hosts' \
+'-T+[Use Tor]: :_hosts' \
+'--tor-proxy=[Use Tor]: :_hosts' \
 '-m+[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '--msg-socket=[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '-x+[ZMQ socket name/address for daemon control interface]: :_files' \
@@ -68,12 +68,12 @@ _arguments "${_arguments_options[@]}" \
 '--electrum-server=[Electrum server to use]' \
 '--monero-daemon=[Monero daemon to use]' \
 '--monero-rpc-wallet=[Monero rpc wallet to use]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
 && ret=0
 ;;
 (connect)
@@ -82,8 +82,8 @@ _arguments "${_arguments_options[@]}" \
 '--data-dir=[Data directory path]: :_files -/' \
 '-c+[Path to the configuration file]: :_files' \
 '--config=[Path to the configuration file]: :_files' \
-'*-T+[Use Tor]: :_hosts' \
-'*--tor-proxy=[Use Tor]: :_hosts' \
+'-T+[Use Tor]: :_hosts' \
+'--tor-proxy=[Use Tor]: :_hosts' \
 '-m+[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '--msg-socket=[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '-x+[ZMQ socket name/address for daemon control interface]: :_files' \
@@ -93,12 +93,12 @@ _arguments "${_arguments_options[@]}" \
 '--electrum-server=[Electrum server to use]' \
 '--monero-daemon=[Monero daemon to use]' \
 '--monero-rpc-wallet=[Monero rpc wallet to use]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
 ':peer -- Address of the remote node, in '<public_key>@<ipv4>|<ipv6>|<onionv2>|<onionv3>\[\:<port>\]' format:' \
 && ret=0
 ;;
@@ -108,8 +108,8 @@ _arguments "${_arguments_options[@]}" \
 '--data-dir=[Data directory path]: :_files -/' \
 '-c+[Path to the configuration file]: :_files' \
 '--config=[Path to the configuration file]: :_files' \
-'*-T+[Use Tor]: :_hosts' \
-'*--tor-proxy=[Use Tor]: :_hosts' \
+'-T+[Use Tor]: :_hosts' \
+'--tor-proxy=[Use Tor]: :_hosts' \
 '-m+[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '--msg-socket=[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '-x+[ZMQ socket name/address for daemon control interface]: :_files' \
@@ -119,12 +119,12 @@ _arguments "${_arguments_options[@]}" \
 '--electrum-server=[Electrum server to use]' \
 '--monero-daemon=[Monero daemon to use]' \
 '--monero-rpc-wallet=[Monero rpc wallet to use]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
 ':peer -- Address of the remote node, in '<public_key>@<ipv4>|<ipv6>|<onionv2>|<onionv3>\[\:<port>\]' format:' \
 && ret=0
 ;;
@@ -134,8 +134,8 @@ _arguments "${_arguments_options[@]}" \
 '--data-dir=[Data directory path]: :_files -/' \
 '-c+[Path to the configuration file]: :_files' \
 '--config=[Path to the configuration file]: :_files' \
-'*-T+[Use Tor]: :_hosts' \
-'*--tor-proxy=[Use Tor]: :_hosts' \
+'-T+[Use Tor]: :_hosts' \
+'--tor-proxy=[Use Tor]: :_hosts' \
 '-m+[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '--msg-socket=[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '-x+[ZMQ socket name/address for daemon control interface]: :_files' \
@@ -145,12 +145,12 @@ _arguments "${_arguments_options[@]}" \
 '--electrum-server=[Electrum server to use]' \
 '--monero-daemon=[Monero daemon to use]' \
 '--monero-rpc-wallet=[Monero rpc wallet to use]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
 '::subject -- Remote peer address or temporary/permanent/short channel id. If absent, returns information about the node itself:' \
 && ret=0
 ;;
@@ -160,8 +160,8 @@ _arguments "${_arguments_options[@]}" \
 '--data-dir=[Data directory path]: :_files -/' \
 '-c+[Path to the configuration file]: :_files' \
 '--config=[Path to the configuration file]: :_files' \
-'*-T+[Use Tor]: :_hosts' \
-'*--tor-proxy=[Use Tor]: :_hosts' \
+'-T+[Use Tor]: :_hosts' \
+'--tor-proxy=[Use Tor]: :_hosts' \
 '-m+[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '--msg-socket=[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '-x+[ZMQ socket name/address for daemon control interface]: :_files' \
@@ -171,12 +171,12 @@ _arguments "${_arguments_options[@]}" \
 '--electrum-server=[Electrum server to use]' \
 '--monero-daemon=[Monero daemon to use]' \
 '--monero-rpc-wallet=[Monero rpc wallet to use]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
 && ret=0
 ;;
 (ls)
@@ -185,8 +185,8 @@ _arguments "${_arguments_options[@]}" \
 '--data-dir=[Data directory path]: :_files -/' \
 '-c+[Path to the configuration file]: :_files' \
 '--config=[Path to the configuration file]: :_files' \
-'*-T+[Use Tor]: :_hosts' \
-'*--tor-proxy=[Use Tor]: :_hosts' \
+'-T+[Use Tor]: :_hosts' \
+'--tor-proxy=[Use Tor]: :_hosts' \
 '-m+[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '--msg-socket=[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '-x+[ZMQ socket name/address for daemon control interface]: :_files' \
@@ -196,12 +196,12 @@ _arguments "${_arguments_options[@]}" \
 '--electrum-server=[Electrum server to use]' \
 '--monero-daemon=[Monero daemon to use]' \
 '--monero-rpc-wallet=[Monero rpc wallet to use]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
 && ret=0
 ;;
 (make)
@@ -210,8 +210,8 @@ _arguments "${_arguments_options[@]}" \
 '--data-dir=[Data directory path]: :_files -/' \
 '-c+[Path to the configuration file]: :_files' \
 '--config=[Path to the configuration file]: :_files' \
-'*-T+[Use Tor]: :_hosts' \
-'*--tor-proxy=[Use Tor]: :_hosts' \
+'-T+[Use Tor]: :_hosts' \
+'--tor-proxy=[Use Tor]: :_hosts' \
 '-m+[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '--msg-socket=[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '-x+[ZMQ socket name/address for daemon control interface]: :_files' \
@@ -221,12 +221,12 @@ _arguments "${_arguments_options[@]}" \
 '--electrum-server=[Electrum server to use]' \
 '--monero-daemon=[Monero daemon to use]' \
 '--monero-rpc-wallet=[Monero rpc wallet to use]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
 '::network -- Type of offer and network to use:' \
 '::arbitrating-blockchain -- The chosen arbitrating blockchain:' \
 '::accordant-blockchain -- The chosen accordant blockchain:' \
@@ -247,8 +247,8 @@ _arguments "${_arguments_options[@]}" \
 '--data-dir=[Data directory path]: :_files -/' \
 '-c+[Path to the configuration file]: :_files' \
 '--config=[Path to the configuration file]: :_files' \
-'*-T+[Use Tor]: :_hosts' \
-'*--tor-proxy=[Use Tor]: :_hosts' \
+'-T+[Use Tor]: :_hosts' \
+'--tor-proxy=[Use Tor]: :_hosts' \
 '-m+[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '--msg-socket=[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '-x+[ZMQ socket name/address for daemon control interface]: :_files' \
@@ -258,21 +258,38 @@ _arguments "${_arguments_options[@]}" \
 '--electrum-server=[Electrum server to use]' \
 '--monero-daemon=[Monero daemon to use]' \
 '--monero-rpc-wallet=[Monero rpc wallet to use]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
 ':public-offer -- Hex encoded offer:' \
 && ret=0
 ;;
 (help)
 _arguments "${_arguments_options[@]}" \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
+'-d+[Data directory path]: :_files -/' \
+'--data-dir=[Data directory path]: :_files -/' \
+'-c+[Path to the configuration file]: :_files' \
+'--config=[Path to the configuration file]: :_files' \
+'-T+[Use Tor]: :_hosts' \
+'--tor-proxy=[Use Tor]: :_hosts' \
+'-m+[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
+'--msg-socket=[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
+'-x+[ZMQ socket name/address for daemon control interface]: :_files' \
+'--ctl-socket=[ZMQ socket name/address for daemon control interface]: :_files' \
+'-n+[Blockchain to use]' \
+'--chain=[Blockchain to use]' \
+'--electrum-server=[Electrum server to use]' \
+'--monero-daemon=[Monero daemon to use]' \
+'--monero-rpc-wallet=[Monero rpc wallet to use]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
+'*-v[Set verbosity level]' \
+'*--verbose[Set verbosity level]' \
 && ret=0
 ;;
         esac
@@ -283,79 +300,61 @@ esac
 (( $+functions[_swap-cli_commands] )) ||
 _swap-cli_commands() {
     local commands; commands=(
-        "listen:Bind to a socket and start listening for incoming LN peer connections, Maker's action" \
-"connect:Connect to the remote lightning network peer" \
-"ping:Ping remote peer (must be already connected)" \
-"info:General information about the running node" \
-"peers:Lists existing peer connections" \
-"ls:Lists running swaps" \
-"make:Maker creates offer and start listening. Command used to to print a hex representation of the offer that shall be shared with Taker. Additionally it spins up the listener awaiting for connection related to this offer. Example usage: `make Testnet Bitcoin Monero "100000 BTC" "200 XMR" 10 10 20 Alice`" \
-"take:Taker accepts offer and connects to Maker's daemon" \
-"help:Prints this message or the help of the given subcommand(s)" \
+'listen:Bind to a socket and start listening for incoming LN peer connections, Maker'\''s action' \
+'connect:Connect to the remote lightning network peer' \
+'ping:Ping remote peer (must be already connected)' \
+'info:General information about the running node' \
+'peers:Lists existing peer connections' \
+'ls:Lists running swaps' \
+'make:Maker creates offer and start listening. Command used to to print a hex representation of the offer that shall be shared with Taker. Additionally it spins up the listener awaiting for connection related to this offer. Example usage: `make Testnet Bitcoin Monero "100000 BTC" "200 XMR" 10 10 20 Alice`' \
+'take:Taker accepts offer and connects to Maker'\''s daemon' \
+'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'swap-cli commands' commands "$@"
 }
 (( $+functions[_swap-cli__connect_commands] )) ||
 _swap-cli__connect_commands() {
-    local commands; commands=(
-        
-    )
+    local commands; commands=()
     _describe -t commands 'swap-cli connect commands' commands "$@"
 }
 (( $+functions[_swap-cli__help_commands] )) ||
 _swap-cli__help_commands() {
-    local commands; commands=(
-        
-    )
+    local commands; commands=()
     _describe -t commands 'swap-cli help commands' commands "$@"
 }
 (( $+functions[_swap-cli__info_commands] )) ||
 _swap-cli__info_commands() {
-    local commands; commands=(
-        
-    )
+    local commands; commands=()
     _describe -t commands 'swap-cli info commands' commands "$@"
 }
 (( $+functions[_swap-cli__listen_commands] )) ||
 _swap-cli__listen_commands() {
-    local commands; commands=(
-        
-    )
+    local commands; commands=()
     _describe -t commands 'swap-cli listen commands' commands "$@"
 }
 (( $+functions[_swap-cli__ls_commands] )) ||
 _swap-cli__ls_commands() {
-    local commands; commands=(
-        
-    )
+    local commands; commands=()
     _describe -t commands 'swap-cli ls commands' commands "$@"
 }
 (( $+functions[_swap-cli__make_commands] )) ||
 _swap-cli__make_commands() {
-    local commands; commands=(
-        
-    )
+    local commands; commands=()
     _describe -t commands 'swap-cli make commands' commands "$@"
 }
 (( $+functions[_swap-cli__peers_commands] )) ||
 _swap-cli__peers_commands() {
-    local commands; commands=(
-        
-    )
+    local commands; commands=()
     _describe -t commands 'swap-cli peers commands' commands "$@"
 }
 (( $+functions[_swap-cli__ping_commands] )) ||
 _swap-cli__ping_commands() {
-    local commands; commands=(
-        
-    )
+    local commands; commands=()
     _describe -t commands 'swap-cli ping commands' commands "$@"
 }
 (( $+functions[_swap-cli__take_commands] )) ||
 _swap-cli__take_commands() {
-    local commands; commands=(
-        
-    )
+    local commands; commands=()
     _describe -t commands 'swap-cli take commands' commands "$@"
 }
 

--- a/shell/_swap-cli.ps1
+++ b/shell/_swap-cli.ps1
@@ -35,12 +35,12 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--electrum-server', 'electrum-server', [CompletionResultType]::ParameterName, 'Electrum server to use')
             [CompletionResult]::new('--monero-daemon', 'monero-daemon', [CompletionResultType]::ParameterName, 'Monero daemon to use')
             [CompletionResult]::new('--monero-rpc-wallet', 'monero-rpc-wallet', [CompletionResultType]::ParameterName, 'Monero rpc wallet to use')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
             [CompletionResult]::new('listen', 'listen', [CompletionResultType]::ParameterValue, 'Bind to a socket and start listening for incoming LN peer connections, Maker''s action')
             [CompletionResult]::new('connect', 'connect', [CompletionResultType]::ParameterValue, 'Connect to the remote lightning network peer')
             [CompletionResult]::new('ping', 'ping', [CompletionResultType]::ParameterValue, 'Ping remote peer (must be already connected)')
@@ -49,7 +49,7 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('ls', 'ls', [CompletionResultType]::ParameterValue, 'Lists running swaps')
             [CompletionResult]::new('make', 'make', [CompletionResultType]::ParameterValue, 'Maker creates offer and start listening. Command used to to print a hex representation of the offer that shall be shared with Taker. Additionally it spins up the listener awaiting for connection related to this offer. Example usage: `make Testnet Bitcoin Monero "100000 BTC" "200 XMR" 10 10 20 Alice`')
             [CompletionResult]::new('take', 'take', [CompletionResultType]::ParameterValue, 'Taker accepts offer and connects to Maker''s daemon')
-            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Prints this message or the help of the given subcommand(s)')
+            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
             break
         }
         'swap-cli;listen' {
@@ -74,12 +74,12 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--electrum-server', 'electrum-server', [CompletionResultType]::ParameterName, 'Electrum server to use')
             [CompletionResult]::new('--monero-daemon', 'monero-daemon', [CompletionResultType]::ParameterName, 'Monero daemon to use')
             [CompletionResult]::new('--monero-rpc-wallet', 'monero-rpc-wallet', [CompletionResultType]::ParameterName, 'Monero rpc wallet to use')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
             break
         }
         'swap-cli;connect' {
@@ -98,12 +98,12 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--electrum-server', 'electrum-server', [CompletionResultType]::ParameterName, 'Electrum server to use')
             [CompletionResult]::new('--monero-daemon', 'monero-daemon', [CompletionResultType]::ParameterName, 'Monero daemon to use')
             [CompletionResult]::new('--monero-rpc-wallet', 'monero-rpc-wallet', [CompletionResultType]::ParameterName, 'Monero rpc wallet to use')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
             break
         }
         'swap-cli;ping' {
@@ -122,12 +122,12 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--electrum-server', 'electrum-server', [CompletionResultType]::ParameterName, 'Electrum server to use')
             [CompletionResult]::new('--monero-daemon', 'monero-daemon', [CompletionResultType]::ParameterName, 'Monero daemon to use')
             [CompletionResult]::new('--monero-rpc-wallet', 'monero-rpc-wallet', [CompletionResultType]::ParameterName, 'Monero rpc wallet to use')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
             break
         }
         'swap-cli;info' {
@@ -146,12 +146,12 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--electrum-server', 'electrum-server', [CompletionResultType]::ParameterName, 'Electrum server to use')
             [CompletionResult]::new('--monero-daemon', 'monero-daemon', [CompletionResultType]::ParameterName, 'Monero daemon to use')
             [CompletionResult]::new('--monero-rpc-wallet', 'monero-rpc-wallet', [CompletionResultType]::ParameterName, 'Monero rpc wallet to use')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
             break
         }
         'swap-cli;peers' {
@@ -170,12 +170,12 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--electrum-server', 'electrum-server', [CompletionResultType]::ParameterName, 'Electrum server to use')
             [CompletionResult]::new('--monero-daemon', 'monero-daemon', [CompletionResultType]::ParameterName, 'Monero daemon to use')
             [CompletionResult]::new('--monero-rpc-wallet', 'monero-rpc-wallet', [CompletionResultType]::ParameterName, 'Monero rpc wallet to use')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
             break
         }
         'swap-cli;ls' {
@@ -194,12 +194,12 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--electrum-server', 'electrum-server', [CompletionResultType]::ParameterName, 'Electrum server to use')
             [CompletionResult]::new('--monero-daemon', 'monero-daemon', [CompletionResultType]::ParameterName, 'Monero daemon to use')
             [CompletionResult]::new('--monero-rpc-wallet', 'monero-rpc-wallet', [CompletionResultType]::ParameterName, 'Monero rpc wallet to use')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
             break
         }
         'swap-cli;make' {
@@ -218,12 +218,12 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--electrum-server', 'electrum-server', [CompletionResultType]::ParameterName, 'Electrum server to use')
             [CompletionResult]::new('--monero-daemon', 'monero-daemon', [CompletionResultType]::ParameterName, 'Monero daemon to use')
             [CompletionResult]::new('--monero-rpc-wallet', 'monero-rpc-wallet', [CompletionResultType]::ParameterName, 'Monero rpc wallet to use')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
             break
         }
         'swap-cli;take' {
@@ -242,19 +242,36 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--electrum-server', 'electrum-server', [CompletionResultType]::ParameterName, 'Electrum server to use')
             [CompletionResult]::new('--monero-daemon', 'monero-daemon', [CompletionResultType]::ParameterName, 'Monero daemon to use')
             [CompletionResult]::new('--monero-rpc-wallet', 'monero-rpc-wallet', [CompletionResultType]::ParameterName, 'Monero rpc wallet to use')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
             break
         }
         'swap-cli;help' {
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
+            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Path to the configuration file')
+            [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'Path to the configuration file')
+            [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')
+            [CompletionResult]::new('--tor-proxy', 'tor-proxy', [CompletionResultType]::ParameterName, 'Use Tor')
+            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming lightning messages')
+            [CompletionResult]::new('--msg-socket', 'msg-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming lightning messages')
+            [CompletionResult]::new('-x', 'x', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
+            [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
+            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Blockchain to use')
+            [CompletionResult]::new('--chain', 'chain', [CompletionResultType]::ParameterName, 'Blockchain to use')
+            [CompletionResult]::new('--electrum-server', 'electrum-server', [CompletionResultType]::ParameterName, 'Electrum server to use')
+            [CompletionResult]::new('--monero-daemon', 'monero-daemon', [CompletionResultType]::ParameterName, 'Monero daemon to use')
+            [CompletionResult]::new('--monero-rpc-wallet', 'monero-rpc-wallet', [CompletionResultType]::ParameterName, 'Monero rpc wallet to use')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
+            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
     })

--- a/shell/_swapd
+++ b/shell/_swapd
@@ -19,8 +19,8 @@ _swapd() {
 '--data-dir=[Data directory path]: :_files -/' \
 '-c+[Path to the configuration file]: :_files' \
 '--config=[Path to the configuration file]: :_files' \
-'*-T+[Use Tor]: :_hosts' \
-'*--tor-proxy=[Use Tor]: :_hosts' \
+'-T+[Use Tor]: :_hosts' \
+'--tor-proxy=[Use Tor]: :_hosts' \
 '-m+[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '--msg-socket=[ZMQ socket name/address to forward all incoming lightning messages]: :_files' \
 '-x+[ZMQ socket name/address for daemon control interface]: :_files' \
@@ -30,12 +30,12 @@ _swapd() {
 '--electrum-server=[Electrum server to use]' \
 '--monero-daemon=[Monero daemon to use]' \
 '--monero-rpc-wallet=[Monero rpc wallet to use]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
 ':swap-id -- Channel id:' \
 ':public-offer -- Public offer to initiate swapd runtime:' \
 ':trade-role -- Trade role of participant (Maker or Taker):' \
@@ -45,9 +45,7 @@ _swapd() {
 
 (( $+functions[_swapd_commands] )) ||
 _swapd_commands() {
-    local commands; commands=(
-        
-    )
+    local commands; commands=()
     _describe -t commands 'swapd commands' commands "$@"
 }
 

--- a/shell/_swapd.ps1
+++ b/shell/_swapd.ps1
@@ -35,12 +35,12 @@ Register-ArgumentCompleter -Native -CommandName 'swapd' -ScriptBlock {
             [CompletionResult]::new('--electrum-server', 'electrum-server', [CompletionResultType]::ParameterName, 'Electrum server to use')
             [CompletionResult]::new('--monero-daemon', 'monero-daemon', [CompletionResultType]::ParameterName, 'Monero daemon to use')
             [CompletionResult]::new('--monero-rpc-wallet', 'monero-rpc-wallet', [CompletionResultType]::ParameterName, 'Monero rpc wallet to use')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
             break
         }
     })

--- a/shell/farcasterd.bash
+++ b/shell/farcasterd.bash
@@ -20,7 +20,7 @@ _farcasterd() {
 
     case "${cmd}" in
         farcasterd)
-            opts=" -d -c -v -T -m -x -n -h -V  --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet --help --version  "
+            opts=" -h -V -d -c -v -T -m -x -n  --help --version --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -31,7 +31,7 @@ _farcasterd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -d)
+                -d)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -39,7 +39,7 @@ _farcasterd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -c)
+                -c)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -47,7 +47,7 @@ _farcasterd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -T)
+                -T)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -55,7 +55,7 @@ _farcasterd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -m)
+                -m)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -63,7 +63,7 @@ _farcasterd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -x)
+                -x)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -71,7 +71,7 @@ _farcasterd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -n)
+                -n)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/shell/peerd.bash
+++ b/shell/peerd.bash
@@ -20,7 +20,7 @@ _peerd() {
 
     case "${cmd}" in
         peerd)
-            opts=" -L -C -p -o -d -c -v -T -m -x -n -h -V  --listen --connect --port --overlay --peer-secret-key --wallet-token --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet --help --version  "
+            opts=" -h -V -L -C -p -o -d -c -v -T -m -x -n  --help --version --listen --connect --port --overlay --peer-secret-key --wallet-token --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -31,7 +31,7 @@ _peerd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -L)
+                -L)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -39,7 +39,7 @@ _peerd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -C)
+                -C)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -47,7 +47,7 @@ _peerd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -p)
+                -p)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -55,7 +55,7 @@ _peerd() {
                     COMPREPLY=($(compgen -W "tcp zmq http websocket smtp" -- "${cur}"))
                     return 0
                     ;;
-                    -o)
+                -o)
                     COMPREPLY=($(compgen -W "tcp zmq http websocket smtp" -- "${cur}"))
                     return 0
                     ;;
@@ -71,7 +71,7 @@ _peerd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -d)
+                -d)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -79,7 +79,7 @@ _peerd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -c)
+                -c)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -87,7 +87,7 @@ _peerd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -T)
+                -T)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -95,7 +95,7 @@ _peerd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -m)
+                -m)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -103,7 +103,7 @@ _peerd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -x)
+                -x)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -111,7 +111,7 @@ _peerd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -n)
+                -n)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/shell/swap-cli.bash
+++ b/shell/swap-cli.bash
@@ -47,7 +47,7 @@ _swap-cli() {
 
     case "${cmd}" in
         swap__cli)
-            opts=" -d -c -v -T -m -x -n -h -V  --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet --help --version  listen connect ping info peers ls make take help"
+            opts=" -h -V -d -c -v -T -m -x -n  --help --version --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet  listen connect ping info peers ls make take help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -58,7 +58,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -d)
+                -d)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -66,7 +66,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -c)
+                -c)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -74,7 +74,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -T)
+                -T)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -82,7 +82,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -m)
+                -m)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -90,7 +90,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -x)
+                -x)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -98,7 +98,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -n)
+                -n)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -123,7 +123,7 @@ _swap-cli() {
             ;;
         
         swap__cli__connect)
-            opts=" -d -c -v -T -m -x -n -h -V  --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet --help --version  <peer> "
+            opts=" -h -V -d -c -v -T -m -x -n  --help --version --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet  <PEER> "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -134,7 +134,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -d)
+                -d)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -142,7 +142,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -c)
+                -c)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -150,7 +150,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -T)
+                -T)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -158,7 +158,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -m)
+                -m)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -166,7 +166,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -x)
+                -x)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -174,7 +174,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -n)
+                -n)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -198,22 +198,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__help)
-            opts=" -h -V  --help --version  "
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        swap__cli__info)
-            opts=" -d -c -v -T -m -x -n -h -V  --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet --help --version  <subject> "
+            opts=" -h -V -d -c -v -T -m -x -n  --help --version --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -224,7 +209,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -d)
+                -d)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -232,7 +217,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -c)
+                -c)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -240,7 +225,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -T)
+                -T)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -248,7 +233,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -m)
+                -m)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -256,7 +241,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -x)
+                -x)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -264,7 +249,82 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -n)
+                -n)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --electrum-server)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --monero-daemon)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --monero-rpc-wallet)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        swap__cli__info)
+            opts=" -h -V -d -c -v -T -m -x -n  --help --version --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet  <SUBJECT> "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                --data-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --tor-proxy)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -T)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --msg-socket)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -m)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ctl-socket)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -x)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --chain)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -n)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -288,7 +348,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__listen)
-            opts=" -i -p -o -d -c -v -T -m -x -n -h -V  --ip --port --overlay --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet --help --version  "
+            opts=" -i -p -o -h -V -d -c -v -T -m -x -n  --ip --port --overlay --help --version --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -299,7 +359,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -i)
+                -i)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -307,7 +367,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -p)
+                -p)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -315,7 +375,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -o)
+                -o)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -323,7 +383,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -d)
+                -d)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -331,7 +391,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -c)
+                -c)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -339,7 +399,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -T)
+                -T)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -347,7 +407,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -m)
+                -m)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -355,7 +415,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -x)
+                -x)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -363,7 +423,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -n)
+                -n)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -387,7 +447,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__ls)
-            opts=" -d -c -v -T -m -x -n -h -V  --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet --help --version  "
+            opts=" -h -V -d -c -v -T -m -x -n  --help --version --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -398,7 +458,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -d)
+                -d)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -406,7 +466,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -c)
+                -c)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -414,7 +474,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -T)
+                -T)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -422,7 +482,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -m)
+                -m)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -430,7 +490,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -x)
+                -x)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -438,7 +498,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -n)
+                -n)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -462,7 +522,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__make)
-            opts=" -d -c -v -T -m -x -n -h -V  --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet --help --version  <network> <arbitrating-blockchain> <accordant-blockchain> <arbitrating-amount> <accordant-amount> <cancel-timelock> <punish-timelock> <fee-strategy> <maker-role> <ip-addr> <port> <overlay> "
+            opts=" -h -V -d -c -v -T -m -x -n  --help --version --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet  <NETWORK> <ARBITRATING_BLOCKCHAIN> <ACCORDANT_BLOCKCHAIN> <ARBITRATING_AMOUNT> <ACCORDANT_AMOUNT> <CANCEL_TIMELOCK> <PUNISH_TIMELOCK> <FEE_STRATEGY> <MAKER_ROLE> <IP_ADDR> <PORT> <OVERLAY> "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -473,7 +533,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -d)
+                -d)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -481,7 +541,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -c)
+                -c)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -489,7 +549,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -T)
+                -T)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -497,7 +557,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -m)
+                -m)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -505,7 +565,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -x)
+                -x)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -513,7 +573,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -n)
+                -n)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -537,7 +597,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__peers)
-            opts=" -d -c -v -T -m -x -n -h -V  --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet --help --version  "
+            opts=" -h -V -d -c -v -T -m -x -n  --help --version --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -548,7 +608,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -d)
+                -d)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -556,7 +616,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -c)
+                -c)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -564,7 +624,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -T)
+                -T)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -572,7 +632,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -m)
+                -m)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -580,7 +640,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -x)
+                -x)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -588,7 +648,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -n)
+                -n)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -612,7 +672,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__ping)
-            opts=" -d -c -v -T -m -x -n -h -V  --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet --help --version  <peer> "
+            opts=" -h -V -d -c -v -T -m -x -n  --help --version --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet  <PEER> "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -623,7 +683,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -d)
+                -d)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -631,7 +691,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -c)
+                -c)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -639,7 +699,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -T)
+                -T)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -647,7 +707,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -m)
+                -m)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -655,7 +715,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -x)
+                -x)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -663,7 +723,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -n)
+                -n)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -687,7 +747,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__take)
-            opts=" -d -c -v -T -m -x -n -h -V  --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet --help --version  <public-offer> "
+            opts=" -h -V -d -c -v -T -m -x -n  --help --version --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet  <PUBLIC_OFFER> "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -698,7 +758,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -d)
+                -d)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -706,7 +766,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -c)
+                -c)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -714,7 +774,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -T)
+                -T)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -722,7 +782,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -m)
+                -m)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -730,7 +790,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -x)
+                -x)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -738,7 +798,7 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -n)
+                -n)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/shell/swapd.bash
+++ b/shell/swapd.bash
@@ -20,7 +20,7 @@ _swapd() {
 
     case "${cmd}" in
         swapd)
-            opts=" -d -c -v -T -m -x -n -h -V  --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet --help --version  <swap-id> <public-offer> <trade-role> "
+            opts=" -h -V -d -c -v -T -m -x -n  --help --version --data-dir --config --verbose --tor-proxy --msg-socket --ctl-socket --chain --electrum-server --monero-daemon --monero-rpc-wallet  <SWAP_ID> <PUBLIC_OFFER> <TRADE_ROLE> "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -31,7 +31,7 @@ _swapd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -d)
+                -d)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -39,7 +39,7 @@ _swapd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -c)
+                -c)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -47,7 +47,7 @@ _swapd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -T)
+                -T)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -55,7 +55,7 @@ _swapd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -m)
+                -m)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -63,7 +63,7 @@ _swapd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -x)
+                -x)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -71,7 +71,7 @@ _swapd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -n)
+                -n)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@
 // If not, see <https://opensource.org/licenses/MIT>.
 
 use internet2::NodeAddr;
-use lnpbp::Chain;
+use lnpbp::chain::Chain;
 
 #[cfg(feature = "shell")]
 use crate::opts::Opts;

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -44,7 +44,7 @@ use bitcoin::{
 };
 use internet2::{addr::InetSocketAddr, NodeAddr, RemoteSocketAddr, ToNodeAddr, TypedEnum};
 use lnp::{message, Messages, TempChannelId as TempSwapId, LIGHTNING_P2P_DEFAULT_PORT};
-use lnpbp::Chain;
+use lnpbp::chain::Chain;
 use microservices::esb::{self, Handler};
 use microservices::rpc::Failure;
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -18,7 +18,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use internet2::PartialNodeAddr;
-use lnpbp::Chain;
+use lnpbp::chain::Chain;
 use microservices::shell::LogLevel;
 
 #[cfg(any(target_os = "linux"))]

--- a/src/peerd/opts.rs
+++ b/src/peerd/opts.rs
@@ -18,7 +18,7 @@ use std::{fs, io::Read};
 use std::{io, net::IpAddr};
 
 use internet2::{FramingProtocol, LocalNode, RemoteNodeAddr};
-use lnpbp::strict_encoding::{StrictDecode, StrictEncode};
+use strict_encoding::{StrictDecode, StrictEncode};
 
 use crate::opts::FARCASTER_NODE_KEY_FILE;
 
@@ -125,7 +125,6 @@ impl FromStr for TokenString {
 }
 
 use bitcoin::secp256k1::{rand::thread_rng, SecretKey};
-use lnpbp::strict_encoding;
 use std::str::FromStr;
 
 /// Hold secret keys and seeds

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -17,7 +17,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use internet2::ZmqType;
-use lnpbp::Chain;
+use lnpbp::chain::Chain;
 use microservices::esb;
 
 use crate::rpc::request::OptionDetails;

--- a/src/rpc/messages.rs
+++ b/src/rpc/messages.rs
@@ -121,7 +121,7 @@ impl StrictDecode for Features {
 }
 
 impl LightningEncode for Features {
-    fn lightning_encode<E: io::Write>(&self, e: E) -> Result<usize, std::io::Error> {
+    fn lightning_encode<E: io::Write>(&self, e: E) -> Result<usize, lightning_encoding::Error> {
         Ok(0)
     }
 }

--- a/src/rpc/messages.rs
+++ b/src/rpc/messages.rs
@@ -10,7 +10,7 @@ use bitcoin::{Script, Txid};
 use internet2::{CreateUnmarshaller, Payload, Unmarshall, Unmarshaller};
 use lightning_encoding::{self, LightningDecode, LightningEncode};
 use lnpbp::chain::AssetId;
-use lnpbp::strict_encoding::{self, StrictDecode, StrictEncode};
+use strict_encoding::{self, StrictDecode, StrictEncode};
 
 /// Some features don't make sense on a per-channels or per-node basis, so each
 /// feature defines how it is presented in those contexts. Some features may be
@@ -132,7 +132,6 @@ impl LightningDecode for Features {
     }
 }
 
-// #[strict_encoding_crate(lnpbp::strict_encoding)]
 // #[display("init({global_features}, {local_features}, {assets:#?})")]
 #[derive(Clone, Debug, From, StrictDecode, StrictEncode)]
 pub struct Init {
@@ -145,7 +144,6 @@ pub struct Init {
 }
 
 #[derive(Clone, Debug, From, StrictDecode, StrictEncode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 pub enum FarMsgs {
     // Part I: Generic messages outside of channel operations
     // ======================================================
@@ -197,7 +195,6 @@ pub enum FarMsgs {
     StrictEncode,
     StrictDecode,
 )]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub struct Ping {
     pub ignored: Vec<u8>,
@@ -219,7 +216,6 @@ pub struct Ping {
     StrictEncode,
     StrictDecode,
 )]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 pub struct Error {
     /// The channel is referred to by channel_id, unless channel_id is 0 (i.e.
     /// all bytes are 0), in which case it refers to all channels.

--- a/src/rpc/reply.rs
+++ b/src/rpc/reply.rs
@@ -17,7 +17,6 @@ use microservices::{rpc, rpc_connection};
 use crate::Error;
 
 #[derive(Clone, Debug, Display, From, Api)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[api(encoding = "strict")]
 #[display(Debug)]
 #[non_exhaustive]

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -131,7 +131,7 @@ impl Msg {
 }
 
 impl LightningEncode for Msg {
-    fn lightning_encode<E: io::Write>(&self, e: E) -> Result<usize, io::Error> {
+    fn lightning_encode<E: io::Write>(&self, e: E) -> Result<usize, lightning_encoding::Error> {
         Payload::from(self.clone()).lightning_encode(e)
     }
 }

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -58,15 +58,14 @@ use internet2::Api;
 use internet2::{NodeAddr, RemoteSocketAddr};
 use lnp::payment::{self, AssetsBalance, Lifecycle};
 use lnp::{message, Messages, TempChannelId as TempSwapId};
-use lnpbp::strict_encoding::{
-    strategies::HashFixedBytes, strict_encode_list, Strategy, StrictDecode, StrictEncode,
-};
 use microservices::rpc::Failure;
 use microservices::rpc_connection;
+use strict_encoding::{
+    strategies::HashFixedBytes, strict_encode_list, Strategy, StrictDecode, StrictEncode,
+};
 
 #[derive(Clone, Debug, Display, From, StrictDecode, StrictEncode, Api)]
 #[api(encoding = "lightning")]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(inner)]
 pub enum Msg {
     #[api(type = 28)]
@@ -163,7 +162,6 @@ impl lightning_encoding::Strategy for Reveal {
 }
 
 #[derive(Eq, PartialEq, Hash, Clone, Debug, Display, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("request_id({0})")]
 pub struct RequestId(pub u64);
 
@@ -176,7 +174,6 @@ impl RequestId {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("commit")]
 pub enum Commit {
     Alice(CommitAliceParameters<BtcXmr>),
@@ -184,12 +181,10 @@ pub enum Commit {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("nodeid")]
 pub struct NodeId(pub bitcoin::secp256k1::PublicKey);
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("{public_offer}")]
 pub struct PubOffer {
     pub public_offer: PublicOffer<BtcXmr>,
@@ -206,17 +201,14 @@ impl From<PublicOffer<BtcXmr>> for PubOffer {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, PartialEq, Eq)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("{0}")]
 pub struct Token(pub String);
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("get keys(token({0}), req_id({1}))")]
 pub struct GetKeys(pub Token, pub RequestId);
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("launch_swap")]
 pub struct LaunchSwap {
     pub peer: ServiceId,
@@ -229,7 +221,6 @@ pub struct LaunchSwap {
 }
 
 #[derive(Clone, Debug, From, StrictDecode, StrictEncode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 pub struct TakeCommit {
     pub commit: Commit,
     pub public_offer_hex: String, // TODO: replace by public offer id
@@ -237,7 +228,6 @@ pub struct TakeCommit {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("keypair(sk:({0}),pk:({1})),id:({2})")]
 pub struct Keys(
     pub bitcoin::secp256k1::SecretKey,
@@ -246,7 +236,6 @@ pub struct Keys(
 );
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("reveal")]
 pub enum Reveal {
     Alice(RevealAliceParameters<BtcXmr>),
@@ -260,7 +249,6 @@ pub enum Reveal {
 //     serde(crate = "serde_crate")
 // )]
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("params")]
 pub enum Params {
     Alice(AliceParameters<BtcXmr>),
@@ -268,7 +256,6 @@ pub enum Params {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(inner)]
 pub enum Tx {
     #[display("lock")]
@@ -288,7 +275,6 @@ pub enum Tx {
 use crate::{Error, ServiceId};
 
 #[derive(Clone, Debug, Display, From, Api)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[api(encoding = "strict")]
 #[non_exhaustive]
 pub enum Request {
@@ -504,7 +490,6 @@ pub enum Request {
 impl rpc_connection::Request for Request {}
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("{source}, {event}")]
 pub struct SyncerdBridgeEvent {
     pub event: Event,
@@ -512,7 +497,6 @@ pub struct SyncerdBridgeEvent {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("{peerd}, {swap_id}")]
 pub struct InitSwap {
     pub peerd: ServiceId,
@@ -530,7 +514,6 @@ pub struct InitSwap {
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(NodeInfo::to_yaml_string)]
 pub struct NodeInfo {
     pub node_ids: Vec<secp256k1::PublicKey>,
@@ -547,7 +530,6 @@ pub struct NodeInfo {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Display, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display("proto_puboffer")]
 pub struct ProtoPublicOffer {
     pub offer: Offer<BtcXmr>,
@@ -562,7 +544,6 @@ pub struct ProtoPublicOffer {
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(SyncerInfo::to_yaml_string)]
 pub struct SyncerInfo {
     #[serde_as(as = "DurationSeconds")]
@@ -579,7 +560,6 @@ pub struct SyncerInfo {
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(PeerInfo::to_yaml_string)]
 pub struct PeerInfo {
     pub local_id: secp256k1::PublicKey,
@@ -604,7 +584,6 @@ pub type RemotePeerMap<T> = BTreeMap<NodeAddr, T>;
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(SwapInfo::to_yaml_string)]
 pub struct SwapInfo {
     #[serde_as(as = "Option<DisplayFromStr>")]
@@ -635,7 +614,6 @@ impl ToYamlString for SwapInfo {}
 impl ToYamlString for SyncerInfo {}
 
 #[derive(Wrapper, Clone, PartialEq, Eq, Debug, From, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[wrapper(IndexRange)]
 pub struct List<T>(Vec<T>)
 where
@@ -677,7 +655,6 @@ where
 }
 
 #[derive(Wrapper, Clone, PartialEq, Eq, Debug, From, Default, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 pub struct OptionDetails(pub Option<String>);
 
 impl Display for OptionDetails {

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -708,7 +708,7 @@ impl From<crate::Error> for Request {
 pub trait IntoProgressOrFalure {
     fn into_progress_or_failure(self) -> Request;
 }
-pub trait IntoSuccessOrFalure {
+pub trait IntoSuccessOrFailure {
     fn into_success_or_failure(self) -> Request;
 }
 
@@ -721,7 +721,7 @@ impl IntoProgressOrFalure for Result<String, crate::Error> {
     }
 }
 
-impl IntoSuccessOrFalure for Result<String, crate::Error> {
+impl IntoSuccessOrFailure for Result<String, crate::Error> {
     fn into_success_or_failure(self) -> Request {
         match self {
             Ok(val) => Request::Success(OptionDetails::with(val)),
@@ -730,7 +730,7 @@ impl IntoSuccessOrFalure for Result<String, crate::Error> {
     }
 }
 
-impl IntoSuccessOrFalure for Result<(), crate::Error> {
+impl IntoSuccessOrFailure for Result<(), crate::Error> {
     fn into_success_or_failure(self) -> Request {
         match self {
             Ok(_) => Request::Success(OptionDetails::new()),

--- a/src/service.rs
+++ b/src/service.rs
@@ -224,7 +224,7 @@ where
                 .send_to(ServiceBus::Msg, ServiceId::Farcasterd, Request::Hello)?;
         }
 
-        let identity = self.esb.handler_ref().identity();
+        let identity = self.esb.handler().identity();
         info!("{} started", identity);
 
         self.esb.run_or_panic(&identity.to_string());

--- a/src/service.rs
+++ b/src/service.rs
@@ -20,10 +20,11 @@ use std::str::FromStr;
 use bitcoin::hashes::hex::{self, ToHex};
 use internet2::{zmqsocket, NodeAddr, ZmqType};
 // use lnp::{TempChannelId as TempSwapId};
-use lnpbp::strict_encoding::{strict_deserialize, strict_serialize};
 #[cfg(feature = "node")]
 use microservices::node::TryService;
 use microservices::{esb, rpc};
+use strict_encoding::{strict_deserialize, strict_serialize};
+use strict_encoding::{StrictDecode, StrictEncode};
 
 use farcaster_core::swap::SwapId;
 
@@ -46,7 +47,6 @@ use crate::Error;
     StrictEncode,
     StrictDecode,
 )]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 pub struct ClientName([u8; 32]);
 
 impl Display for ClientName {
@@ -82,7 +82,6 @@ impl FromStr for ClientName {
 
 /// Identifiers of daemons participating in LNP Node
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Display, From, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 pub enum ServiceId {
     #[display("loopback")]
     Loopback,

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -72,7 +72,7 @@ use internet2::zmqsocket::{self, ZmqSocketAddr, ZmqType};
 use internet2::{
     session, CreateUnmarshaller, NodeAddr, Session, TypedEnum, Unmarshall, Unmarshaller,
 };
-use lnpbp::Chain;
+use lnpbp::chain::Chain;
 use microservices::esb::{self, Handler};
 use monero::cryptonote::hash::keccak_256;
 use request::{Commit, InitSwap, Params, Reveal, TakeCommit, Tx};

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -159,7 +159,6 @@ pub struct Runtime {
     storage: Box<dyn storage::Driver>,
 }
 
-
 struct TemporalSafety {
     cancel_timelock: BlockHeight,
     punish_timelock: BlockHeight,

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -27,7 +27,7 @@ use internet2::zmqsocket::Connection;
 use internet2::zmqsocket::ZmqType;
 use internet2::PlainTranscoder;
 use internet2::ZMQ_CONTEXT;
-use lnpbp::Chain;
+use lnpbp::chain::Chain;
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 use std::io;

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -16,7 +16,7 @@ use internet2::zmqsocket::Connection;
 use internet2::zmqsocket::ZmqType;
 use internet2::PlainTranscoder;
 use internet2::ZMQ_CONTEXT;
-use lnpbp::Chain;
+use lnpbp::chain::Chain;
 use monero::Hash;
 use monero_rpc::BlockHash;
 use monero_rpc::GetBlockHeaderSelector;

--- a/src/syncerd/opts.rs
+++ b/src/syncerd/opts.rs
@@ -13,8 +13,8 @@
 // If not, see <https://opensource.org/licenses/MIT>.
 
 use clap::{AppSettings, Clap};
-use lnpbp::strict_encoding::{StrictDecode, StrictEncode};
 use std::str::FromStr;
+use strict_encoding::{StrictDecode, StrictEncode};
 
 /// Syncer blockchain management daemon; part of Farcaster Node
 ///
@@ -40,7 +40,6 @@ pub struct Opts {
 }
 
 #[derive(Clap, Clone, Hash, PartialEq, Eq, Debug, StrictEncode, StrictDecode)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 pub enum Coin {
     /// Launches a bitcoin syncer
     Bitcoin,

--- a/src/syncerd/runtime.rs
+++ b/src/syncerd/runtime.rs
@@ -35,7 +35,7 @@ use internet2::{
     presentation, transport, zmqsocket, NodeAddr, RemoteSocketAddr, TypedEnum, ZmqType, ZMQ_CONTEXT,
 };
 use lnp::{message, Messages, TempChannelId as TempSwapId};
-use lnpbp::Chain;
+use lnpbp::chain::Chain;
 use microservices::esb::{self, Handler};
 use microservices::rpc::Failure;
 

--- a/src/syncerd/types.rs
+++ b/src/syncerd/types.rs
@@ -1,5 +1,6 @@
+use strict_encoding::{StrictDecode, StrictEncode};
+
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub enum AddressAddendum {
     Monero(XmrAddressAddendum),
@@ -7,7 +8,6 @@ pub enum AddressAddendum {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub struct BtcAddressAddendum {
     /// The address the syncer will watch and query.
@@ -19,7 +19,6 @@ pub struct BtcAddressAddendum {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub struct XmrAddressAddendum {
     pub spend_key: [u8; 32],
@@ -28,14 +27,12 @@ pub struct XmrAddressAddendum {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub struct Abort {
     pub id: u32,
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub struct WatchHeight {
     pub id: u32,
@@ -43,7 +40,6 @@ pub struct WatchHeight {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub struct WatchAddress {
     pub id: u32,
@@ -53,7 +49,6 @@ pub struct WatchAddress {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub enum Boolean {
     True,
@@ -70,7 +65,6 @@ impl From<Boolean> for bool {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub struct WatchTransaction {
     pub id: u32,
@@ -80,7 +74,6 @@ pub struct WatchTransaction {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub struct BroadcastTransaction {
     pub id: u32,
@@ -90,7 +83,6 @@ pub struct BroadcastTransaction {
 /// Tasks created by the daemon and handle by syncers to process a blockchain
 /// and generate [`Event`] back to the syncer.
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub enum Task {
     Abort(Abort),
@@ -101,7 +93,6 @@ pub enum Task {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub struct TaskAborted {
     pub id: u32,
@@ -109,7 +100,6 @@ pub struct TaskAborted {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub struct HeightChanged {
     pub id: u32,
@@ -118,7 +108,6 @@ pub struct HeightChanged {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub struct AddressTransaction {
     pub id: u32,
@@ -129,7 +118,6 @@ pub struct AddressTransaction {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub struct TransactionConfirmations {
     pub id: u32,
@@ -138,7 +126,6 @@ pub struct TransactionConfirmations {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub struct TransactionBroadcasted {
     pub id: u32,
@@ -150,7 +137,6 @@ pub struct TransactionBroadcasted {
 /// Events are identified with a unique 32-bits integer that match the [`Task`]
 /// id.
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[strict_encoding_crate(lnpbp::strict_encoding)]
 #[display(Debug)]
 pub enum Event {
     /// Notify the daemon the blockchain height changed.

--- a/src/walletd/opts.rs
+++ b/src/walletd/opts.rs
@@ -75,8 +75,8 @@ use bitcoin::secp256k1::{
     rand::{rngs::ThreadRng, thread_rng},
     PublicKey, Secp256k1, SecretKey,
 };
-use lnpbp::strict_encoding;
-use lnpbp::strict_encoding::{StrictDecode, StrictEncode};
+use strict_encoding;
+use strict_encoding::{StrictDecode, StrictEncode};
 
 /// Hold secret keys and seeds
 #[derive(StrictEncode, StrictDecode, Clone, PartialEq, Eq, Debug)]

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -37,8 +37,8 @@ use farcaster_core::{
         FullySignedPunish, FullySignedRefund, FundingTransaction, SignedAdaptorBuy,
         SignedAdaptorRefund, SignedArbitratingLock,
     },
-    crypto::CommitmentEngine,
     crypto::{ArbitratingKeyId, GenerateKey},
+    crypto::{CommitmentEngine, ProveCrossGroupDleq},
     monero::Monero,
     negotiation::PublicOffer,
     protocol_message::{
@@ -433,7 +433,18 @@ impl Runtime {
                             } else {
                                 trace!("Setting bob params: {}", reveal);
                                 bob_commit.verify_with_reveal(&CommitmentEngine, reveal.clone())?;
-                                *bob_params = Some(reveal.into());
+                                let remote_params_candidate: BobParameters<BtcXmr> = reveal.into();
+                                let proof_verification = key_manager.verify_proof(
+                                    &remote_params_candidate.spend,
+                                    &remote_params_candidate.adaptor,
+                                    remote_params_candidate.proof.clone(),
+                                );
+
+                                if !proof_verification.is_ok() {
+                                    error!("DLEQ proof invalid");
+                                    return Ok(());
+                                }
+                                *bob_params = Some(remote_params_candidate);
                                 // nothing to do yet, waiting for Msg
                                 // CoreArbitratingSetup to proceed
                                 return Ok(());
@@ -462,7 +473,20 @@ impl Runtime {
                                 error!("Alice params already set");
                                 return Ok(());
                             }
-                            *remote_params = Some(reveal.into());
+
+                            trace!("Setting remote params: {}", reveal);
+                            let remote_params_candidate: AliceParameters<BtcXmr> = reveal.into();
+                            let proof_verification = key_manager.verify_proof(
+                                &remote_params_candidate.spend,
+                                &remote_params_candidate.adaptor,
+                                remote_params_candidate.proof.clone(),
+                            );
+
+                            if !proof_verification.is_ok() {
+                                error!("DLEQ proof invalid");
+                                return Ok(());
+                            }
+                            *remote_params = Some(remote_params_candidate);
 
                             // set wallet core_arb_txs
                             if core_arb_setup.is_some() {

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -533,7 +533,7 @@ impl Runtime {
                         let sig = signed_arb_lock.lock_sig;
                         let tx = core_arb_setup.lock.clone();
                         let mut lock_tx = LockTx::from_partial(tx);
-                        let lock_pubkey = key_manager.get_pubkey(ArbitratingKeyId::Fund)?;
+                        let lock_pubkey = key_manager.get_pubkey(ArbitratingKeyId::Lock)?;
                         lock_tx.add_witness(lock_pubkey, sig)?;
                         let finalized_lock_tx =
                             Broadcastable::<BitcoinSegwitV0>::finalize_and_extract(&mut lock_tx)?;
@@ -1042,8 +1042,7 @@ where
 }
 
 pub fn create_funding(key_manager: &mut KeyManager) -> Result<FundingTx, Error> {
-    let pk = key_manager.get_pubkey(ArbitratingKeyId::Fund)?;
-    debug!("bug to fix: not Fund, Lock^");
+    let pk = key_manager.get_pubkey(ArbitratingKeyId::Lock)?;
     Ok(FundingTx::initialize(
         pk,
         farcaster_core::blockchain::Network::Testnet,

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -14,7 +14,7 @@ use internet2::Decrypt;
 use internet2::PlainTranscoder;
 use internet2::RoutedFrame;
 use internet2::ZMQ_CONTEXT;
-use lnpbp::Chain;
+use lnpbp::chain::Chain;
 use monero::Address;
 use monero_rpc::GetBlockHeaderSelector;
 use std::collections::HashMap;

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -581,8 +581,7 @@ fn find_coinbase_transaction_amount(txs: Vec<bitcoin::Transaction>) -> u64 {
 
 fn bitcoin_setup() -> bitcoincore_rpc::Client {
     let path = std::path::PathBuf::from_str("tests/data_dir/regtest/.cookie").unwrap();
-    let bitcoin_rpc =
-        Client::new("http://localhost:18443".to_string(), Auth::CookieFile(path)).unwrap();
+    let bitcoin_rpc = Client::new("http://localhost:18443", Auth::CookieFile(path)).unwrap();
 
     // make sure a wallet is created and loaded
     match bitcoin_rpc.create_wallet("wallet", None, None, None, None) {

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -464,7 +464,8 @@ fn bitcoin_syncer_broadcast_tx_test() {
         .unwrap();
     let transaction = bitcoin_rpc.get_transaction(&txid, None).unwrap();
 
-    // Generate over 101 blocks to reach block maturity, and some more for extra leeway
+    // Generate over 101 blocks to reach block maturity, and some more for extra
+    // leeway
     bitcoin_rpc.generate_to_address(110, &address).unwrap();
 
     // allow some time for things to happen, like the electrum server catching up


### PR DESCRIPTION
[bumped bitcoin to `0.27` in `farcaster-core`](https://github.com/farcaster-project/farcaster-core/pull/141) and these were the consequent changes (as well as some other consequent bumps in core: https://github.com/farcaster-project/farcaster-core/pull/148)

I think just about all of the lnp stack dependencies are now on the latest version (alpha/beta where necessary to be compatible with bitcoin 0.27) - quite little of the API has changed.