### PR TITLE
Syncer: Fix infinite loop in task receiver

### DIFF
--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -422,6 +422,7 @@ async fn run_syncerd_task_receiver(
                     // do nothing
                 }
             }
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     });
 }
@@ -612,7 +613,12 @@ impl Synclet for BitcoinSyncer {
         polling: bool,
     ) {
         std::thread::spawn(move || {
-            let rt = Runtime::new().unwrap();
+            use tokio::runtime::Builder;
+            let rt = Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()
+                .unwrap();
             rt.block_on(async {
                 let (event_tx, event_rx): (
                     TokioSender<SyncerdBridgeEvent>,

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -289,6 +289,7 @@ async fn run_syncerd_task_receiver(
                     // do nothing
                 }
             }
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     });
 }
@@ -476,7 +477,12 @@ impl Synclet for MoneroSyncer {
             error!("monero syncer only supports polling for now - switching to polling=true");
         }
         let _handle = std::thread::spawn(move || {
-            let rt = Runtime::new().unwrap();
+            use tokio::runtime::Builder;
+            let rt = Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()
+                .unwrap();
             rt.block_on(async {
                 let (event_tx, event_rx): (
                     TokioSender<SyncerdBridgeEvent>,


### PR DESCRIPTION
Sleep in the task receiver loop

Also limit the tokio runtime to two worker threads to additionally consume fewer system resources