### PR TITLE
Monero syncer: Add restore height for sweep wallet

### DIFF
--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -1500,7 +1500,7 @@ impl Runtime {
                             .pop()
                             .unwrap();
                         if let (Request::SyncerTask(Task::SweepAddress(mut task)), ServiceBus::Ctl) =
-                            (request.clone(), bus_id.clone())
+                            (request.clone(), bus_id)
                         {
                             // safe cast
                             task.from_height = Some(self.syncer_state.monero_height - *confirmations as u64);

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -224,7 +224,7 @@ async fn sweep_address(
     spend: monero::PrivateKey,
     network: &monero::Network,
     wallet_mutex: Arc<Mutex<monero_rpc::WalletClient>>,
-    from_height: Option<u64>,
+    restore_height: Option<u64>,
 ) -> Result<Vec<Vec<u8>>, Error> {
     let keypair = monero::KeyPair { view, spend };
     let password = s!(" ");
@@ -232,10 +232,10 @@ async fn sweep_address(
     let wallet_filename = format!("sweep:{}", address);
 
     // add some extra leeway for the wallet restore height
-    let restore_height = match from_height {
-        Some(height) if height > 10 => Some(height - 10),
-        _ => None,
-    };
+    // let restore_height = match from_height {
+    //     Some(height) if height > 10 => Some(height - 10),
+    //     _ => None,
+    // };
 
     let wallet = wallet_mutex.lock().await;
     trace!("taking sweep wallet lock");

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -224,11 +224,18 @@ async fn sweep_address(
     spend: monero::PrivateKey,
     network: &monero::Network,
     wallet_mutex: Arc<Mutex<monero_rpc::WalletClient>>,
+    from_height: Option<u64>,
 ) -> Result<Vec<Vec<u8>>, Error> {
     let keypair = monero::KeyPair { view, spend };
     let password = s!(" ");
     let address = monero::Address::from_keypair(*network, &keypair);
     let wallet_filename = format!("sweep:{}", address);
+
+    // add some extra leeway for the wallet restore height
+    let restore_height = match from_height {
+        Some(height) if height > 10 => Some(height - 10),
+        _ => None,
+    };
 
     let wallet = wallet_mutex.lock().await;
     trace!("taking sweep wallet lock");
@@ -243,7 +250,7 @@ async fn sweep_address(
         );
         wallet
             .generate_from_keys(GenerateFromKeysArgs {
-                restore_height: Some(1),
+                restore_height,
                 filename: wallet_filename.clone(),
                 address,
                 spendkey: Some(keypair.spend),
@@ -257,6 +264,7 @@ async fn sweep_address(
     // failsafe to check if the wallet really supports spending
     wallet.query_key(PrivateKeyType::Spend).await?;
     let (account, addrs) = (0, None);
+    wallet.refresh(restore_height).await?;
     let balance = wallet.get_balance(account, addrs).await?;
     // only sweep once all the balance is unlocked
     if balance.unlocked_balance != 0 {
@@ -502,6 +510,7 @@ fn sweep_polling(
                         addendum.spend_key,
                         &network,
                         Arc::clone(&wallet),
+                        sweep_address_task.from_height,
                     )
                     .await
                     .unwrap_or_else(|err| {

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -929,6 +929,7 @@ async fn syncer_state_sweep_addresses() {
     let sweep_task = SweepAddress {
         id: TaskId(0),
         lifetime: 11,
+        from_height: None,
         addendum: SweepAddressAddendum::Monero(SweepXmrAddress {
             view_key: monero::PrivateKey::from_str(
                 "77916d0cd56ed1920aef6ca56d8a41bac915b68e4c46a589e0956e27a7b77404",

--- a/src/syncerd/types.rs
+++ b/src/syncerd/types.rs
@@ -77,6 +77,7 @@ pub struct SweepAddress {
     pub id: TaskId,
     pub lifetime: u64,
     pub addendum: SweepAddressAddendum,
+    pub from_height: Option<u64>,
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -976,6 +976,7 @@ async fn monero_syncer_sweep_test() {
         task: Task::SweepAddress(SweepAddress {
             id: TaskId(0),
             lifetime: blocks + 40,
+            from_height: None,
             addendum: SweepAddressAddendum::Monero(SweepXmrAddress {
                 spend_key,
                 view_key,


### PR DESCRIPTION
This is supposed to fix #254 , please test if this makes the excessive monero-wallet-rpc logging disappear.