### PR TITLE
Bitcoin syncer: Use unseen transaction pattern

### DIFF
--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -320,7 +320,7 @@ impl SyncerState {
         self.tasks_sources.insert(self.task_count.into(), source);
     }
 
-    pub async fn change_height(&mut self, height: u64, block: Vec<u8>) {
+    pub async fn change_height(&mut self, height: u64, block: Vec<u8>) -> bool {
         if self.block_height != height || self.block_hash != block {
             self.block_height = height;
             self.block_hash = block.clone();
@@ -342,6 +342,9 @@ impl SyncerState {
                 )
                 .await;
             }
+            true
+        } else {
+            false
         }
     }
 

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -452,6 +452,8 @@ fn bitcoin_syncer_transaction_test(polling: bool) {
     })
     .unwrap();
 
+    std::thread::sleep(duration);
+
     println!("awaiting confirmations");
     let message = rx_event.recv_multipart(0).unwrap();
     println!("received confirmation");


### PR DESCRIPTION
The Bitcoin syncer now uses the same seen/unseen transaction part like the monero syncer. Unseen transactions are continuously polled, until they are either mined or detected in the mempool. Subsequent polling is only done if either the block hash or block height changes.