### PR TITLE
Replace get verbose transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,7 +832,8 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "electrum-client"
 version = "0.8.0"
-source = "git+https://github.com/Lederstrumpf/rust-electrum-client?branch=verboseTransactionGetRebased#7f6139290ace70b5904550bcaa6fb96bcb689f96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd12f125852d77980725243b2a8b3bea73cd4c7a22c33bc52b08b664c561dc7"
 dependencies = [
  "bitcoin 0.27.1",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ colored = { version = "2", optional = true }
 configure_me = { version = "0.4", optional = true }
 dotenv = { version = "0.15", optional = true }
 # Coin clients
-electrum-client = { git = "https://github.com/Lederstrumpf/rust-electrum-client", branch = "verboseTransactionGetRebased" }
+electrum-client = "0.8.0"
 env_logger = "0.7"
 internet2 = "0.5.0-alpha.2"
 # Rust language
@@ -119,7 +119,7 @@ clap_generate = "3.0.0-beta.4"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 shellexpand = "2"
 configure_me_codegen = "0.4"
-electrum-client = { git = "https://github.com/Lederstrumpf/rust-electrum-client", branch = "verboseTransactionGetRebased" }
+electrum-client = "0.8.0"
 
 [dependencies.microservices]
 # path = '../ext/rust-internet2'

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -262,7 +262,7 @@ impl ElectrumRpc {
                             );
                             let mut state_guard = state.lock().await;
                             state_guard
-                                .change_transaction(tx_id.to_vec(), None, None)
+                                .change_transaction(tx_id.to_vec(), None, Some(0))
                                 .await;
                             drop(state_guard);
                             continue;
@@ -289,7 +289,7 @@ impl ElectrumRpc {
                                     );
                                     let mut state_guard = state.lock().await;
                                     state_guard
-                                        .change_transaction(tx_id.to_vec(), None, None)
+                                        .change_transaction(tx_id.to_vec(), None, Some(0))
                                         .await;
                                     drop(state_guard);
                                     continue;

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -295,14 +295,13 @@ impl ElectrumRpc {
                                 }
                             };
                             let blockhash = Some(block.block_hash().to_vec());
-                            // SAFETY: safe cast u64 from usize, confirmations should not overflow
-                            // 32-bits
+                            // SAFETY: safe cast u64 from usize
                             (Some(confirm_height as u64), blockhash)
                         }
                     };
 
                     let current_block_height = match self.client.block_headers_subscribe() {
-                        // SAFETY: safe cast u64 from usize, confirmations should not overflow 32-bits
+                        // SAFETY: safe cast u64 from usize
                         Ok(block) => block.height as u64,
                         Err(err) => {
                             debug!(

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -299,7 +299,7 @@ impl ElectrumRpc {
                             // SAFETY: safe cast u64 from usize, confirmations should not overflow
                             // 32-bits
                             (
-                                (current_block_height - confirm_height as u64) as u32,
+                                (current_block_height - confirm_height as u64) as u32 + 1,
                                 blockhash,
                             )
                         }

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -70,6 +70,10 @@ impl SyncerState {
         }
     }
 
+    pub fn block_height(&self) -> u64 {
+        self.block_height
+    }
+
     pub async fn abort(&mut self, task_id: u32, source: ServiceId) {
         // check addresses tasks
         let ids: Vec<u32> = self

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,17 +1,22 @@
-### Running functional tests
+# Running functional tests
 
-By default the functional tests are not run when executing `cargo test`. To run
-them, run `cargo test -- --ignored`.
+Run the tests with:
 
-Before running the functional tests, start the docker containers first with
-`docker-compose up`.
+```
+docker-compose up -d
+sudo chown -R $USER data_dir
+cargo test --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1
+```
 
-Docker creates and mounts a volume in the `data_dir` directory. The owner of
-this directory is the root user, so ownership has to be changed before running
-the functional tests with `sudo chown -R $USER data_dir`.
+## Steps
 
-Alternatively, the regtest setup can be run directly on the host, with the tests
-expecting the following endpoints:
+By default the functional tests are not run when executing `cargo test`. To run them, run `cargo test --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1`.
+
+Before running the functional tests, start the docker containers first with `docker-compose up -d`.
+
+Docker creates and mounts a volume in the `data_dir` directory. The owner of this directory is the root user, so ownership has to be changed before running the functional tests with `sudo chown -R $USER data_dir`.
+
+Alternatively, the regtest setup can be run directly on the host, with the tests expecting the following endpoints:
 
 - Bitcoind rpc cookie at `./tests/data_dir/regtest/.cookie`
 - Bitcoind at `http://localhost:18443`

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -12,10 +12,7 @@ services:
             - 18443:18443
     electrs:
         image: ghcr.io/farcaster-project/containers/electrs:latest
-        environment:
-            NETWORK: regtest
-            ELECTRUM_RPC_PORT: 50001
-            DAEMON_RPC_ADDR: bitcoin-core:18443
+        command: "/usr/bin/electrs -vv --network regtest --daemon-dir /data --daemon-rpc-addr bitcoin-core:18443 --electrum-rpc-addr 0.0.0.0:50001 --txid-limit 100000"
         volumes:
             - ./data_dir:/data
         ports:


### PR DESCRIPTION
Replace the get verbose transaction call to Electrum server by 3 different calls allowing to extract the tx confirmations and the block hash.