### PR TITLE
Clippy

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+enum-variant-size-threshold=4000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  static_analysis:
-    name: Static Analysis
+  rust_format:
+    name: Rust Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -28,6 +28,24 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  rust_clippy:
+    name: Rust Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+
+      - name: Run Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all --all-targets --all-features -- -D warnings
 
   test:
     name: Unit tests

--- a/build.rs
+++ b/build.rs
@@ -55,9 +55,9 @@ fn main() -> Result<(), configure_me_codegen::Error> {
     .iter_mut()
     {
         let name = app.get_name().to_string();
-        generate_to::<Bash, _, _>(app, &name, &outdir);
-        generate_to::<PowerShell, _, _>(app, &name, &outdir);
-        generate_to::<Zsh, _, _>(app, &name, &outdir);
+        generate_to::<Bash, _, _>(app, &name, &outdir)?;
+        generate_to::<PowerShell, _, _>(app, &name, &outdir)?;
+        generate_to::<Zsh, _, _>(app, &name, &outdir)?;
     }
 
     configure_me_codegen::build_script_auto()

--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,10 @@
 extern crate amplify_derive;
 
 use clap::IntoApp;
-use clap_generate::{generate_to, generators::{Bash, PowerShell, Zsh}};
+use clap_generate::{
+    generate_to,
+    generators::{Bash, PowerShell, Zsh},
+};
 
 pub mod opts {
     include!("src/opts.rs");

--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,7 @@
 extern crate amplify_derive;
 
 use clap::IntoApp;
-use clap_generate::{generate_to, generators::*};
+use clap_generate::{generate_to, generators::{Bash, PowerShell, Zsh}};
 
 pub mod opts {
     include!("src/opts.rs");

--- a/src/bin/address.rs
+++ b/src/bin/address.rs
@@ -61,5 +61,5 @@ pub fn main() {
     let args: Vec<_> = std::env::args().collect();
     let path = args[1].as_str();
     let address = pop_address(path);
-    io::stdout().write(address.to_string().as_bytes()).unwrap();
+    let _ = io::stdout().write(address.to_string().as_bytes()).unwrap();
 }

--- a/src/bin/peerd.rs
+++ b/src/bin/peerd.rs
@@ -102,10 +102,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
 use bitcoin::secp256k1::PublicKey;
-use farcaster_node::{
-    peerd::{self, Opts},
-    rpc::request::Token,
-};
+use farcaster_node::peerd::{self, Opts};
 use farcaster_node::{Config, LogStyle};
 use internet2::{session, FramingProtocol, NodeAddr, RemoteNodeAddr, RemoteSocketAddr};
 use microservices::peer::PeerConnection;
@@ -182,7 +179,6 @@ fn main() {
 
     let local_node = opts.peer_key_opts.local_node();
     let local_id = local_node.node_id();
-    let wallet_token = Token(opts.wallet_token.wallet_token.clone());
     info!(
         "{}: {}",
         "Local node id".bright_green_bold(),
@@ -268,7 +264,6 @@ fn main() {
         local_socket,
         remote_socket,
         connect,
-        wallet_token,
     )
     .expect("Error running peerd runtime");
 

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -175,7 +175,7 @@ impl Exec for Command {
             } => {
                 // println!("{:#?}", &public_offer);
                 let PublicOffer {
-                    version,
+                    version: _,
                     offer,
                     node_id,
                     peer_address,
@@ -212,7 +212,6 @@ impl Exec for Command {
                 runtime.request(ServiceId::Farcasterd, Request::ReadProgress(swapid))?;
                 runtime.report_progress()?;
             }
-            _ => unimplemented!(),
         }
         Ok(())
     }
@@ -225,7 +224,7 @@ fn take_offer() -> bool {
     match std::str::from_utf8(&input[..]) {
         Ok("y") | Ok("Y") => true,
         Ok("n") | Ok("N") => {
-            println!("{}", "Rejecting offer");
+            println!("Rejecting offer");
             false
         }
         _ => take_offer(),

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -66,10 +66,11 @@ impl Exec for Command {
                     Request::NodeInfo(info) => println!("{}", info),
                     Request::PeerInfo(info) => println!("{}", info),
                     Request::SwapInfo(info) => println!("{}", info),
-                    _ => Err(Error::Other(format!(
-                        "{}",
-                        "Server returned unrecognizable response"
-                    )))?,
+                    _ => {
+                        return Err(Error::Other(
+                            "Server returned unrecognizable response".to_string(),
+                        ))
+                    }
                 }
             }
 
@@ -96,7 +97,7 @@ impl Exec for Command {
             Command::Connect { peer: node_locator } => {
                 let peer = node_locator
                     .to_node_addr(LIGHTNING_P2P_DEFAULT_PORT)
-                    .ok_or_else(|| internet2::presentation::Error::InvalidEndpoint)?;
+                    .ok_or(internet2::presentation::Error::InvalidEndpoint)?;
 
                 runtime.request(ServiceId::Farcasterd, Request::ConnectPeer(peer))?;
                 runtime.report_progress()?;
@@ -105,7 +106,7 @@ impl Exec for Command {
             Command::Ping { peer } => {
                 let node_addr = peer
                     .to_node_addr(LIGHTNING_P2P_DEFAULT_PORT)
-                    .ok_or_else(|| internet2::presentation::Error::InvalidEndpoint)?;
+                    .ok_or(internet2::presentation::Error::InvalidEndpoint)?;
 
                 runtime.request(ServiceId::Peer(node_addr), Request::PingPeer)?;
             }

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -51,7 +51,7 @@ pub struct Opts {
 
 impl Opts {
     pub fn process(&mut self) {
-        self.shared.process()
+        self.shared.process();
     }
 }
 /// Command-line commands:

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -16,7 +16,6 @@ use bitcoin::Address;
 use clap::{AppSettings, Clap};
 use monero::Address as XmrAddress;
 use std::net::IpAddr;
-use std::path::PathBuf;
 use std::str::FromStr;
 
 use internet2::{FramingProtocol, PartialNodeAddr};

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -229,7 +229,7 @@ impl FromStr for AmountOfAsset {
                 .next()
                 .ok_or(AmountOfAssetParseError::NeedsValuePair)?;
             if split.count() > 0 {
-                Err(AmountOfAssetParseError::NeedsValuePair)?
+                return Err(AmountOfAssetParseError::NeedsValuePair);
             }
         } else if s.contains(' ') {
             let mut split = s.split(' ');
@@ -240,7 +240,7 @@ impl FromStr for AmountOfAsset {
                 .next()
                 .ok_or(AmountOfAssetParseError::NeedsValuePair)?;
             if split.count() > 0 {
-                Err(AmountOfAssetParseError::NeedsValuePair)?
+                return Err(AmountOfAssetParseError::NeedsValuePair);
             }
         } else {
             return Err(AmountOfAssetParseError::NeedsValuePair);

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -398,7 +398,7 @@ impl Runtime {
                         self.listens
                             .clone()
                             .into_iter()
-                            .find_map(|x| Some(x))
+                            .find_map(Some)
                             .expect("exactly 1 listener checked on pattern match"),
                     ),
                     (TradeRole::Taker, _) if public_offer.node_id == maker_node_id => (

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -824,7 +824,7 @@ impl Runtime {
     }
 
     fn listen(&mut self, addr: &RemoteSocketAddr, sk: SecretKey) -> Result<String, Error> {
-        if let &RemoteSocketAddr::Ftcp(inet) = addr {
+        if let RemoteSocketAddr::Ftcp(inet) = *addr {
             let socket_addr = SocketAddr::try_from(inet)?;
             let ip = socket_addr.ip();
             let port = socket_addr.port();

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -291,7 +291,7 @@ impl Runtime {
                         }
                     }
                     ServiceId::Swap(swap_id) => {
-                        if self.running_swaps.insert(swap_id.clone()) {
+                        if self.running_swaps.insert(*swap_id) {
                             info!(
                                 "Swap {} is registered; total {} \
                                  swaps are known",
@@ -309,7 +309,7 @@ impl Runtime {
                     ServiceId::Syncer(coin, network) => {
                         // TODO: check if correct network
                         self.syncers
-                            .insert((coin.clone(), network.clone()), source.clone());
+                            .insert((coin.clone(), *network), source.clone());
                     }
                     _ => {
                         // Ignoring the rest of daemon/client types
@@ -329,7 +329,7 @@ impl Runtime {
                         Request::Progress(format!("Swap daemon {} operational", source)),
                     ));
                     // when online, Syncers say Hello, then they get registered to self.syncers
-                    self.syncers_up(Coin::Bitcoin, Coin::Monero, network.clone())?;
+                    self.syncers_up(Coin::Bitcoin, Coin::Monero, *network)?;
                     // FIXME msgs should go to walletd?
                     senders.send_to(
                         ServiceBus::Ctl,
@@ -355,7 +355,7 @@ impl Runtime {
                         Params::Alice(_) => {}
                         Params::Bob(_) => {}
                     }
-                    self.syncers_up(Coin::Bitcoin, Coin::Monero, network.clone())?;
+                    self.syncers_up(Coin::Bitcoin, Coin::Monero, *network)?;
                     // FIXME msgs should go to walletd?
                     senders.send_to(
                         ServiceBus::Ctl,
@@ -473,7 +473,7 @@ impl Runtime {
                     ServiceId::Farcasterd, // source
                     source,                // destination
                     Request::NodeInfo(NodeInfo {
-                        node_ids: self.node_ids().clone(),
+                        node_ids: self.node_ids(),
                         listens: self.listens.iter().cloned().collect(),
                         uptime: SystemTime::now()
                             .duration_since(self.started)
@@ -639,7 +639,7 @@ impl Runtime {
                     return Ok(());
                 }
 
-                let public_offer = offer.clone().to_public_v1(node_ids[0], public_addr.into());
+                let public_offer = offer.to_public_v1(node_ids[0], public_addr.into());
                 let pub_offer_id = public_offer.id();
                 let hex_public_offer = public_offer.to_hex();
                 if self.public_offers.insert(public_offer) {
@@ -696,7 +696,7 @@ impl Runtime {
                         offer: _,
                         node_id,      // bitcoin::Pubkey
                         peer_address, // InetSocketAddr
-                    } = public_offer.clone();
+                    } = public_offer;
 
                     let daemon_service = internet2::RemoteNodeAddr {
                         node_id,                                           // checked above
@@ -860,7 +860,7 @@ impl Runtime {
         sk: SecretKey,
     ) -> Result<String, Error> {
         debug!("Instantiating peerd...");
-        if self.connections.contains(&node_addr) {
+        if self.connections.contains(node_addr) {
             return Err(Error::Other(format!(
                 "Already connected to peer {}",
                 node_addr

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -422,7 +422,7 @@ impl Runtime {
                     };
                     let peer = daemon_service
                         .to_node_addr(internet2::LIGHTNING_P2P_DEFAULT_PORT)
-                        .ok_or_else(|| internet2::presentation::Error::InvalidEndpoint)?
+                        .ok_or(internet2::presentation::Error::InvalidEndpoint)?
                         .into();
 
                     self.consumed_offers.insert(public_offer.id());
@@ -886,7 +886,7 @@ impl Runtime {
         // status is Some if peerd returns because it crashed
         let (child, status) = child.and_then(|mut c| c.try_wait().map(|s| (c, s)))?;
 
-        if let Some(_) = status {
+        if status.is_some() {
             return Err(Error::Peer(internet2::presentation::Error::InvalidEndpoint));
         }
 

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -924,6 +924,7 @@ impl Runtime {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn launch_swapd(
     runtime: &mut Runtime,
     peerd: ServiceId,

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -876,7 +876,7 @@ impl Runtime {
                 "--peer-secret-key",
                 &format!("{:x}", sk),
                 "--wallet-token",
-                &format!("{}", self.wallet_token.clone().to_string()),
+                &format!("{}", self.wallet_token.clone()),
             ],
         );
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -22,29 +22,29 @@ use lnpbp::chain::Chain;
 use microservices::shell::LogLevel;
 
 #[cfg(any(target_os = "linux"))]
-pub const FARCASTER_NODE_DATA_DIR: &'static str = "~/.farcaster_node";
+pub const FARCASTER_NODE_DATA_DIR: &str = "~/.farcaster_node";
 #[cfg(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))]
-pub const FARCASTER_NODE_DATA_DIR: &'static str = "~/.farcaster_node";
+pub const FARCASTER_NODE_DATA_DIR: &str = "~/.farcaster_node";
 #[cfg(target_os = "macos")]
-pub const FARCASTER_NODE_DATA_DIR: &'static str = "~/Library/Application Support/FARCASTER Node";
+pub const FARCASTER_NODE_DATA_DIR: &str = "~/Library/Application Support/FARCASTER Node";
 #[cfg(target_os = "windows")]
-pub const FARCASTER_NODE_DATA_DIR: &'static str = "~\\AppData\\Local\\FARCASTER Node";
+pub const FARCASTER_NODE_DATA_DIR: &str = "~\\AppData\\Local\\FARCASTER Node";
 #[cfg(target_os = "ios")]
-pub const FARCASTER_NODE_DATA_DIR: &'static str = "~/Documents";
+pub const FARCASTER_NODE_DATA_DIR: &str = "~/Documents";
 #[cfg(target_os = "android")]
-pub const FARCASTER_NODE_DATA_DIR: &'static str = ".";
+pub const FARCASTER_NODE_DATA_DIR: &str = ".";
 
-pub const FARCASTER_NODE_MSG_SOCKET_NAME: &'static str = "lnpz:{data_dir}/msg.rpc?api=esb";
-pub const FARCASTER_NODE_CTL_SOCKET_NAME: &'static str = "lnpz:{data_dir}/ctl.rpc?api=esb";
+pub const FARCASTER_NODE_MSG_SOCKET_NAME: &str = "lnpz:{data_dir}/msg.rpc?api=esb";
+pub const FARCASTER_NODE_CTL_SOCKET_NAME: &str = "lnpz:{data_dir}/ctl.rpc?api=esb";
 
-pub const FARCASTER_NODE_CONFIG: &'static str = "{data_dir}/farcaster.toml";
+pub const FARCASTER_NODE_CONFIG: &str = "{data_dir}/farcaster.toml";
 
-pub const FARCASTER_NODE_TOR_PROXY: &'static str = "127.0.0.1:9050";
-pub const FARCASTER_NODE_KEY_FILE: &'static str = "{data_dir}/key.dat";
+pub const FARCASTER_NODE_TOR_PROXY: &str = "127.0.0.1:9050";
+pub const FARCASTER_NODE_KEY_FILE: &str = "{data_dir}/key.dat";
 
-pub const ELECTRUM_SERVER: &'static str = "tcp://localhost:50001";
-pub const MONERO_DAEMON: &'static str = "http://node.monerooutreach.org:18081";
-pub const MONERO_RPC_WALLET: &'static str = "http://localhost:18083";
+pub const ELECTRUM_SERVER: &str = "tcp://localhost:50001";
+pub const MONERO_DAEMON: &str = "http://node.monerooutreach.org:18081";
+pub const MONERO_RPC_WALLET: &str = "http://localhost:18083";
 
 /// Shared options used by different binaries
 #[derive(Clap, Clone, PartialEq, Eq, Debug)]

--- a/src/peerd/opts.rs
+++ b/src/peerd/opts.rs
@@ -140,7 +140,6 @@ impl PeerKeyOpts {
         let secret_key = SecretKey::from_str(&self.peer_secret_key).expect("peer secret key");
         let ephemeral_secret_key = SecretKey::new(&mut rng);
         let local_node = LocalNode::from_keys(secret_key, ephemeral_secret_key);
-        let node_secrets = PeerSecrets { local_node };
-        node_secrets
+        PeerSecrets { local_node }
     }
 }

--- a/src/peerd/opts.rs
+++ b/src/peerd/opts.rs
@@ -13,14 +13,10 @@
 // If not, see <https://opensource.org/licenses/MIT>.
 
 use clap::{AppSettings, ArgGroup, Clap, ValueHint};
-use std::path::PathBuf;
-use std::{fs, io::Read};
 use std::{io, net::IpAddr};
 
 use internet2::{FramingProtocol, LocalNode, RemoteNodeAddr};
 use strict_encoding::{StrictDecode, StrictEncode};
-
-use crate::opts::FARCASTER_NODE_KEY_FILE;
 
 /// Lightning peer network connection daemon; part of LNP Node
 ///

--- a/src/peerd/opts.rs
+++ b/src/peerd/opts.rs
@@ -103,7 +103,7 @@ pub struct PeerKeyOpts {
     pub peer_secret_key: String,
 }
 
-/// WalletToken configuration
+/// ``WalletToken`` configuration
 #[derive(Clap, Clone, PartialEq, Eq, Debug)]
 pub struct TokenString {
     #[clap(long)]

--- a/src/peerd/runtime.rs
+++ b/src/peerd/runtime.rs
@@ -466,10 +466,7 @@ impl Runtime {
         }
         let mut rng = rand::thread_rng();
         let len: u16 = rng.gen_range(4, 32);
-        let mut noise = vec![0u8; len as usize];
-        for i in 0..noise.len() {
-            noise[i] = rng.gen();
-        }
+        let noise = vec![0u8; len as usize].iter().map(|_| rng.gen()).collect();
         let pong_size = rng.gen_range(4, 32);
         self.messages_sent += 1;
         self.sender.send_message(Msg::Ping(message::Ping {
@@ -482,11 +479,11 @@ impl Runtime {
 
     fn pong(&mut self, pong_size: u16) -> Result<(), Error> {
         trace!("Replying with pong to the remote peer");
-        let mut noise = vec![0u8; pong_size as usize];
         let mut rng = rand::thread_rng();
-        for i in 0..noise.len() {
-            noise[i] = rng.gen();
-        }
+        let noise = vec![0u8; pong_size as usize]
+            .iter()
+            .map(|_| rng.gen())
+            .collect();
         self.messages_sent += 1;
         self.sender.send_message(Msg::Pong(noise))?;
         Ok(())

--- a/src/peerd/runtime.rs
+++ b/src/peerd/runtime.rs
@@ -119,7 +119,7 @@ impl esb::Handler<ServiceBus> for BridgeHandler {
 
     fn handle_err(&mut self, err: esb::Error) -> Result<(), esb::Error> {
         // We simply propagate the error since it's already being reported
-        Err(err)?
+        Err(err)
     }
 }
 
@@ -316,11 +316,11 @@ impl Runtime {
                     remote_socket: vec![self.remote_socket],
                     uptime: SystemTime::now()
                         .duration_since(self.started)
-                        .unwrap_or(Duration::from_secs(0)),
+                        .unwrap_or_else(|_| Duration::from_secs(0)),
                     since: self
                         .started
                         .duration_since(SystemTime::UNIX_EPOCH)
-                        .unwrap_or(Duration::from_secs(0))
+                        .unwrap_or_else(|_| Duration::from_secs(0))
                         .as_secs(),
                     messages_sent: self.messages_sent,
                     messages_received: self.messages_received,
@@ -453,7 +453,7 @@ impl Runtime {
             other => {
                 error!("Request is not supported by the BRIDGE interface");
                 dbg!(other);
-                return Err(Error::NotSupported(ServiceBus::Bridge, request.get_type()))?;
+                return Err(Error::NotSupported(ServiceBus::Bridge, request.get_type()));
             }
         }
         Ok(())

--- a/src/peerd/runtime.rs
+++ b/src/peerd/runtime.rs
@@ -40,7 +40,6 @@ pub fn run(
     local_socket: Option<InetSocketAddr>,
     remote_socket: InetSocketAddr,
     connect: bool,
-    wallet_token: Token,
 ) -> Result<(), Error> {
     debug!("Splitting connection into receiver and sender parts");
     let (receiver, sender) = connection.split();
@@ -88,7 +87,6 @@ pub fn run(
         messages_sent: 0,
         messages_received: 0,
         awaited_pong: None,
-        wallet_token,
     };
     let mut service = Service::service(config, runtime)?;
     service.add_loopback(rx)?;
@@ -109,9 +107,9 @@ impl esb::Handler<ServiceBus> for BridgeHandler {
 
     fn handle(
         &mut self,
-        senders: &mut esb::SenderList<ServiceBus, ServiceId>,
-        bus: ServiceBus,
-        addr: ServiceId,
+        _senders: &mut esb::SenderList<ServiceBus, ServiceId>,
+        _bus: ServiceBus,
+        _addr: ServiceId,
         request: Request,
     ) -> Result<(), Error> {
         // Bridge does not receive replies for now
@@ -194,7 +192,6 @@ pub struct Runtime {
     messages_sent: usize,
     messages_received: usize,
     awaited_pong: Option<u16>,
-    wallet_token: Token,
 }
 
 impl CtlServer for Runtime {}
@@ -258,7 +255,7 @@ impl Runtime {
     fn handle_rpc_msg(
         &mut self,
         _senders: &mut esb::SenderList<ServiceBus, ServiceId>,
-        source: ServiceId,
+        _source: ServiceId,
         request: Request,
     ) -> Result<(), Error> {
         // match &request {

--- a/src/peerd/runtime.rs
+++ b/src/peerd/runtime.rs
@@ -305,7 +305,7 @@ impl Runtime {
                     source, channel_id
                 );
                 self.routing.remove(&source);
-                self.routing.insert(channel_id.clone().into(), source);
+                self.routing.insert(channel_id.into(), source);
             }
 
             Request::GetInfo => {

--- a/src/peerd/runtime.rs
+++ b/src/peerd/runtime.rs
@@ -31,6 +31,8 @@ use crate::rpc::{
     Request, ServiceBus,
 };
 use crate::{Config, CtlServer, Error, LogStyle, Service, ServiceId};
+
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     config: Config,
     connection: PeerConnection,

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -92,14 +92,15 @@ impl Client {
 
     pub fn report_failure(&mut self) -> Result<Request, Error> {
         match self.response()? {
-            Request::Failure(fail) => {
-                // // Errors reported on swap-cli binary
-                // eprintln!(
-                //     "{}: {}",
-                //     "Request failure".err(),
-                //     fail.err_details()
-                // );
-                Err(Error::from(fail))?
+            Request::Failure(fail) =>
+            // // Errors reported on swap-cli binary
+            // eprintln!(
+            //     "{}: {}",
+            //     "Request failure".err(),
+            //     fail.err_details()
+            // );
+            {
+                Err(Error::from(fail))
             }
             resp => Ok(resp),
         }
@@ -131,7 +132,7 @@ impl Client {
                 }
                 other => {
                     eprintln!("{}: {}", "Unexpected report".err(), other.err_details());
-                    Err(Error::Other(s!("Unexpected server response")))?
+                    return Err(Error::Other(s!("Unexpected server response")));
                 }
             }
         }
@@ -165,6 +166,6 @@ impl esb::Handler<ServiceBus> for Handler {
 
     fn handle_err(&mut self, err: esb::Error) -> Result<(), esb::Error> {
         // We simply propagate the error since it's already being reported
-        Err(err)?
+        Err(err)
     }
 }

--- a/src/rpc/messages.rs
+++ b/src/rpc/messages.rs
@@ -109,25 +109,25 @@ pub struct Features {
 /// TODO: Implement proper strict encoding for Features
 
 impl StrictEncode for Features {
-    fn strict_encode<E: io::Write>(&self, e: E) -> Result<usize, strict_encoding::Error> {
+    fn strict_encode<E: io::Write>(&self, _e: E) -> Result<usize, strict_encoding::Error> {
         Ok(0)
     }
 }
 
 impl StrictDecode for Features {
-    fn strict_decode<D: io::Read>(d: D) -> Result<Self, strict_encoding::Error> {
+    fn strict_decode<D: io::Read>(_d: D) -> Result<Self, strict_encoding::Error> {
         Ok(none!())
     }
 }
 
 impl LightningEncode for Features {
-    fn lightning_encode<E: io::Write>(&self, e: E) -> Result<usize, lightning_encoding::Error> {
+    fn lightning_encode<E: io::Write>(&self, _e: E) -> Result<usize, lightning_encoding::Error> {
         Ok(0)
     }
 }
 
 impl LightningDecode for Features {
-    fn lightning_decode<D: io::Read>(d: D) -> Result<Self, lightning_encoding::Error> {
+    fn lightning_decode<D: io::Read>(_d: D) -> Result<Self, lightning_encoding::Error> {
         Ok(none!())
     }
 }

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -12,6 +12,8 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
+#![allow(clippy::clone_on_copy)]
+
 use crate::syncerd::{
     types::{Event, Task},
     SweepXmrAddress,

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -757,9 +757,9 @@ impl IntoSuccessOrFailure for Result<(), crate::Error> {
     }
 }
 
-impl Into<Reveal> for (SwapId, Params) {
-    fn into(self) -> Reveal {
-        match self {
+impl From<(SwapId, Params)> for Reveal {
+    fn from(tuple: (SwapId, Params)) -> Self {
+        match tuple {
             (swap_id, Params::Alice(params)) => Reveal::AliceParameters((swap_id, params).into()),
             (swap_id, Params::Bob(params)) => Reveal::BobParameters((swap_id, params).into()),
         }

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -702,7 +702,7 @@ impl Display for OptionDetails {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self.as_inner() {
             None => Ok(()),
-            Some(msg) => f.write_str(&msg),
+            Some(msg) => f.write_str(msg),
         }
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -68,15 +68,14 @@ impl FromStr for ClientName {
     type Err = hex::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut me = Self::default();
         if s.len() > 32 {
-            let mut me = Self::default();
             me.0.copy_from_slice(&s.as_bytes()[0..32]);
-            Ok(me)
         } else {
             let mut me = Self::default();
             me.0[0..s.len()].copy_from_slice(s.as_bytes());
-            Ok(me)
         }
+        Ok(me)
     }
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -195,6 +195,7 @@ where
         Self::with(config, runtime, true)
     }
 
+    #[allow(clippy::self_named_constructors)]
     pub fn service(config: Config, runtime: Runtime) -> Result<Self, esb::Error> {
         Self::with(config, runtime, false)
     }

--- a/src/swapd/opts.rs
+++ b/src/swapd/opts.rs
@@ -12,12 +12,10 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-use clap::{AppSettings, Clap, ValueHint};
+use clap::{AppSettings, Clap};
 
-use bitcoin::hashes::hex::FromHex;
 use farcaster_core::swap::SwapId;
 use farcaster_core::{negotiation::PublicOffer, role::TradeRole, swap::btcxmr::BtcXmr};
-use internet2::PartialNodeAddr;
 use std::str::FromStr;
 
 /// Lightning peer network channel daemon; part of LNP Node

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -647,7 +647,7 @@ impl Runtime {
         if self.peer_service != source {
             return Err(Error::Farcaster(format!(
                 "{}: expected {}, found {}",
-                "Incorrect peer connection".to_string(),
+                "Incorrect peer connection",
                 self.peer_service,
                 source
             )));
@@ -656,12 +656,12 @@ impl Runtime {
         match &request {
             Request::Protocol(msg) => {
                 if msg.swap_id() != self.swap_id() {
-                    Err(Error::Farcaster(format!(
+                    return Err(Error::Farcaster(format!(
                         "{}: expected {}, found {}",
-                        "Incorrect swap_id ".to_string(),
+                        "Incorrect swap_id ",
                         self.swap_id(),
                         msg.swap_id(),
-                    )))?
+                    )));
                 }
                 match &msg {
                     // we are taker and the maker committed, now we reveal after checking

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -870,7 +870,7 @@ impl Runtime {
                                 _ => {
                                     let err_msg = "expected Some(Commit::Alice(commit))";
                                     error!("{}", err_msg);
-                                    Err(Error::Farcaster(err_msg.to_string()))?
+                                    return Err(Error::Farcaster(err_msg.to_string()));
                                 }
                             },
                             Reveal::BobParameters(reveal) => match &remote_commit {
@@ -881,7 +881,7 @@ impl Runtime {
                                 _ => {
                                     let err_msg = "expected Some(Commit::Bob(commit))";
                                     error!("{}", err_msg);
-                                    Err(Error::Farcaster(err_msg.to_string()))?
+                                    return Err(Error::Farcaster(err_msg.to_string()));
                                 }
                             },
                             Reveal::Proof(_) => {
@@ -1044,7 +1044,9 @@ impl Runtime {
                     }
 
                     // bob and alice
-                    Msg::Abort(_) => Err(Error::Farcaster("Abort not yet supported".to_string()))?,
+                    Msg::Abort(_) => {
+                        return Err(Error::Farcaster("Abort not yet supported".to_string()))
+                    }
                     Msg::Ping(_) | Msg::Pong(_) | Msg::PingPeer => {
                         unreachable!("ping/pong must remain in peerd, and unreachable in swapd")
                     }
@@ -1079,10 +1081,10 @@ impl Runtime {
                 | ServiceId::Wallet
             ) => {}
             (Request::GetInfo, ServiceId::Client(_)) => {}
-            _ => Err(Error::Farcaster(
+            _ => return Err(Error::Farcaster(
                 "Permission Error: only Farcasterd, Wallet, Client and Syncer can can control swapd"
                     .to_string(),
-            ))?,
+            )),
         };
 
         match request {
@@ -1886,11 +1888,11 @@ impl Runtime {
                     maker_peer: self.maker_peer.clone().map(|p| vec![p]).unwrap_or_default(),
                     uptime: SystemTime::now()
                         .duration_since(self.started)
-                        .unwrap_or(Duration::from_secs(0)),
+                        .unwrap_or_else(|_| Duration::from_secs(0)),
                     since: self
                         .started
                         .duration_since(SystemTime::UNIX_EPOCH)
-                        .unwrap_or(Duration::from_secs(0))
+                        .unwrap_or_else(|_| Duration::from_secs(0))
                         .as_secs(),
                     // params: self.params, // FIXME
                     // serde::Serialize/Deserialize missing

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -551,8 +551,7 @@ impl SyncerState {
         self.tasks
             .watched_addrs
             .values()
-            .find(|&&x| x == TxLabel::AccLock)
-            .is_some()
+            .any(|&x| x == TxLabel::AccLock)
     }
     fn handle_tx_confs(&self, id: &u32, confirmations: &Option<u32>) {
         if let Some(txlabel) = self.tasks.watched_txs.get(id) {
@@ -647,9 +646,7 @@ impl Runtime {
         if self.peer_service != source {
             return Err(Error::Farcaster(format!(
                 "{}: expected {}, found {}",
-                "Incorrect peer connection",
-                self.peer_service,
-                source
+                "Incorrect peer connection", self.peer_service, source
             )));
         }
         let msg_bus = ServiceBus::Msg;

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -2003,22 +2003,20 @@ fn aggregate_xmr_spend_view(
     alice_params: &AliceParameters<BtcXmr>,
     bob_params: &BobParameters<BtcXmr>,
 ) -> (monero::PublicKey, monero::PrivateKey) {
-    let alice_view = alice_params
+    let alice_view = *alice_params
         .accordant_shared_keys
         .clone()
         .into_iter()
         .find(|vk| vk.tag() == &SharedKeyId::new(SHARED_VIEW_KEY_ID))
-        .unwrap()
-        .elem()
-        .clone();
-    let bob_view = bob_params
+        .expect("accordant shared keys should always have a view key")
+        .elem();
+    let bob_view = *bob_params
         .accordant_shared_keys
         .clone()
         .into_iter()
         .find(|vk| vk.tag() == &SharedKeyId::new(SHARED_VIEW_KEY_ID))
-        .unwrap()
-        .elem()
-        .clone();
+        .expect("accordant shared keys should always have a view key")
+        .elem();
     (alice_params.spend + bob_params.spend, alice_view + bob_view)
 }
 

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -84,7 +84,7 @@ use request::{Commit, InitSwap, Params, Reveal, TakeCommit, Tx};
 pub fn run(
     config: Config,
     swap_id: SwapId,
-    chain: Chain,
+    _chain: Chain,
     public_offer: PublicOffer<BtcXmr>,
     local_trade_role: TradeRole,
 ) -> Result<(), Error> {
@@ -193,7 +193,7 @@ impl TemporalSafety {
     /// check if temporal params are in correct order
     fn valid_params(&self) -> Result<(), Error> {
         let btc_finality = self.btc_finality_thr;
-        let xmr_finality = self.xmr_finality_thr;
+        // let xmr_finality = self.xmr_finality_thr;
         let cancel = self.cancel_timelock;
         let punish = self.punish_timelock;
         let race = self.race_thr;
@@ -493,7 +493,7 @@ impl SyncerState {
         &mut self,
         spend: monero::PublicKey,
         view: monero::PrivateKey,
-        swap_role: SwapRole,
+        _swap_role: SwapRole,
         tx_label: TxLabel,
     ) -> Task {
         info!("XMR view key: {}", view);
@@ -936,13 +936,11 @@ impl Runtime {
                         match &self.state {
                             State::Alice(AliceState::CommitA(CommitC {
                                 trade_role: TradeRole::Maker,
-                                local_params,
                                 ..
                             }))
                             | State::Bob(BobState::CommitB(
                                 CommitC {
                                     trade_role: TradeRole::Maker,
-                                    local_params,
                                     ..
                                 },
                                 _,
@@ -983,7 +981,7 @@ impl Runtime {
                         lock,
                         cancel,
                         refund,
-                        cancel_sig,
+                        cancel_sig: _,
                     }) => {
                         if swap_id != &self.swap_id() {
                             error!("Swapd not responsible for swap {}", swap_id);
@@ -1087,7 +1085,6 @@ impl Runtime {
             ))?,
         };
 
-        let ctl_bus = ServiceBus::Ctl;
         match request {
             Request::SweepXmrAddress(SweepXmrAddress {
                 view_key,
@@ -1143,7 +1140,7 @@ impl Runtime {
                             (State::Bob(BobState::CommitB(
                                 CommitC {
                                     trade_role: local_trade_role,
-                                    local_params: local_params,
+                                    local_params,
                                     local_commit: local_commit.clone(),
                                     remote_commit: None,
                                 },
@@ -1156,7 +1153,7 @@ impl Runtime {
                         Ok((
                             (State::Alice(AliceState::CommitA(CommitC {
                                 trade_role: local_trade_role,
-                                local_params: local_params,
+                                local_params,
                                 local_commit: local_commit.clone(),
                                 remote_commit: None,
                             }))),
@@ -1370,8 +1367,8 @@ impl Runtime {
                         id,
                         hash,
                         amount,
-                        block,
-                        tx,
+                        block: _,
+                        tx: _,
                     }) if self.state.swap_role() == SwapRole::Bob => {
                         if amount < &self.syncer_state.monero_amount.as_pico() {
                             error!(
@@ -1391,8 +1388,8 @@ impl Runtime {
                         }
                     }
                     Event::TransactionConfirmations(TransactionConfirmations {
-                        id,
-                        block,
+                        id: _,
+                        block: _,
                         confirmations: Some(confirmations),
                     }) if self.temporal_safety.final_tx(*confirmations, Coin::Monero)
                         && self.state.swap_role() == SwapRole::Bob
@@ -1431,7 +1428,7 @@ impl Runtime {
                     }
                     Event::TransactionConfirmations(TransactionConfirmations {
                         id,
-                        block,
+                        block: _,
                         confirmations,
                     }) if self.syncer_state.tasks.watched_txs.contains_key(id) => {
                         self.syncer_state.handle_tx_confs(id, confirmations);
@@ -1451,8 +1448,8 @@ impl Runtime {
                     Event::AddressTransaction(AddressTransaction {
                         id,
                         hash,
-                        amount,
-                        block,
+                        amount: _,
+                        block: _,
                         tx,
                     }) => {
                         let tx = bitcoin::Transaction::deserialize(tx)?;
@@ -1511,7 +1508,7 @@ impl Runtime {
                     }
                     Event::TransactionConfirmations(TransactionConfirmations {
                         id,
-                        block,
+                        block: _,
                         confirmations: Some(confirmations),
                     }) if self.temporal_safety.final_tx(*confirmations, Coin::Bitcoin) => {
                         self.syncer_state.handle_tx_confs(id, &Some(*confirmations));
@@ -1682,7 +1679,7 @@ impl Runtime {
                     }
                     Event::TransactionConfirmations(TransactionConfirmations {
                         id,
-                        block,
+                        block: _,
                         confirmations,
                     }) => {
                         self.syncer_state.handle_tx_confs(id, confirmations);
@@ -1707,11 +1704,11 @@ impl Runtime {
                     _ => Err(Error::Farcaster(s!("Wrong state: must be RevealB"))),
                 }?;
                 let CoreArbitratingSetup {
-                    swap_id,
+                    swap_id: _,
                     lock,
                     cancel,
                     refund,
-                    cancel_sig,
+                    cancel_sig: _,
                 } = core_arb_setup.clone();
                 for (tx, tx_label) in [lock, cancel, refund].iter().zip([
                     TxLabel::Lock,

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -531,14 +531,11 @@ fn address_polling(
             };
 
             loop {
-                match rpc.ping() {
-                    Err(err) => {
-                        error!("error ping electrum client in address polling: {:?}", err);
-                        // break this loop and retry, since the electrum rpc client is probably
-                        // broken
-                        break;
-                    }
-                    _ => {}
+                if let Err(err) = rpc.ping() {
+                    error!("error ping electrum client in address polling: {:?}", err);
+                    // break this loop and retry, since the electrum rpc client is probably
+                    // broken
+                    break;
                 }
                 let state_guard = state.lock().await;
                 let addresses = state_guard.addresses.clone();
@@ -614,14 +611,11 @@ fn height_polling(
             drop(state_guard);
             // inner loop actually polls
             loop {
-                match rpc.ping() {
-                    Err(err) => {
-                        error!("error ping electrum client in height polling: {:?}", err);
-                        // break this loop and retry, since the electrum rpc client is probably
-                        // broken
-                        break;
-                    }
-                    _ => {}
+                if let Err(err) = rpc.ping() {
+                    error!("error ping electrum client in height polling: {:?}", err);
+                    // break this loop and retry, since the electrum rpc client is probably
+                    // broken
+                    break;
                 }
                 let mut blocks = match rpc.new_block_check() {
                     Ok(blks) => blks,

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -130,9 +130,10 @@ impl ElectrumRpc {
             self.client
                 .script_subscribe(&address_addendum.script_pubkey)?
         };
-        if let Some(_) = self
+        if self
             .addresses
             .insert(address_addendum.clone(), script_status)
+            .is_some()
         {
         } else {
             info!(
@@ -202,7 +203,10 @@ impl ElectrumRpc {
 
                 while let Ok(Some(script_status)) = self.client.script_pop(script_pubkey) {
                     if Some(script_status) != previous_status {
-                        if let Some(_) = self.addresses.insert(address.clone(), Some(script_status))
+                        if self
+                            .addresses
+                            .insert(address.clone(), Some(script_status))
+                            .is_some()
                         {
                             info!(
                                 "updated address {:?} with script_status {:?}",

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -78,7 +78,7 @@ impl From<&ElectrumRpc> for Vec<Script> {
     fn from(x: &ElectrumRpc) -> Self {
         x.addresses
             .keys()
-            .filter_map(|addr| Some(addr.script_pubkey.clone()))
+            .map(|addr| addr.script_pubkey.clone())
             .collect()
     }
 }

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -96,7 +96,7 @@ pub struct AddressNotif {
 }
 
 impl ElectrumRpc {
-    fn new(electrum_server: &String, polling: bool) -> Result<Self, electrum_client::Error> {
+    fn new(electrum_server: &str, polling: bool) -> Result<Self, electrum_client::Error> {
         let client = Client::new(electrum_server)?;
         let header = client.block_headers_subscribe()?;
         info!("New ElectrumRpc at height {:?}", header.height);
@@ -132,7 +132,7 @@ impl ElectrumRpc {
         };
         if let Some(_) = self
             .addresses
-            .insert(address_addendum.clone(), script_status.clone())
+            .insert(address_addendum.clone(), script_status)
         {
         } else {
             info!(
@@ -200,11 +200,9 @@ impl ElectrumRpc {
                 // get pending notifications for this address/script_pubkey
                 let script_pubkey = &address.script_pubkey;
 
-                while let Ok(Some(script_status)) = self.client.script_pop(&script_pubkey) {
+                while let Ok(Some(script_status)) = self.client.script_pop(script_pubkey) {
                     if Some(script_status) != previous_status {
-                        if let Some(_) = self
-                            .addresses
-                            .insert(address.clone(), Some(script_status.clone()))
+                        if let Some(_) = self.addresses.insert(address.clone(), Some(script_status))
                         {
                             info!(
                                 "updated address {:?} with script_status {:?}",
@@ -730,7 +728,7 @@ impl Synclet for BitcoinSyncer {
     }
 }
 
-fn logging(txs: &Vec<AddressTx>, address: &BtcAddressAddendum) {
+fn logging(txs: &[AddressTx], address: &BtcAddressAddendum) {
     txs.iter().for_each(|tx| {
         trace!(
             "processing address {} notification txid {}",

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -669,6 +669,7 @@ fn transaction_polling(
     })
 }
 
+#[derive(Default)]
 pub struct BitcoinSyncer {}
 
 impl BitcoinSyncer {

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -415,11 +415,7 @@ fn address_polling(
                 // wallet
                 let mut address_transactions = None;
                 match rpc
-                    .check_address(
-                        address_addendum.clone(),
-                        network.clone(),
-                        Arc::clone(&wallet_mutex),
-                    )
+                    .check_address(address_addendum.clone(), network, Arc::clone(&wallet_mutex))
                     .await
                 {
                     Ok(addr_txs) => {
@@ -614,7 +610,7 @@ impl Synclet for MoneroSyncer {
         if !polling {
             error!("monero syncer only supports polling for now - switching to polling=true");
         }
-        let network = match chain.clone() {
+        let network = match chain {
             Chain::Mainnet | Chain::Regtest(_) => monero::Network::Mainnet,
             Chain::Testnet3 => monero::Network::Stagenet,
             Chain::Signet => monero::Network::Testnet,
@@ -654,7 +650,7 @@ impl Synclet for MoneroSyncer {
                 let address_handle = address_polling(
                     Arc::clone(&state),
                     syncer_servers.clone(),
-                    network.clone(),
+                    network,
                     Arc::clone(&wallet_mutex),
                 );
 

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -464,7 +464,7 @@ fn height_polling(
                 let mut transactions = state_guard.transactions.clone();
                 drop(state_guard);
 
-                if transactions.len() > 0 {
+                if !transactions.is_empty() {
                     let tx_ids: Vec<Vec<u8>> =
                         transactions.drain().map(|(_, tx)| tx.task.hash).collect();
                     let mut polled_transactions = vec![];
@@ -540,7 +540,7 @@ fn unseen_transaction_polling(
         loop {
             let state_guard = state.lock().await;
             let unseen_transactions = state_guard.unseen_transactions.clone();
-            if unseen_transactions.len() > 0 {
+            if !unseen_transactions.is_empty() {
                 let transactions = state_guard.transactions.clone();
                 let tx_ids: Vec<Vec<u8>> = unseen_transactions
                     .iter()

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -78,7 +78,7 @@ impl MoneroRpc {
     async fn get_block_hash(&mut self, height: u64) -> Result<Vec<u8>, Error> {
         let daemon_client = monero_rpc::RpcClient::new(self.node_rpc_url.clone());
         let daemon = daemon_client.daemon();
-        let selector = GetBlockHeaderSelector::Height(height.into());
+        let selector = GetBlockHeaderSelector::Height(height);
         let header = daemon.get_block_header(selector).await?;
         Ok(header.hash.0.to_vec())
     }
@@ -459,7 +459,7 @@ fn height_polling(
             if let Some(block_notif) = block_notif {
                 let mut state_guard = state.lock().await;
                 state_guard
-                    .change_height(block_notif.height, block_notif.block_hash.into())
+                    .change_height(block_notif.height, block_notif.block_hash)
                     .await;
                 let mut transactions = state_guard.transactions.clone();
                 drop(state_guard);

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -311,6 +311,7 @@ async fn sweep_address(
     Ok(None)
 }
 
+#[derive(Default)]
 pub struct MoneroSyncer {}
 
 impl MoneroSyncer {

--- a/src/syncerd/opts.rs
+++ b/src/syncerd/opts.rs
@@ -13,7 +13,6 @@
 // If not, see <https://opensource.org/licenses/MIT>.
 
 use clap::{AppSettings, Clap};
-use farcaster_core::blockchain;
 use std::str::FromStr;
 use strict_encoding::{StrictDecode, StrictEncode};
 

--- a/src/syncerd/runtime.rs
+++ b/src/syncerd/runtime.rs
@@ -210,7 +210,7 @@ impl Runtime {
                     source.clone(),
                     Request::TaskList(self.tasks.iter().cloned().collect()),
                 )?;
-                let resp = Request::Progress(format!("ListedTasks?",));
+                let resp = Request::Progress("ListedTasks?".to_string());
                 notify_cli = Some((Some(source), resp));
             }
 

--- a/src/syncerd/runtime.rs
+++ b/src/syncerd/runtime.rs
@@ -192,11 +192,11 @@ impl Runtime {
                     Request::SyncerInfo(SyncerInfo {
                         uptime: SystemTime::now()
                             .duration_since(self.started)
-                            .unwrap_or(Duration::from_secs(0)),
+                            .unwrap_or_else(|_| Duration::from_secs(0)),
                         since: self
                             .started
                             .duration_since(SystemTime::UNIX_EPOCH)
-                            .unwrap_or(Duration::from_secs(0))
+                            .unwrap_or_else(|_| Duration::from_secs(0))
                             .as_secs(),
                         tasks: self.tasks.iter().cloned().collect(),
                     }),

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -521,7 +521,7 @@ impl SyncerState {
 
     fn add_lifetime(&mut self, lifetime: u64, id: u32) -> Result<(), Error> {
         if lifetime < self.block_height {
-            Err(Error::Farcaster("task lifetime expired".to_string()))?;
+            return Err(Error::Farcaster("task lifetime expired".to_string()));
         }
 
         if let Some(lifetimes) = self.lifetimes.get_mut(&lifetime) {

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -81,21 +81,21 @@ impl SyncerState {
             .iter()
             .filter_map(|(id, address_transaction)| {
                 if address_transaction.task.id == task_id {
-                    Some(id.clone())
+                    Some(*id)
                 } else {
                     None
                 }
             })
             .collect();
         for id in ids.iter() {
-            if let Some(source_id) = self.tasks_sources.get(&id) {
+            if let Some(source_id) = self.tasks_sources.get(id) {
                 if *source_id == source {
                     self.remove_address(id);
                     send_event(
                         &self.tx_event,
                         &mut vec![(
                             Event::TaskAborted(TaskAborted {
-                                id: task_id.clone(),
+                                id: task_id,
                                 error: None,
                             }),
                             source.clone(),
@@ -113,21 +113,21 @@ impl SyncerState {
             .iter()
             .filter_map(|(id, watched_transaction)| {
                 if watched_transaction.task.id == task_id {
-                    Some(id.clone())
+                    Some(*id)
                 } else {
                     None
                 }
             })
             .collect();
         for id in ids.iter() {
-            if let Some(source_id) = self.tasks_sources.get(&id) {
+            if let Some(source_id) = self.tasks_sources.get(id) {
                 if *source_id == source {
                     self.remove_transaction(id);
                     send_event(
                         &self.tx_event,
                         &mut vec![(
                             Event::TaskAborted(TaskAborted {
-                                id: task_id.clone(),
+                                id: task_id,
                                 error: None,
                             }),
                             source.clone(),
@@ -145,21 +145,21 @@ impl SyncerState {
             .iter()
             .filter_map(|(id, watch_height)| {
                 if watch_height.id == task_id {
-                    Some(id.clone())
+                    Some(*id)
                 } else {
                     None
                 }
             })
             .collect();
         for id in ids.iter() {
-            if let Some(source_id) = self.tasks_sources.get(&id) {
+            if let Some(source_id) = self.tasks_sources.get(id) {
                 if *source_id == source {
                     self.remove_height(id);
                     send_event(
                         &self.tx_event,
                         &mut vec![(
                             Event::TaskAborted(TaskAborted {
-                                id: task_id.clone(),
+                                id: task_id,
                                 error: None,
                             }),
                             source.clone(),
@@ -177,21 +177,21 @@ impl SyncerState {
             .iter()
             .filter_map(|(id, sweep_address)| {
                 if sweep_address.id == task_id {
-                    Some(id.clone())
+                    Some(*id)
                 } else {
                     None
                 }
             })
             .collect();
         for id in ids.iter() {
-            if let Some(source_id) = self.tasks_sources.get(&id) {
+            if let Some(source_id) = self.tasks_sources.get(id) {
                 if *source_id == source {
                     self.remove_sweep_address(id);
                     send_event(
                         &self.tx_event,
                         &mut vec![(
                             Event::TaskAborted(TaskAborted {
-                                id: task_id.clone(),
+                                id: task_id,
                                 error: None,
                             }),
                             source.clone(),
@@ -207,7 +207,7 @@ impl SyncerState {
             &self.tx_event,
             &mut vec![(
                 Event::TaskAborted(TaskAborted {
-                    id: task_id.clone(),
+                    id: task_id,
                     error: Some(format!(
                         "abort failed, task with id {} from source {} not found",
                         task_id, source
@@ -291,8 +291,8 @@ impl SyncerState {
             error!("{}", e);
             return;
         }
-        self.sweep_addresses.insert(self.task_count, task.clone());
-        self.tasks_sources.insert(self.task_count, source.clone());
+        self.sweep_addresses.insert(self.task_count, task);
+        self.tasks_sources.insert(self.task_count, source);
     }
 
     pub async fn change_height(&mut self, height: u64, block: Vec<u8>) {
@@ -389,7 +389,7 @@ impl SyncerState {
                     (
                         id,
                         AddressTransactions {
-                            task: addr.task.clone(),
+                            task: addr.task,
                             known_txs: txs.clone(),
                         },
                     )
@@ -439,12 +439,12 @@ impl SyncerState {
                 .filter_map(|(id, watched_tx)| {
                     // return unchanged transactions
                     if tx_id != watched_tx.task.hash {
-                        return Some((id.clone(), watched_tx.clone()));
+                        return Some((*id, watched_tx.clone()));
                     }
                     if confirmations.is_some() {
-                        unseen_transactions.remove(&id);
+                        unseen_transactions.remove(id);
                     } else {
-                        unseen_transactions.insert(id.clone());
+                        unseen_transactions.insert(*id);
                     }
                     let transaction_confirmations = if confirmations
                         != watched_tx.transaction_confirmations.confirmations
@@ -457,7 +457,7 @@ impl SyncerState {
                         };
                         events.push((
                             Event::TransactionConfirmations(tx_confs.clone()),
-                            tasks_sources.get(&id).unwrap().clone(),
+                            tasks_sources.get(id).unwrap().clone(),
                         ));
                         tx_confs
                     } else {
@@ -468,7 +468,7 @@ impl SyncerState {
                         None
                     } else {
                         Some((
-                            id.clone(),
+                            *id,
                             WatchedTransaction {
                                 task: watched_tx.task.clone(),
                                 transaction_confirmations,
@@ -492,7 +492,7 @@ impl SyncerState {
                         txids,
                     }),
                     self.tasks_sources
-                        .get(&id)
+                        .get(id)
                         .cloned()
                         .expect("task source missing"),
                 )],

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -345,14 +345,14 @@ impl SyncerState {
             let changes_detected: bool = addresses
                 .iter()
                 .find_map(|(_, addr)| {
-                    let new_txs = txs.difference(&addr.known_txs).collect::<Vec<&_>>();
-                    if !new_txs.is_empty() {
+                    // let new_txs = txs.difference(&addr.known_txs).collect::<Vec<&_>>();
+                    if txs.difference(&addr.known_txs).next().is_some() {
                         Some(true)
                     } else {
                         None
                     }
                 })
-                .unwrap_or_else(|| false);
+                .unwrap_or(false);
 
             if !changes_detected {
                 trace!("no changes to process, skipping...");

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -982,5 +982,4 @@ async fn syncer_state_height() {
     assert_eq!(state.tasks_sources.len(), 0);
     assert_eq!(state.watch_height.len(), 0);
     assert!(event_rx.try_recv().is_err());
-    return;
 }

--- a/src/walletd/opts.rs
+++ b/src/walletd/opts.rs
@@ -103,11 +103,13 @@ pub struct NodeSecrets {
 impl NodeSecrets {
     pub fn new(key_file: String) -> Self {
         if PathBuf::from(key_file.clone()).exists() {
-            NodeSecrets::strict_decode(fs::File::open(key_file.clone()).expect(&format!(
-                "Unable to open key file {}; please check that the user \
+            NodeSecrets::strict_decode(fs::File::open(key_file.clone()).unwrap_or_else(|_| {
+                panic!(
+                    "Unable to open key file {}; please check that the user \
                     running the deamon has necessary permissions",
-                key_file
-            )))
+                    key_file
+                )
+            }))
             .expect("Unable to read node code file format")
         } else {
             let mut rng = thread_rng();
@@ -120,10 +122,12 @@ impl NodeSecrets {
                 wallet_counter: Counter(0),
             };
 
-            let key_file_handle = fs::File::create(&key_file).expect(&format!(
-                "Unable to create key file '{}'; please check that path exists",
-                key_file
-            ));
+            let key_file_handle = fs::File::create(&key_file).unwrap_or_else(|_| {
+                panic!(
+                    "Unable to create key file '{}'; please check that path exists",
+                    key_file
+                )
+            });
             node_secrets
                 .strict_encode(key_file_handle)
                 .expect("Unable to save generated node secrets");
@@ -155,10 +159,12 @@ impl NodeSecrets {
 
     pub fn increment_wallet_counter(&mut self) -> u32 {
         self.wallet_counter.increment();
-        let key_file_handle = fs::File::create(&self.key_file).expect(&format!(
-            "Unable to create key file '{}'; please check that path exists",
-            self.key_file
-        ));
+        let key_file_handle = fs::File::create(&self.key_file).unwrap_or_else(|_| {
+            panic!(
+                "Unable to create key file '{}'; please check that path exists",
+                self.key_file
+            )
+        });
         self.strict_encode(key_file_handle)
             .expect("Unable to save incremented wallet counter");
         self.wallet_counter.0

--- a/src/walletd/opts.rs
+++ b/src/walletd/opts.rs
@@ -106,7 +106,7 @@ impl NodeSecrets {
             NodeSecrets::strict_decode(fs::File::open(key_file.clone()).expect(&format!(
                 "Unable to open key file {}; please check that the user \
                     running the deamon has necessary permissions",
-                key_file.clone()
+                key_file
             )))
             .expect("Unable to read node code file format")
         } else {

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -483,7 +483,7 @@ impl Runtime {
                                                               * clone(), */
                                 );
 
-                                if !proof_verification.is_ok() {
+                                if proof_verification.is_err() {
                                     error!("DLEQ proof invalid");
                                     return Ok(());
                                 }
@@ -540,7 +540,7 @@ impl Runtime {
                                 remote_proof.proof.clone(),
                             );
 
-                            if !proof_verification.is_ok() {
+                            if proof_verification.is_err() {
                                 error!("DLEQ proof invalid");
                                 return Ok(());
                             }
@@ -1191,7 +1191,7 @@ impl Runtime {
             }
             Request::GetKeys(request::GetKeys(wallet_token, request_id)) => {
                 if wallet_token != self.wallet_token {
-                    Err(Error::InvalidToken)?
+                    return Err(Error::InvalidToken);
                 }
                 trace!("sent Secret request to farcasterd");
                 self.send_farcasterd(

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -469,7 +469,6 @@ impl Runtime {
                         {
                             if let Some(remote_params) = remote_params {
                                 error!("bob_params were previously set to: {}", remote_params);
-                                return Ok(());
                             } else {
                                 trace!("Setting bob params: {}", reveal);
                                 bob_commit.verify_with_reveal(&CommitmentEngine, reveal.clone())?;
@@ -501,12 +500,11 @@ impl Runtime {
                                 }
                                 // nothing to do yet, waiting for Msg
                                 // CoreArbitratingSetup to proceed
-                                return Ok(());
                             }
                         } else {
                             error!("only Some(Wallet::Alice)");
-                            return Ok(());
                         }
+                        return Ok(());
                     }
                     // getting parameters from counterparty alice routed through
                     // swapd, thus I'm Bob on this swap: Bob can proceed

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -285,7 +285,7 @@ impl Runtime {
                 let external_address = self.btc_addrs.remove(&swap_id).expect("checked above");
                 match offer.maker_role {
                     SwapRole::Bob => {
-                        let bob = Bob::<BtcXmr>::new(external_address.into(), FeePriority::Low);
+                        let bob = Bob::<BtcXmr>::new(external_address, FeePriority::Low);
                         let wallet_index = self.node_secrets.increment_wallet_counter();
                         let mut key_manager =
                             KeyManager::new(self.node_secrets.wallet_seed, wallet_index)?;
@@ -336,8 +336,7 @@ impl Runtime {
                         }
                     }
                     SwapRole::Alice => {
-                        let alice: Alice<BtcXmr> =
-                            Alice::new(external_address.into(), FeePriority::Low);
+                        let alice: Alice<BtcXmr> = Alice::new(external_address, FeePriority::Low);
                         let wallet_seed = self.node_secrets.wallet_seed;
                         let wallet_index = self.node_secrets.increment_wallet_counter();
                         let mut key_manager = KeyManager::new(wallet_seed, wallet_index)?;
@@ -949,7 +948,7 @@ impl Runtime {
             }) if source == ServiceId::Farcasterd => {
                 let PublicOffer { offer, node_id, .. } = public_offer.clone();
 
-                let swap_id: SwapId = SwapId::random().into();
+                let swap_id: SwapId = SwapId::random();
                 self.swaps.insert(swap_id, None);
                 self.xmr_addrs.insert(swap_id, internal_address);
 
@@ -959,7 +958,7 @@ impl Runtime {
                 let mut key_manager = KeyManager::new(self.node_secrets.wallet_seed, wallet_index)?;
                 match taker_role {
                     SwapRole::Bob => {
-                        let bob: Bob<BtcXmr> = Bob::new(external_address.into(), FeePriority::Low);
+                        let bob: Bob<BtcXmr> = Bob::new(external_address, FeePriority::Low);
                         let (local_params, local_proof) =
                             bob.generate_parameters(&mut key_manager, &public_offer)?;
                         let funding = create_funding(&mut key_manager, offer.network)?;
@@ -1004,8 +1003,7 @@ impl Runtime {
                         )?;
                     }
                     SwapRole::Alice => {
-                        let alice: Alice<BtcXmr> =
-                            Alice::new(external_address.into(), FeePriority::Low);
+                        let alice: Alice<BtcXmr> = Alice::new(external_address, FeePriority::Low);
                         let (local_params, local_proof) =
                             alice.generate_parameters(&mut key_manager, &public_offer)?;
                         let wallet_seed = self.node_secrets.wallet_seed;

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -391,7 +391,7 @@ impl Runtime {
                             ..
                         })) = self.wallets.get_mut(&swap_id)
                         {
-                            if let Some(_) = remote_commit {
+                            if remote_commit.is_some() {
                                 error!("Bob commit (remote) already set");
                             } else if let Commit::BobParameters(commit) = commit {
                                 trace!("Setting bob commit");
@@ -408,7 +408,7 @@ impl Runtime {
                             ..
                         })) = self.wallets.get_mut(&swap_id)
                         {
-                            if let Some(_) = remote_commit_params {
+                            if remote_commit_params.is_some() {
                                 error!("Alice commit (remote) already set");
                             } else if let Commit::AliceParameters(commit) = commit {
                                 trace!("Setting alice commit");

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -1349,14 +1349,11 @@ async fn setup_monero() -> (monero_rpc::RegtestDaemonClient, monero_rpc::WalletC
     let regtest = daemon.regtest();
     let wallet_client = monero_rpc::RpcClient::new("http://localhost:18083".to_string());
     let wallet = wallet_client.wallet();
-    match wallet
+    // Ignore if fails, maybe the wallet already exists
+    let _ = wallet
         .create_wallet("test".to_string(), None, "English".to_string())
-        .await
-    {
-        _ => {
-            wallet.open_wallet("test".to_string(), None).await.unwrap();
-        }
-    }
+        .await;
+    wallet.open_wallet("test".to_string(), None).await.expect("The wallet exists, created the line before");
     (regtest, wallet)
 }
 

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -946,7 +946,7 @@ async fn monero_syncer_address_test() {
 
     let addendum_1 = AddressAddendum::Monero(XmrAddressAddendum {
         spend_key: address1.public_spend,
-        view_key: view_key,
+        view_key,
         from_height: 0,
     });
     let watch_address_task_1 = SyncerdTask {
@@ -973,7 +973,7 @@ async fn monero_syncer_address_test() {
 
     let addendum_2 = AddressAddendum::Monero(XmrAddressAddendum {
         spend_key: address2.public_spend,
-        view_key: view_key,
+        view_key,
         from_height: 0,
     });
     let watch_address_task_2 = SyncerdTask {
@@ -1001,7 +1001,7 @@ async fn monero_syncer_address_test() {
 
     let addendum_3 = AddressAddendum::Monero(XmrAddressAddendum {
         spend_key: address2.public_spend,
-        view_key: view_key,
+        view_key,
         from_height: 0,
     });
     let watch_address_task_3 = SyncerdTask {
@@ -1031,7 +1031,7 @@ async fn monero_syncer_address_test() {
 
     let addendum_4 = AddressAddendum::Monero(XmrAddressAddendum {
         spend_key: address4.public_spend,
-        view_key: view_key,
+        view_key,
         from_height: 0,
     });
     for i in 0..5 {
@@ -1061,7 +1061,7 @@ async fn monero_syncer_address_test() {
 
     let addendum_5 = AddressAddendum::Monero(XmrAddressAddendum {
         spend_key: address5.public_spend,
-        view_key: view_key,
+        view_key,
         from_height: blocks,
     });
 

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -744,13 +744,13 @@ fn find_coinbase_transaction_id(txs: Vec<bitcoin::Transaction>) -> bitcoin::Txid
             return transaction.txid();
         }
     }
-    bitcoin::Txid::from_slice(&vec![0; 32]).unwrap()
+    bitcoin::Txid::from_slice(&[0; 32]).unwrap()
 }
 
 fn find_coinbase_transaction_amount(txs: Vec<bitcoin::Transaction>) -> u64 {
     for transaction in txs {
         if transaction.input[0].previous_output.txid
-            == bitcoin::Txid::from_slice(&vec![0; 32]).unwrap()
+            == bitcoin::Txid::from_slice(&[0; 32]).unwrap()
         {
             return transaction.output[0].value;
         }

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -348,7 +348,7 @@ fn bitcoin_syncer_address_test(polling: bool) {
         task: Task::WatchAddress(WatchAddress {
             id: 5,
             lifetime: blocks + 5,
-            addendum: addendum_5.clone(),
+            addendum: addendum_5,
             include_tx: Boolean::False,
         }),
         source: SOURCE1.clone(),
@@ -739,7 +739,7 @@ fn create_bitcoin_syncer(
 fn find_coinbase_transaction_id(txs: Vec<bitcoin::Transaction>) -> bitcoin::Txid {
     for transaction in txs {
         if transaction.input[0].previous_output.txid
-            == bitcoin::Txid::from_slice(&vec![0; 32]).unwrap()
+            == bitcoin::Txid::from_slice(&[0; 32]).unwrap()
         {
             return transaction.txid();
         }

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -823,7 +823,7 @@ async fn monero_syncer_block_height_test() {
     let task = SyncerdTask {
         task: Task::WatchHeight(WatchHeight {
             id: 1,
-            lifetime: u64::from(blocks) + 2,
+            lifetime: blocks + 2,
         }),
         source: SOURCE1.clone(),
     };
@@ -1234,7 +1234,7 @@ async fn monero_syncer_transaction_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: 1,
             lifetime: blocks + 5,
-            hash: hex::decode(transaction.tx_hash.to_string()).unwrap().into(),
+            hash: hex::decode(transaction.tx_hash.to_string()).unwrap(),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -1426,8 +1426,7 @@ fn get_request_from_message(message: Vec<Vec<u8>>) -> Request {
     let mut transcoder = PlainTranscoder {};
     let routed_message = recv_routed(message);
     let plain_message = transcoder.decrypt(routed_message.msg).unwrap();
-    let request = (&*unmarshaller.unmarshall(&plain_message).unwrap()).clone();
-    request
+    (&*unmarshaller.unmarshall(&plain_message).unwrap()).clone()
 }
 
 // as taken from the rust-internet2 crate - for now we only use the message

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -763,11 +763,8 @@ fn bitcoin_setup() -> bitcoincore_rpc::Client {
     let bitcoin_rpc = Client::new("http://localhost:18443", Auth::CookieFile(path)).unwrap();
 
     // make sure a wallet is created and loaded
-    match bitcoin_rpc.create_wallet("wallet", None, None, None, None) {
-        Err(_e) => match bitcoin_rpc.load_wallet("wallet") {
-            _ => {}
-        },
-        _ => {}
+    if bitcoin_rpc.create_wallet("wallet", None, None, None, None).is_err() {
+        let _ = bitcoin_rpc.load_wallet("wallet");
     }
     bitcoin_rpc
 }

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -738,8 +738,7 @@ fn create_bitcoin_syncer(
 
 fn find_coinbase_transaction_id(txs: Vec<bitcoin::Transaction>) -> bitcoin::Txid {
     for transaction in txs {
-        if transaction.input[0].previous_output.txid
-            == bitcoin::Txid::from_slice(&[0; 32]).unwrap()
+        if transaction.input[0].previous_output.txid == bitcoin::Txid::from_slice(&[0; 32]).unwrap()
         {
             return transaction.txid();
         }
@@ -749,8 +748,7 @@ fn find_coinbase_transaction_id(txs: Vec<bitcoin::Transaction>) -> bitcoin::Txid
 
 fn find_coinbase_transaction_amount(txs: Vec<bitcoin::Transaction>) -> u64 {
     for transaction in txs {
-        if transaction.input[0].previous_output.txid
-            == bitcoin::Txid::from_slice(&[0; 32]).unwrap()
+        if transaction.input[0].previous_output.txid == bitcoin::Txid::from_slice(&[0; 32]).unwrap()
         {
             return transaction.output[0].value;
         }
@@ -763,7 +761,10 @@ fn bitcoin_setup() -> bitcoincore_rpc::Client {
     let bitcoin_rpc = Client::new("http://localhost:18443", Auth::CookieFile(path)).unwrap();
 
     // make sure a wallet is created and loaded
-    if bitcoin_rpc.create_wallet("wallet", None, None, None, None).is_err() {
+    if bitcoin_rpc
+        .create_wallet("wallet", None, None, None, None)
+        .is_err()
+    {
         let _ = bitcoin_rpc.load_wallet("wallet");
     }
     bitcoin_rpc
@@ -1353,7 +1354,10 @@ async fn setup_monero() -> (monero_rpc::RegtestDaemonClient, monero_rpc::WalletC
     let _ = wallet
         .create_wallet("test".to_string(), None, "English".to_string())
         .await;
-    wallet.open_wallet("test".to_string(), None).await.expect("The wallet exists, created the line before");
+    wallet
+        .open_wallet("test".to_string(), None)
+        .await
+        .expect("The wallet exists, created the line before");
     (regtest, wallet)
 }
 

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -24,8 +24,7 @@ fn spawn_swap() {
     info!("opts: {:?}", opts);
     let config: Config = opts.shared.clone().into();
 
-    let mut client =
-        Client::with(config.clone(), config.chain).expect("Error running client");
+    let mut client = Client::with(config.clone(), config.chain).expect("Error running client");
 
     let mut farcasterd_maker = launch("../farcasterd", data_dir_maker.clone()).unwrap();
     let mut farcasterd_taker = launch("../farcasterd", data_dir_taker.clone()).unwrap();

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -7,7 +7,6 @@ use farcaster_node::rpc::Client;
 use farcaster_node::{Config, LogStyle};
 use sysinfo::{ProcessExt, System, SystemExt};
 
-use farcaster_node::cli::Command;
 use microservices::shell::Exec;
 
 #[test]

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -25,7 +25,7 @@ fn spawn_swap() {
     let config: Config = opts.shared.clone().into();
 
     let mut client =
-        Client::with(config.clone(), config.chain.clone()).expect("Error running client");
+        Client::with(config.clone(), config.chain).expect("Error running client");
 
     let mut farcasterd_maker = launch("../farcasterd", data_dir_maker.clone()).unwrap();
     let mut farcasterd_taker = launch("../farcasterd", data_dir_taker.clone()).unwrap();


### PR DESCRIPTION
All patches here were found by running `cargo clippy --all --all-targets --all-features -- -D warnings`. This patch should be tested extensively before merging to make sure no regressions were introduced.

However, there remain two unpatched linter findings that warrant further discussion here.

1. We use a bunch of enums that have a large size difference between their possible values. We could either Box these, or add clippy exceptions for them.
2. There seems to be a problem with `#[display(Debug)]` / `derive(Display)` where we take a reference that is immediately dereffed.


