### PR TITLE
Functional tests and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: rustfmt
+
       - name: Run Rustfmt
         uses: actions-rs/cargo@v1
         with:
@@ -35,7 +42,6 @@ jobs:
         with:
           toolchain: nightly
           override: true
-          components: rustfmt
 
       - name: Build & test
         uses: actions-rs/cargo@v1
@@ -73,7 +79,6 @@ jobs:
         with:
           toolchain: nightly
           override: true
-          components: rustfmt
 
       - name: Correct permissions
         run: sudo chown -R $USER tests

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@
 
 # Shell utilities
 /shell
+
+# Functional tests: generated folders
+/tests/data_dir
+/tests/.farcaster_node_0
+/tests/.farcaster_node_1

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -284,7 +284,8 @@ fn query_addr_history(
 
     let mut addr_txs = vec![];
     for hist in tx_hist {
-        // skip the transasction if it is either in the mempool (0 and -1) or below a certain block height
+        // skip the transasction if it is either in the mempool (0 and -1) or below a
+        // certain block height
         if hist.height <= min_block_height.try_into().unwrap() && hist.height > 0 {
             continue;
         }


### PR DESCRIPTION
- Run `cargo fmt` in nightly
- ~Add namespace for inproc monero bridge (see if it resolve the issue at https://github.com/farcaster-project/farcaster-node/runs/4153268390?check_suite_focus=true#step:7:1710)~
- Ran cargo fmt
- Ignore generated folder when running functional tests

Work already done in https://github.com/farcaster-project/farcaster-node/pull/172