### PR TITLE
Individual tests atomic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-targets --all-features --no-fail-fast --verbose -- --ignored --nocapture
+          args: --workspace --all-targets --all-features --no-fail-fast --verbose -- --ignored --test-threads=1
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,6 +948,7 @@ dependencies = [
  "monero",
  "monero-rpc",
  "nix",
+ "paste",
  "regex",
  "serde 1.0.127",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,8 @@ tokio = { version = "1.12.0", features = ["full"] }
 toml = { version = "0.5", optional = true }
 # IPC
 zmq = "0.9"
+# Misc
+paste = "1.0"
 
 [build-dependencies]
 farcaster_core = { version = "0.3.0", features = ["serde"] }

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -284,7 +284,8 @@ fn query_addr_history(
 
     let mut addr_txs = vec![];
     for hist in tx_hist {
-        // skip the transasction if it is either in the mempool (0 and -1) or below a certain block height
+        // skip the transasction if it is either in the mempool (0 and -1) or below a
+        // certain block height
         if hist.height <= min_block_height.try_into().unwrap() && hist.height > 0 {
             continue;
         }

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -21,10 +21,10 @@ use internet2::ZMQ_CONTEXT;
 use lnpbp::chain::Chain;
 use monero::Address;
 use monero_rpc::GetBlockHeaderSelector;
+use paste::paste;
 use std::collections::HashMap;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
-use paste::paste;
 
 use bitcoin::hashes::Hash;
 use internet2::{CreateUnmarshaller, Unmarshall};


### PR DESCRIPTION
Based on #172.

- Split tests atomically, no big wrapper functions
- Remove no-capture, if test fail stdout is printed anyway, cleaner logs for passed tests
- Run all tests (bitcoin and monero ones) in sequence within 1 unique thread