### PR TITLE
Modify doc and swap-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,15 +129,15 @@ When listening for other peers to connect, e.g. for executing a swap, a `peerd` 
 To create an offer and spawn a listening `peerd` accepting incoming connections, run the following command:
 
 ```
-swap-cli make --arb-addr tb1q935eq5fl2a3ajpqp0e3d7z36g7vctcgv05f5lf\
-    --acc-addr 54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu\
-    --arb-amount "0.0000135 BTC" --acc-amount "0.001 XMR"\
+swap-cli make --btc-addr tb1q935eq5fl2a3ajpqp0e3d7z36g7vctcgv05f5lf\
+    --xmr-addr 54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu\
+    --btc-amount "0.0000135 BTC" --xmr-amount "0.001 XMR"\
     --network Testnet --arb-blockchain ECDSA --acc-blockchain Monero\
     --maker-role Bob --cancel-timelock 4 --punish-timelock 5 --fee-strategy "1 satoshi/vByte"\
     --public-ip-addr 1.2.3.4 --bind-ip-addr 0.0.0.0 --port 9735 --overlay tcp
 ```
 
-Network and assets by default are Bitcoin and Monero on testnet. The first arguments `--arb-addr` and `--acc-addr` are the Bitcoin and Monero addresses used to get the bitcoins and moneros as a refund or when the swap completes depending on the role. They are followed by the amounts exchanged.
+Network and assets by default are Bitcoin and Monero on testnet. The first arguments `--btc-addr` and `--xmr-addr` are the Bitcoin and Monero addresses used to get the bitcoins and moneros as a refund or when the swap completes depending on the role. They are followed by the amounts exchanged.
 
 :mag_right: Default value `ECDSA` for `--arb-blockchain` is a temporary hack, but it represents `Bitcoin<ECDSA>`, as Bitcoin can take many forms.
 
@@ -160,8 +160,8 @@ Follow your `farcasterd` log (**with a log level set at `-vv`**) and fund the sw
 Taking a public offer is a much simpler process, all you need is a running node (doesn't require to know your network topology), an encoded public offer, a Bitcoin address and a Monero address to receive assets, again as a refund or as a payment depending on your swap role and if the swap completes.
 
 ```
-swap-cli take --arb-addr tb1qmcku4ht3tq53tvdl5hj03rajpdkdatd4w4mswx\
-    --acc-addr 54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu\
+swap-cli take --btc-addr tb1qmcku4ht3tq53tvdl5hj03rajpdkdatd4w4mswx\
+    --xmr-addr 54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu\
     --offer {offer}
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Running `monero-wallet-rpc` is also possible with Docker, see [run `monero rpc w
 
 ### Configuration
 
-`farcasterd` can be configured through a toml file located by default at `~/.farcaster/farcasterd.toml`, if no file is found `farcasterd` is launched with some default values. You can see an example [here](./farcasterd.toml).
+`farcasterd` can be configured through a toml file located by default at `~/.farcaster/farcasterd.toml` (Linux and BSD, see [here](./src/opts.rs) for more platforms specific), if no file is found `farcasterd` is launched with some default values. You can see an example [here](./farcasterd.toml).
 
 **Syncers**
 

--- a/README.md
+++ b/README.md
@@ -132,17 +132,20 @@ To create an offer and spawn a listening `peerd` accepting incoming connections,
 swap-cli make --arb-addr tb1q935eq5fl2a3ajpqp0e3d7z36g7vctcgv05f5lf\
     --acc-addr 54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu\
     --arb-amount "0.0000135 BTC" --acc-amount "0.001 XMR"\
-    --maker-role Bob\
-    --public-ip-addr 1.2.3.4 --port 9735
+    --network Testnet --arb-blockchain ECDSA --acc-blockchain Monero\
+    --maker-role Bob --cancel-timelock 4 --punish-timelock 5 --fee-strategy "1 satoshi/vByte"\
+    --public-ip-addr 1.2.3.4 --bind-ip-addr 0.0.0.0 --port 9735 --overlay tcp
 ```
 
 Network and assets by default are Bitcoin and Monero on testnet. The first arguments `--arb-addr` and `--acc-addr` are the Bitcoin and Monero addresses used to get the bitcoins and moneros as a refund or when the swap completes depending on the role. They are followed by the amounts exchanged.
 
-The role for the maker is specified in the offer with `--maker-role`. `Alice` sells moneros for bitcoins, `Bob` sells bitcoins for moneros. Timelock parameters are set by default to **4** and **5** for cancel and punish and the transaction fee that must be applied is by default **1 satoshi per vByte**.
+:mag_right: Default value `ECDSA` for `--arb-blockchain` is a temporary hack, but it represents `Bitcoin<ECDSA>`, as Bitcoin can take many forms.
 
-Here the maker will send bitcoins and will receive moneros in his `54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu` address if the swap is successful, 4 and 5 blocks are used for the timelocks and 1 satoshi per virtual byte must be used for the Bitcoin transaction fee (default values).
+The role for the maker is specified in the offer with `--maker-role`. `Alice` sells moneros for bitcoins, `Bob` sells bitcoins for moneros. Timelock parameters are set to **4** and **5** for cancel and punish and the transaction fee that must be applied is **1 satoshi per vByte**.
 
-Then the last two arguments in this example are: `--public-ip-addr` (default to `127.0.0.1`) and `--port` to be explicit in this example (default to `9735`). We don't specify `--bind-ip-addr` and leave its default to `0.0.0.0`,
+Here the maker will send bitcoins and will receive moneros in his `54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu` address if the swap is successful.
+
+`--public-ip-addr` (default to `127.0.0.1`) and `--port` (default to `9735`) are used in the public offer for the taker to connect. `--bind-ip-addr` allow to bind the listening peerd to `0.0.0.0`, `tcp` is used as overlay between peers.
 
 :mag_right: To be able for a taker to connect and take the offer the `public-ip-addr:port` must be accessible and answered by the `peerd` binded to `bind-id-address:port`.
 

--- a/compose/farcasterd.toml
+++ b/compose/farcasterd.toml
@@ -1,0 +1,4 @@
+[syncers.testnet]
+electrum_server = "ssl://blockstream.info:993"
+monero_daemon = "http://stagenet.melo.tools:38081"
+monero_rpc_wallet = "http://walletrpc:38083"

--- a/doc/docker-stack.md
+++ b/doc/docker-stack.md
@@ -50,23 +50,24 @@ Images used in the docker compose are produced by the `farcaster-project` direct
 
 ## Docker image
 
-You can use the docker image produced directly by the GitHub CI with:
+You can use the docker image directly with:
 
 ```
-docker run --rm -t -p 9735:9735 -p 9981:9981\
+docker run --rm --init -t -p 9735:9735 -p 9981:9981\
+    --mount type=bind,source=<config folder>,destination=/etc/farcaster\
     --name farcaster_node\
     ghcr.io/farcaster-project/farcaster-node/farcasterd:latest\
-    -vv\
-    --electrum-server ssl://blockstream.info:993\
-    --monero-daemon http://stagenet.melo.tools:38081\
-    --monero-rpc-wallet http://localhost:38083
+    -vvv -c /etc/farcaster/farcasterd.toml
 ```
+
+If you don't use the default values for syncers daemons don't forget to mount your config inside the container (here at `/etc/farcaster`) and pass the config file with `-c /etc/farcaster/farcasterd.toml`.
 
 or build the node image and start a container by running inside the project folder:
 
 ```
 docker build --no-cache -t farcasterd:latest .
 docker run --rm -t --init -p 9735:9735 -p 9981:9981\
+    --mount type=bind,source=<config folder>,destination=/etc/farcaster\
     --name farcaster_node\
     farcasterd:latest\
     {farcasterd args...}
@@ -94,12 +95,12 @@ docker run --rm -p 38083:38083 ghcr.io/farcaster-project/containers/monero-walle
     --confirm-external-bind
 ```
 
-Then use the following values when launching `farcasterd`:
+Then use the following values in `farcasterd` configuration file:
 
-| `--monero-rpc-wallet` | value                    |
-| --------------------- | ------------------------ |
-| mainnet               | `http://localhost:18083` |
-| stagenet              | `http://localhost:38083` |
+| `monero_rpc_wallet` | value                    |
+| ------------------- | ------------------------ |
+| mainnet             | `http://localhost:18083` |
+| stagenet            | `http://localhost:38083` |
 
 Remove `--stagenet` add change `--rpc-bind-port` and `-p` values to `18083` and connect to a **mainnet** daemon host, see [:bulb: Use public infrastructure](../README.md#bulb-use-public-infrastructure) for public mainnet daemon hosts.
 

--- a/doc/docker-stack.md
+++ b/doc/docker-stack.md
@@ -31,7 +31,7 @@ swap info
 
 You should get a returned value from the node. You can use this stack to take a public offer or to make an offer. In the case you want to make an offer make sure the public address and the port will be reachable from external networks.
 
-:mega: The only port forwarded to the host is `9735`, make sure to use this one when making offers.
+:mega: The only port forwarded to the host is `9735`, make sure to use this one when making offers (by default port `9735` is used).
 
 To stop and remove the containers simply run in the project folder:
 

--- a/doc/local-swap.md
+++ b/doc/local-swap.md
@@ -8,23 +8,49 @@ We'll create two node instances and will make them running a swap, for that make
 
 ## Run `monero rpc wallet` with Docker
 
-:warning: You should run two containers, one for each `farcasterd` services, choose different ports and modify `--rpc-bind-port` and `-p` values accordingly.
+:warning: You should run two containers, one for each `farcasterd` services, choose different ports and modify `--rpc-bind-port` and `-p` values accordingly. Pull the latest image and launch two containers:
+
+```
+docker pull ghcr.io/farcaster-project/containers/monero-wallet-rpc:latest
+docker run --rm -p 38083:38083 ghcr.io/farcaster-project/containers/monero-wallet-rpc:latest\
+    /usr/bin/monero-wallet-rpc --stagenet\
+    --disable-rpc-login --wallet-dir wallets\
+    --daemon-host stagenet.melo.tools:38081\
+    --rpc-bind-ip 0.0.0.0 --rpc-bind-port 38083\
+    --confirm-external-bind
+```
+
+and
+
+```
+docker run --rm -p 38084:38084 ghcr.io/farcaster-project/containers/monero-wallet-rpc:latest\
+    /usr/bin/monero-wallet-rpc --stagenet\
+    --disable-rpc-login --wallet-dir wallets\
+    --daemon-host stagenet.melo.tools:38081\
+    --rpc-bind-ip 0.0.0.0 --rpc-bind-port 38084\
+    --confirm-external-bind
+```
 
 See [run `monero rpc wallet`](./docker-stack.md#run-monero-rpc-wallet) with Docker for more details.
 
 ## Launch `farcasterd` services
 
-Launch two `farcasterd` services with different data directories (`.node01` and `.node02`):
+We will start two daemons with different data directories (`.node01` and `.node02`). First configure both node (with config files `.node01/farcasterd.toml` and `.node02/farcasterd.toml`) to use the two different monero rpc wallets you previously started and change the port for `monero_rpc_wallet` accordingly:
+
+```toml
+[syncers.testnet]
+electrum_server = "ssl://blockstream.info:993"
+monero_daemon = "http://stagenet.melo.tools:38081"
+monero_rpc_wallet = "http://localhost:{38083|38084}"
+```
+
+Then launch two `farcasterd` services:
 
 ```
-farcasterd -vv\
-    --data-dir {.node01|.node02}\
-    --electrum-server ssl://blockstream.info:993\
-    --monero-daemon http://stagenet.melo.tools:38081\
-    --monero-rpc-wallet http://localhost:{38083|38084}
+farcasterd -vv --data-dir {.node01|.node02}
 ```
 
-You can use other public daemons, see [:bulb: Use public infrastructure](../README.md#bulb-use-public-infrastructure) for more details.
+You can use other public daemons for syncers, see [:bulb: Use public infrastructure](../README.md#bulb-use-public-infrastructure) for more details.
 
 ## Configure `swap-cli` clients
 
@@ -41,26 +67,22 @@ You need to have access to Bitcoin (testnet) and Monero (stagenet) test coins, u
 
 ## Make the offer
 
-Maker creates offer and start listening. Command used to print a serialized representation of the offer that shall be shared with taker. Additionally it spins up the listener awaiting for connection related to this offer (binded on `0.0.0.0:9735` with an offer public address of `127.0.0.1:9735`).
+Maker creates offer and start listening. Command used to print a serialized representation of the offer that shall be shared with taker. Additionally it spins up the listener awaiting for connection related to this offer (binded on `0.0.0.0:9735` by default with an offer public address of `127.0.0.1:9735` by default).
 
 ```
-swap1-cli make tb1q4gj53tuew3e6u4a32kdtle2q72su8te39dpceq\
-    54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu\
-    Testnet ECDSA Monero\
-    "0.00001350 BTC" "0.001 XMR"\
-    Alice 4 5 "1 satoshi/vByte"\
-    "127.0.0.1" "0.0.0.0" 9735
+swap1-cli make --arb-addr tb1q4gj53tuew3e6u4a32kdtle2q72su8te39dpceq\
+    --acc-addr 54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu\
+    --arb-amount "0.0000135 BTC"\
+    --acc-amount "0.001 XMR"
 ```
 
-:mag_right: The `ECDSA` above is a temporary hack, but it represents `Bitcoin<ECDSA>`, as Bitcoin can take many forms.
+:mag_right: Default value `ECDSA` for `--arb-blockchain` is a temporary hack, but it represents `Bitcoin<ECDSA>`, as Bitcoin can take many forms.
 
-This will produce the following encoded offer:
+The command will create a public offer based on the chosen parameters, spin up a listening `peerd` (in that case `0.0.0.0:9735`), and return the encoded offer (starting with `Offer:...`).
 
-`Offer:Cke4ftrP5A71LQM2fvVdFMNR4gmBqNCsR11111uMM4pF11111112Lvo11111TB9zym113GTvtvqfD1111112g5B8NNdQ79CnoUCEtZVSK1pYzGhNQeM28QBZNSKAZ5sJk8WA11111111111111111111111111111111111111111AfZ113XRBtzfJQ4h`
+This public offer should be shared by maker with taker. It also contains information on how to connect to maker (in that case `127.0.0.1:9735`). Additionally, it adds the public offers to the set of public offers in `farcasterd` that will be later used to initiate the swap upon takers requests.
 
-This public offer should be shared by maker with taker. It also contains information on how to connect to maker. Additionally, it adds the public offers to the set of public offers in `farcasterd` that will be later used to initiate the swap upon takers message.
-
-To get a detailed explaination of make parameters run `swap1-cli make --help`.
+To get a detailed explaination of make and more details on all possible arguments you can change run `swap1-cli make --help`.
 
 ## Take an offer
 
@@ -69,11 +91,13 @@ Taker accepts offer and connects to maker's daemon node with the following comma
 Example of taking the offer above produced by maker:
 
 ```
-swap2-cli take tb1qt3r3t6yultt8ne88ffgvgyym0sstj4apwsz05j\
-    54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu\
-    Offer:Cke4ftrP5A71LQM2fvVdFMNR4gmBqNCsR11111uMM4pF11111112Lvo11111TB9zym113GTvtvqfD1111112g5B8NNdQ79CnoUCEtZVSK1pYzGhNQeM28QBZNSKAZ5sJk8WA11111111111111111111111111111111111111111AfZ113XRBtzfJQ4h
+swap2-cli take --arb-addr tb1qt3r3t6yultt8ne88ffgvgyym0sstj4apwsz05j\
+    --acc-addr 54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu\
+    --offer Offer:...
 ```
 
-The first argument is the Bitcoin destination address in case the bitcoins needs to be refunded or if the swap completes (depending on the swap role).
+The `--arb-addr` argument is the Bitcoin destination address in case the bitcoins needs to be refunded or if the swap completes (depending on the swap role), the `--acc-addr` for Monero, and finally the offer with `--offer` or `-o`.
+
+Upon taking the public offer is printed and user is asked for validation with `y` or `n`.
 
 :mag_right: Flag of interest: `--without-validation` or `-w`, for externally validated automated setups (skip validation in cli).

--- a/doc/local-swap.md
+++ b/doc/local-swap.md
@@ -70,10 +70,10 @@ You need to have access to Bitcoin (testnet) and Monero (stagenet) test coins, u
 Maker creates offer and start listening. Command used to print a serialized representation of the offer that shall be shared with taker. Additionally it spins up the listener awaiting for connection related to this offer (binded on `0.0.0.0:9735` by default with an offer public address of `127.0.0.1:9735` by default).
 
 ```
-swap1-cli make --arb-addr tb1q4gj53tuew3e6u4a32kdtle2q72su8te39dpceq\
-    --acc-addr 54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu\
-    --arb-amount "0.0000135 BTC"\
-    --acc-amount "0.001 XMR"
+swap1-cli make --btc-addr tb1q4gj53tuew3e6u4a32kdtle2q72su8te39dpceq\
+    --xmr-addr 54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu\
+    --btc-amount "0.0000135 BTC"\
+    --xmr-amount "0.001 XMR"
 ```
 
 :mag_right: Default value `ECDSA` for `--arb-blockchain` is a temporary hack, but it represents `Bitcoin<ECDSA>`, as Bitcoin can take many forms.
@@ -91,12 +91,12 @@ Taker accepts offer and connects to maker's daemon node with the following comma
 Example of taking the offer above produced by maker:
 
 ```
-swap2-cli take --arb-addr tb1qt3r3t6yultt8ne88ffgvgyym0sstj4apwsz05j\
-    --acc-addr 54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu\
+swap2-cli take --btc-addr tb1qt3r3t6yultt8ne88ffgvgyym0sstj4apwsz05j\
+    --xmr-addr 54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu\
     --offer Offer:...
 ```
 
-The `--arb-addr` argument is the Bitcoin destination address in case the bitcoins needs to be refunded or if the swap completes (depending on the swap role), the `--acc-addr` for Monero, and finally the offer with `--offer` or `-o`.
+The `--btc-addr` argument is the Bitcoin destination address in case the bitcoins needs to be refunded or if the swap completes (depending on the swap role), the `--xmr-addr` for Monero, and finally the offer with `--offer` or `-o`.
 
 Upon taking the public offer is printed and user is asked for validation with `y` or `n`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,13 @@ services:
     ports:
       - "9735:9735"
       - "9981:9981"
-    command: "-vv --electrum-server ssl://blockstream.info:993 --monero-daemon http://stagenet.melo.tools:38081 --monero-rpc-wallet http://walletrpc:38083"
+    command: "-vvv -c /etc/farcaster/farcasterd.toml"
     depends_on:
       - "walletrpc"
+    volumes:
+      - type: bind
+        source: ./compose
+        target: /etc/farcaster
   walletrpc:
     image: "ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3"
     command: "/usr/bin/monero-wallet-rpc --stagenet --disable-rpc-login --wallet-dir wallets --daemon-host stagenet.melo.tools:38081 --rpc-bind-ip 0.0.0.0 --rpc-bind-port 38083 --confirm-external-bind"

--- a/farcasterd.toml
+++ b/farcasterd.toml
@@ -1,14 +1,32 @@
+# Syncers configuration
+# configures the Bitcoin and Monero syncers for the three
+# networks.
+
+# Mainnet daemons
 [syncers.mainnet]
+# Electrum Server used by the Bitcoin syncer
 electrum_server = "ssl://blockstream.info:700"
+# Monero daemon used by the Monero syncer
 monero_daemon = "http://node.monerooutreach.org:18081"
+# Monero Wallet RPC used by the Monero syncer
+# Point to local running wallet
 monero_rpc_wallet = "http://localhost:18083"
 
+# Testnet/stagenet daemons
 [syncers.testnet]
+# Electrum Server used by the Bitcoin syncer on testnet
 electrum_server = "ssl://blockstream.info:993"
+# Monero daemon used by the Monero syncer on stagenet
 monero_daemon = "http://stagenet.melo.tools:38081"
+# Monero Wallet RPC used by the Monero syncer on stagenet
+# Point to local running wallet
 monero_rpc_wallet = "http://localhost:38083"
 
+# Local development daemons, null by default
 [syncers.local]
+# Electrum Server used by the Bitcoin syncer on regtest
 electrum_server = "tcp://localhost:50001"
+# Monero daemon used by the Monero syncer on regtest
 monero_daemon = "http://localhost:18081"
+# Monero Wallet RPC used by the Monero syncer on regtest
 monero_rpc_wallet = "http://localhost:18083"

--- a/shell/_swap-cli
+++ b/shell/_swap-cli
@@ -95,14 +95,14 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (make)
 _arguments "${_arguments_options[@]}" \
-'--arb-addr=[Bitcoin address used as destination or refund address]' \
-'--acc-addr=[Monero address used as destination or refund address]' \
+'--btc-addr=[Bitcoin address used as destination or refund address]' \
+'--xmr-addr=[Monero address used as destination or refund address]' \
 '-n+[Network to use to execute the swap between the chosen blockchains]: :(Testnet Mainnet Local)' \
 '--network=[Network to use to execute the swap between the chosen blockchains]: :(Testnet Mainnet Local)' \
 '--arb-blockchain=[The chosen arbitrating blockchain]: :(ECDSA)' \
 '--acc-blockchain=[The chosen accordant blockchain]: :(Monero)' \
-'--arb-amount=[Amount of arbitrating assets to exchanged]' \
-'--acc-amount=[Amount of accordant assets to exchanged]' \
+'--btc-amount=[Amount of arbitrating assets to exchanged]' \
+'--xmr-amount=[Amount of accordant assets to exchanged]' \
 '-r+[The future maker swap role, either Alice of Bob. This will dictate with asset will be exchanged for which asset. Alice will sell accordant assets for arbitrating ones and Bob the inverse, sell arbitrating assets for accordant ones]: :(Alice Bob)' \
 '--maker-role=[The future maker swap role, either Alice of Bob. This will dictate with asset will be exchanged for which asset. Alice will sell accordant assets for arbitrating ones and Bob the inverse, sell arbitrating assets for accordant ones]: :(Alice Bob)' \
 '--cancel-timelock=[The cancel timelock parameter of the arbitrating blockchain]' \
@@ -133,8 +133,8 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (take)
 _arguments "${_arguments_options[@]}" \
-'--arb-addr=[Bitcoin address used as destination or refund address]' \
-'--acc-addr=[Monero address used as destination or refund address]' \
+'--btc-addr=[Bitcoin address used as destination or refund address]' \
+'--xmr-addr=[Monero address used as destination or refund address]' \
 '-o+[An encoded public offer]' \
 '--offer=[An encoded public offer]' \
 '-d+[Data directory path]: :_files -/' \

--- a/shell/_swap-cli
+++ b/shell/_swap-cli
@@ -157,6 +157,26 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (make)
 _arguments "${_arguments_options[@]}" \
+'--arb-addr=[Bitcoin address used as destination or refund address]' \
+'--acc-addr=[Monero address used as destination or refund address]' \
+'-n+[Network to use to execute the swap between the chosen blockchains]: :(Testnet Mainnet Local)' \
+'--network=[Network to use to execute the swap between the chosen blockchains]: :(Testnet Mainnet Local)' \
+'--arb-blockchain=[The chosen arbitrating blockchain]: :(ECDSA)' \
+'--acc-blockchain=[The chosen accordant blockchain]: :(Monero)' \
+'--arb-amount=[Amount of arbitrating assets to exchanged]' \
+'--acc-amount=[Amount of accordant assets to exchanged]' \
+'-r+[The future maker swap role, either Alice of Bob. This will dictate with asset will be exchanged for which asset. Alice will sell accordant assets for arbitrating ones and Bob the inverse, sell arbitrating assets for accordant ones]: :(Alice Bob)' \
+'--maker-role=[The future maker swap role, either Alice of Bob. This will dictate with asset will be exchanged for which asset. Alice will sell accordant assets for arbitrating ones and Bob the inverse, sell arbitrating assets for accordant ones]: :(Alice Bob)' \
+'--cancel-timelock=[The cancel timelock parameter of the arbitrating blockchain]' \
+'--punish-timelock=[The punish timelock parameter of the arbitrating blockchain]' \
+'--fee-strategy=[The chosen fee strategy for the arbitrating transactions]' \
+'-I+[Public IPv4 or IPv6 address present in the public offer allowing taker to connect]' \
+'--public-ip-addr=[Public IPv4 or IPv6 address present in the public offer allowing taker to connect]' \
+'-b+[IPv4 or IPv6 address to bind to, listening for takers]' \
+'--bind-ip-addr=[IPv4 or IPv6 address to bind to, listening for takers]' \
+'-p+[Port to use; defaults to the native LN port]' \
+'--port=[Port to use; defaults to the native LN port]' \
+'--overlay=[Use overlay protocol (http, websocket etc)]' \
 '-d+[Data directory path]: :_files -/' \
 '--data-dir=[Data directory path]: :_files -/' \
 '-T+[Use Tor]: :_hosts' \
@@ -171,25 +191,14 @@ _arguments "${_arguments_options[@]}" \
 '--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-':arbitrating-addr -- Bitcoin address used as destination or refund address:' \
-':accordant-addr -- Monero address used as destination or refund address:' \
-'::network -- Network to use:(Testnet Mainnet Local)' \
-'::arbitrating-blockchain -- The chosen arbitrating blockchain:(ECDSA)' \
-'::accordant-blockchain -- The chosen accordant blockchain:(Monero)' \
-'::arbitrating-amount -- Amount of arbitrating assets to exchanged:' \
-'::accordant-amount -- Amount of accordant assets to exchanged:' \
-'::maker-role -- The future maker swap role:(Alice Bob)' \
-'::cancel-timelock -- The cancel timelock parameter of the arbitrating blockchain:' \
-'::punish-timelock -- The punish timelock parameter of the arbitrating blockchain:' \
-'::fee-strategy -- The chosen fee strategy for the arbitrating transactions:' \
-'::public-ip-addr -- public IPv4 or IPv6 address for public offer:' \
-'::bind-ip-addr -- IPv4 or IPv6 address to bind to:' \
-'::port -- Port to use; defaults to the native LN port:' \
-'::overlay -- Use overlay protocol (http, websocket etc):' \
 && ret=0
 ;;
 (take)
 _arguments "${_arguments_options[@]}" \
+'--arb-addr=[Bitcoin address used as destination or refund address]' \
+'--acc-addr=[Monero address used as destination or refund address]' \
+'-o+[An encoded public offer]' \
+'--offer=[An encoded public offer]' \
 '-d+[Data directory path]: :_files -/' \
 '--data-dir=[Data directory path]: :_files -/' \
 '-T+[Use Tor]: :_hosts' \
@@ -198,17 +207,14 @@ _arguments "${_arguments_options[@]}" \
 '--msg-socket=[ZMQ socket name/address to forward all incoming protocol messages]: :_files' \
 '-x+[ZMQ socket name/address for daemon control interface]: :_files' \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]: :_files' \
-'-w[Accept Offer without validation]' \
-'--without-validation[Accept Offer without validation]' \
+'-w[Accept the public offer without validation]' \
+'--without-validation[Accept the public offer without validation]' \
 '-h[Print help information]' \
 '--help[Print help information]' \
 '-V[Print version information]' \
 '--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-':bitcoin-address -- bitcoin address used as destination or refund address:' \
-':monero-address -- monero address used as destination or refund address:' \
-':public-offer -- Hex encoded offer:' \
 && ret=0
 ;;
 (progress)
@@ -227,7 +233,7 @@ _arguments "${_arguments_options[@]}" \
 '--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-':swapid -- SwapId:' \
+':swapid -- The swap id requested:' \
 && ret=0
 ;;
 (help)
@@ -262,9 +268,9 @@ _swap-cli_commands() {
 'info:General information about the running node' \
 'peers:Lists existing peer connections' \
 'ls:Lists running swaps' \
-'make:Maker creates offer and start listening. Command used to to print a hex representation of the offer that shall be shared with Taker. Additionally it spins up the listener awaiting for connection related to this offer. Example usage: `make tb1q4gj53tuew3e6u4a32kdtle2q72su8te39dpceq 55LTR8KniP4LQGJSPtbYDacR7dz8RBFnsfAKMaMuwUNYX6aQbBcovzDPyrQF9KXF9tVU6Xk3K8no1BywnJX6GvZX8yJsXvt Testnet ECDSA Monero "0.00001350 BTC" "0.001 XMR" Alice 10 30 "1 satoshi/vByte" "127.0.0.1" "0.0.0.0" 9745`' \
-'take:Taker accepts offer and connects to Maker'\''s daemon' \
-'progress:Request Swap progress report' \
+'make:Maker creates offer and start listening for incoming connections. Command used to to print the resulting public offer that shall be shared with Taker. Additionally it spins up the listener awaiting for connection related to this offer' \
+'take:Taker accepts offer and connects to maker'\''s daemon to start the trade' \
+'progress:Request swap progress report' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'swap-cli commands' commands "$@"

--- a/shell/_swap-cli
+++ b/shell/_swap-cli
@@ -38,69 +38,7 @@ _swap-cli() {
         (( CURRENT += 1 ))
         curcontext="${curcontext%:*:*}:swap-cli-command-$line[1]:"
         case $line[1] in
-            (listen)
-_arguments "${_arguments_options[@]}" \
-'-i+[IPv4 or IPv6 address to bind to]' \
-'--ip=[IPv4 or IPv6 address to bind to]' \
-'-p+[Port to use; defaults to the native LN port]' \
-'--port=[Port to use; defaults to the native LN port]' \
-'-o+[Use overlay protocol (http, websocket etc)]' \
-'--overlay=[Use overlay protocol (http, websocket etc)]' \
-'-d+[Data directory path]: :_files -/' \
-'--data-dir=[Data directory path]: :_files -/' \
-'-T+[Use Tor]: :_hosts' \
-'--tor-proxy=[Use Tor]: :_hosts' \
-'-m+[ZMQ socket name/address to forward all incoming protocol messages]: :_files' \
-'--msg-socket=[ZMQ socket name/address to forward all incoming protocol messages]: :_files' \
-'-x+[ZMQ socket name/address for daemon control interface]: :_files' \
-'--ctl-socket=[ZMQ socket name/address for daemon control interface]: :_files' \
-'-h[Print help information]' \
-'--help[Print help information]' \
-'-V[Print version information]' \
-'--version[Print version information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
-&& ret=0
-;;
-(connect)
-_arguments "${_arguments_options[@]}" \
-'-d+[Data directory path]: :_files -/' \
-'--data-dir=[Data directory path]: :_files -/' \
-'-T+[Use Tor]: :_hosts' \
-'--tor-proxy=[Use Tor]: :_hosts' \
-'-m+[ZMQ socket name/address to forward all incoming protocol messages]: :_files' \
-'--msg-socket=[ZMQ socket name/address to forward all incoming protocol messages]: :_files' \
-'-x+[ZMQ socket name/address for daemon control interface]: :_files' \
-'--ctl-socket=[ZMQ socket name/address for daemon control interface]: :_files' \
-'-h[Print help information]' \
-'--help[Print help information]' \
-'-V[Print version information]' \
-'--version[Print version information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
-':peer -- Address of the remote node, in '<public_key>@<ipv4>|<ipv6>|<onionv2>|<onionv3>\[\:<port>\]' format:' \
-&& ret=0
-;;
-(ping)
-_arguments "${_arguments_options[@]}" \
-'-d+[Data directory path]: :_files -/' \
-'--data-dir=[Data directory path]: :_files -/' \
-'-T+[Use Tor]: :_hosts' \
-'--tor-proxy=[Use Tor]: :_hosts' \
-'-m+[ZMQ socket name/address to forward all incoming protocol messages]: :_files' \
-'--msg-socket=[ZMQ socket name/address to forward all incoming protocol messages]: :_files' \
-'-x+[ZMQ socket name/address for daemon control interface]: :_files' \
-'--ctl-socket=[ZMQ socket name/address for daemon control interface]: :_files' \
-'-h[Print help information]' \
-'--help[Print help information]' \
-'-V[Print version information]' \
-'--version[Print version information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
-':peer -- Address of the remote node, in '<public_key>@<ipv4>|<ipv6>|<onionv2>|<onionv3>\[\:<port>\]' format:' \
-&& ret=0
-;;
-(info)
+            (info)
 _arguments "${_arguments_options[@]}" \
 '-d+[Data directory path]: :_files -/' \
 '--data-dir=[Data directory path]: :_files -/' \
@@ -262,9 +200,6 @@ esac
 (( $+functions[_swap-cli_commands] )) ||
 _swap-cli_commands() {
     local commands; commands=(
-'listen:Bind to a socket and start listening for incoming LN peer connections, Maker'\''s action' \
-'connect:Connect to the remote lightning network peer' \
-'ping:Ping remote peer (must be already connected)' \
 'info:General information about the running node' \
 'peers:Lists existing peer connections' \
 'ls:Lists running swaps' \
@@ -275,11 +210,6 @@ _swap-cli_commands() {
     )
     _describe -t commands 'swap-cli commands' commands "$@"
 }
-(( $+functions[_swap-cli__connect_commands] )) ||
-_swap-cli__connect_commands() {
-    local commands; commands=()
-    _describe -t commands 'swap-cli connect commands' commands "$@"
-}
 (( $+functions[_swap-cli__help_commands] )) ||
 _swap-cli__help_commands() {
     local commands; commands=()
@@ -289,11 +219,6 @@ _swap-cli__help_commands() {
 _swap-cli__info_commands() {
     local commands; commands=()
     _describe -t commands 'swap-cli info commands' commands "$@"
-}
-(( $+functions[_swap-cli__listen_commands] )) ||
-_swap-cli__listen_commands() {
-    local commands; commands=()
-    _describe -t commands 'swap-cli listen commands' commands "$@"
 }
 (( $+functions[_swap-cli__ls_commands] )) ||
 _swap-cli__ls_commands() {
@@ -309,11 +234,6 @@ _swap-cli__make_commands() {
 _swap-cli__peers_commands() {
     local commands; commands=()
     _describe -t commands 'swap-cli peers commands' commands "$@"
-}
-(( $+functions[_swap-cli__ping_commands] )) ||
-_swap-cli__ping_commands() {
-    local commands; commands=()
-    _describe -t commands 'swap-cli ping commands' commands "$@"
 }
 (( $+functions[_swap-cli__progress_commands] )) ||
 _swap-cli__progress_commands() {

--- a/shell/_swap-cli.ps1
+++ b/shell/_swap-cli.ps1
@@ -40,9 +40,9 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('info', 'info', [CompletionResultType]::ParameterValue, 'General information about the running node')
             [CompletionResult]::new('peers', 'peers', [CompletionResultType]::ParameterValue, 'Lists existing peer connections')
             [CompletionResult]::new('ls', 'ls', [CompletionResultType]::ParameterValue, 'Lists running swaps')
-            [CompletionResult]::new('make', 'make', [CompletionResultType]::ParameterValue, 'Maker creates offer and start listening. Command used to to print a hex representation of the offer that shall be shared with Taker. Additionally it spins up the listener awaiting for connection related to this offer. Example usage: `make tb1q4gj53tuew3e6u4a32kdtle2q72su8te39dpceq 55LTR8KniP4LQGJSPtbYDacR7dz8RBFnsfAKMaMuwUNYX6aQbBcovzDPyrQF9KXF9tVU6Xk3K8no1BywnJX6GvZX8yJsXvt Testnet ECDSA Monero "0.00001350 BTC" "0.001 XMR" Alice 10 30 "1 satoshi/vByte" "127.0.0.1" "0.0.0.0" 9745`')
-            [CompletionResult]::new('take', 'take', [CompletionResultType]::ParameterValue, 'Taker accepts offer and connects to Maker''s daemon')
-            [CompletionResult]::new('progress', 'progress', [CompletionResultType]::ParameterValue, 'Request Swap progress report')
+            [CompletionResult]::new('make', 'make', [CompletionResultType]::ParameterValue, 'Maker creates offer and start listening for incoming connections. Command used to to print the resulting public offer that shall be shared with Taker. Additionally it spins up the listener awaiting for connection related to this offer')
+            [CompletionResult]::new('take', 'take', [CompletionResultType]::ParameterValue, 'Taker accepts offer and connects to maker''s daemon to start the trade')
+            [CompletionResult]::new('progress', 'progress', [CompletionResultType]::ParameterValue, 'Request swap progress report')
             [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
             break
         }
@@ -155,6 +155,26 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             break
         }
         'swap-cli;make' {
+            [CompletionResult]::new('--arb-addr', 'arb-addr', [CompletionResultType]::ParameterName, 'Bitcoin address used as destination or refund address')
+            [CompletionResult]::new('--acc-addr', 'acc-addr', [CompletionResultType]::ParameterName, 'Monero address used as destination or refund address')
+            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Network to use to execute the swap between the chosen blockchains')
+            [CompletionResult]::new('--network', 'network', [CompletionResultType]::ParameterName, 'Network to use to execute the swap between the chosen blockchains')
+            [CompletionResult]::new('--arb-blockchain', 'arb-blockchain', [CompletionResultType]::ParameterName, 'The chosen arbitrating blockchain')
+            [CompletionResult]::new('--acc-blockchain', 'acc-blockchain', [CompletionResultType]::ParameterName, 'The chosen accordant blockchain')
+            [CompletionResult]::new('--arb-amount', 'arb-amount', [CompletionResultType]::ParameterName, 'Amount of arbitrating assets to exchanged')
+            [CompletionResult]::new('--acc-amount', 'acc-amount', [CompletionResultType]::ParameterName, 'Amount of accordant assets to exchanged')
+            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'The future maker swap role, either Alice of Bob. This will dictate with asset will be exchanged for which asset. Alice will sell accordant assets for arbitrating ones and Bob the inverse, sell arbitrating assets for accordant ones')
+            [CompletionResult]::new('--maker-role', 'maker-role', [CompletionResultType]::ParameterName, 'The future maker swap role, either Alice of Bob. This will dictate with asset will be exchanged for which asset. Alice will sell accordant assets for arbitrating ones and Bob the inverse, sell arbitrating assets for accordant ones')
+            [CompletionResult]::new('--cancel-timelock', 'cancel-timelock', [CompletionResultType]::ParameterName, 'The cancel timelock parameter of the arbitrating blockchain')
+            [CompletionResult]::new('--punish-timelock', 'punish-timelock', [CompletionResultType]::ParameterName, 'The punish timelock parameter of the arbitrating blockchain')
+            [CompletionResult]::new('--fee-strategy', 'fee-strategy', [CompletionResultType]::ParameterName, 'The chosen fee strategy for the arbitrating transactions')
+            [CompletionResult]::new('-I', 'I', [CompletionResultType]::ParameterName, 'Public IPv4 or IPv6 address present in the public offer allowing taker to connect')
+            [CompletionResult]::new('--public-ip-addr', 'public-ip-addr', [CompletionResultType]::ParameterName, 'Public IPv4 or IPv6 address present in the public offer allowing taker to connect')
+            [CompletionResult]::new('-b', 'b', [CompletionResultType]::ParameterName, 'IPv4 or IPv6 address to bind to, listening for takers')
+            [CompletionResult]::new('--bind-ip-addr', 'bind-ip-addr', [CompletionResultType]::ParameterName, 'IPv4 or IPv6 address to bind to, listening for takers')
+            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'Port to use; defaults to the native LN port')
+            [CompletionResult]::new('--port', 'port', [CompletionResultType]::ParameterName, 'Port to use; defaults to the native LN port')
+            [CompletionResult]::new('--overlay', 'overlay', [CompletionResultType]::ParameterName, 'Use overlay protocol (http, websocket etc)')
             [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')
@@ -172,6 +192,10 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             break
         }
         'swap-cli;take' {
+            [CompletionResult]::new('--arb-addr', 'arb-addr', [CompletionResultType]::ParameterName, 'Bitcoin address used as destination or refund address')
+            [CompletionResult]::new('--acc-addr', 'acc-addr', [CompletionResultType]::ParameterName, 'Monero address used as destination or refund address')
+            [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'An encoded public offer')
+            [CompletionResult]::new('--offer', 'offer', [CompletionResultType]::ParameterName, 'An encoded public offer')
             [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')
@@ -180,8 +204,8 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--msg-socket', 'msg-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
             [CompletionResult]::new('-x', 'x', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
-            [CompletionResult]::new('-w', 'w', [CompletionResultType]::ParameterName, 'Accept Offer without validation')
-            [CompletionResult]::new('--without-validation', 'without-validation', [CompletionResultType]::ParameterName, 'Accept Offer without validation')
+            [CompletionResult]::new('-w', 'w', [CompletionResultType]::ParameterName, 'Accept the public offer without validation')
+            [CompletionResult]::new('--without-validation', 'without-validation', [CompletionResultType]::ParameterName, 'Accept the public offer without validation')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')

--- a/shell/_swap-cli.ps1
+++ b/shell/_swap-cli.ps1
@@ -34,9 +34,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('listen', 'listen', [CompletionResultType]::ParameterValue, 'Bind to a socket and start listening for incoming LN peer connections, Maker''s action')
-            [CompletionResult]::new('connect', 'connect', [CompletionResultType]::ParameterValue, 'Connect to the remote lightning network peer')
-            [CompletionResult]::new('ping', 'ping', [CompletionResultType]::ParameterValue, 'Ping remote peer (must be already connected)')
             [CompletionResult]::new('info', 'info', [CompletionResultType]::ParameterValue, 'General information about the running node')
             [CompletionResult]::new('peers', 'peers', [CompletionResultType]::ParameterValue, 'Lists existing peer connections')
             [CompletionResult]::new('ls', 'ls', [CompletionResultType]::ParameterValue, 'Lists running swaps')
@@ -44,63 +41,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('take', 'take', [CompletionResultType]::ParameterValue, 'Taker accepts offer and connects to maker''s daemon to start the trade')
             [CompletionResult]::new('progress', 'progress', [CompletionResultType]::ParameterValue, 'Request swap progress report')
             [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
-            break
-        }
-        'swap-cli;listen' {
-            [CompletionResult]::new('-i', 'i', [CompletionResultType]::ParameterName, 'IPv4 or IPv6 address to bind to')
-            [CompletionResult]::new('--ip', 'ip', [CompletionResultType]::ParameterName, 'IPv4 or IPv6 address to bind to')
-            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'Port to use; defaults to the native LN port')
-            [CompletionResult]::new('--port', 'port', [CompletionResultType]::ParameterName, 'Port to use; defaults to the native LN port')
-            [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'Use overlay protocol (http, websocket etc)')
-            [CompletionResult]::new('--overlay', 'overlay', [CompletionResultType]::ParameterName, 'Use overlay protocol (http, websocket etc)')
-            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
-            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
-            [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')
-            [CompletionResult]::new('--tor-proxy', 'tor-proxy', [CompletionResultType]::ParameterName, 'Use Tor')
-            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
-            [CompletionResult]::new('--msg-socket', 'msg-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
-            [CompletionResult]::new('-x', 'x', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
-            [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            break
-        }
-        'swap-cli;connect' {
-            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
-            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
-            [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')
-            [CompletionResult]::new('--tor-proxy', 'tor-proxy', [CompletionResultType]::ParameterName, 'Use Tor')
-            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
-            [CompletionResult]::new('--msg-socket', 'msg-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
-            [CompletionResult]::new('-x', 'x', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
-            [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            break
-        }
-        'swap-cli;ping' {
-            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
-            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
-            [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')
-            [CompletionResult]::new('--tor-proxy', 'tor-proxy', [CompletionResultType]::ParameterName, 'Use Tor')
-            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
-            [CompletionResult]::new('--msg-socket', 'msg-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
-            [CompletionResult]::new('-x', 'x', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
-            [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;info' {

--- a/shell/_swap-cli.ps1
+++ b/shell/_swap-cli.ps1
@@ -95,14 +95,14 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             break
         }
         'swap-cli;make' {
-            [CompletionResult]::new('--arb-addr', 'arb-addr', [CompletionResultType]::ParameterName, 'Bitcoin address used as destination or refund address')
-            [CompletionResult]::new('--acc-addr', 'acc-addr', [CompletionResultType]::ParameterName, 'Monero address used as destination or refund address')
+            [CompletionResult]::new('--btc-addr', 'btc-addr', [CompletionResultType]::ParameterName, 'Bitcoin address used as destination or refund address')
+            [CompletionResult]::new('--xmr-addr', 'xmr-addr', [CompletionResultType]::ParameterName, 'Monero address used as destination or refund address')
             [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Network to use to execute the swap between the chosen blockchains')
             [CompletionResult]::new('--network', 'network', [CompletionResultType]::ParameterName, 'Network to use to execute the swap between the chosen blockchains')
             [CompletionResult]::new('--arb-blockchain', 'arb-blockchain', [CompletionResultType]::ParameterName, 'The chosen arbitrating blockchain')
             [CompletionResult]::new('--acc-blockchain', 'acc-blockchain', [CompletionResultType]::ParameterName, 'The chosen accordant blockchain')
-            [CompletionResult]::new('--arb-amount', 'arb-amount', [CompletionResultType]::ParameterName, 'Amount of arbitrating assets to exchanged')
-            [CompletionResult]::new('--acc-amount', 'acc-amount', [CompletionResultType]::ParameterName, 'Amount of accordant assets to exchanged')
+            [CompletionResult]::new('--btc-amount', 'btc-amount', [CompletionResultType]::ParameterName, 'Amount of arbitrating assets to exchanged')
+            [CompletionResult]::new('--xmr-amount', 'xmr-amount', [CompletionResultType]::ParameterName, 'Amount of accordant assets to exchanged')
             [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'The future maker swap role, either Alice of Bob. This will dictate with asset will be exchanged for which asset. Alice will sell accordant assets for arbitrating ones and Bob the inverse, sell arbitrating assets for accordant ones')
             [CompletionResult]::new('--maker-role', 'maker-role', [CompletionResultType]::ParameterName, 'The future maker swap role, either Alice of Bob. This will dictate with asset will be exchanged for which asset. Alice will sell accordant assets for arbitrating ones and Bob the inverse, sell arbitrating assets for accordant ones')
             [CompletionResult]::new('--cancel-timelock', 'cancel-timelock', [CompletionResultType]::ParameterName, 'The cancel timelock parameter of the arbitrating blockchain')
@@ -132,8 +132,8 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             break
         }
         'swap-cli;take' {
-            [CompletionResult]::new('--arb-addr', 'arb-addr', [CompletionResultType]::ParameterName, 'Bitcoin address used as destination or refund address')
-            [CompletionResult]::new('--acc-addr', 'acc-addr', [CompletionResultType]::ParameterName, 'Monero address used as destination or refund address')
+            [CompletionResult]::new('--btc-addr', 'btc-addr', [CompletionResultType]::ParameterName, 'Bitcoin address used as destination or refund address')
+            [CompletionResult]::new('--xmr-addr', 'xmr-addr', [CompletionResultType]::ParameterName, 'Monero address used as destination or refund address')
             [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'An encoded public offer')
             [CompletionResult]::new('--offer', 'offer', [CompletionResultType]::ParameterName, 'An encoded public offer')
             [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')

--- a/shell/swap-cli.bash
+++ b/shell/swap-cli.bash
@@ -13,17 +13,11 @@ _swap-cli() {
                 cmd="swap__cli"
                 ;;
             
-            connect)
-                cmd+="__connect"
-                ;;
             help)
                 cmd+="__help"
                 ;;
             info)
                 cmd+="__info"
-                ;;
-            listen)
-                cmd+="__listen"
                 ;;
             ls)
                 cmd+="__ls"
@@ -33,9 +27,6 @@ _swap-cli() {
                 ;;
             peers)
                 cmd+="__peers"
-                ;;
-            ping)
-                cmd+="__ping"
                 ;;
             progress)
                 cmd+="__progress"
@@ -50,7 +41,7 @@ _swap-cli() {
 
     case "${cmd}" in
         swap__cli)
-            opts=" -h -V -d -v -T -m -x  --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  listen connect ping info peers ls make take progress help"
+            opts=" -h -V -d -v -T -m -x  --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  info peers ls make take progress help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -97,53 +88,6 @@ _swap-cli() {
             return 0
             ;;
         
-        swap__cli__connect)
-            opts=" -h -V -d -v -T -m -x  --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  <PEER> "
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                
-                --data-dir)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -d)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --tor-proxy)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -T)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --msg-socket)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -m)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --ctl-socket)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -x)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
         swap__cli__help)
             opts=" -h -V -d -v -T -m -x  --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
@@ -199,77 +143,6 @@ _swap-cli() {
             fi
             case "${prev}" in
                 
-                --data-dir)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -d)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --tor-proxy)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -T)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --msg-socket)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -m)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --ctl-socket)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -x)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        swap__cli__listen)
-            opts=" -i -p -o -h -V -d -v -T -m -x  --ip --port --overlay --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  "
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                
-                --ip)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -i)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --port)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -p)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --overlay)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -o)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --data-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -485,53 +358,6 @@ _swap-cli() {
             ;;
         swap__cli__peers)
             opts=" -h -V -d -v -T -m -x  --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  "
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                
-                --data-dir)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -d)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --tor-proxy)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -T)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --msg-socket)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -m)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --ctl-socket)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -x)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        swap__cli__ping)
-            opts=" -h -V -d -v -T -m -x  --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  <PEER> "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/shell/swap-cli.bash
+++ b/shell/swap-cli.bash
@@ -230,18 +230,18 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__make)
-            opts=" -n -r -I -b -p -h -V -d -v -T -m -x  --arb-addr --acc-addr --network --arb-blockchain --acc-blockchain --arb-amount --acc-amount --maker-role --cancel-timelock --punish-timelock --fee-strategy --public-ip-addr --bind-ip-addr --port --overlay --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  "
+            opts=" -n -r -I -b -p -h -V -d -v -T -m -x  --btc-addr --xmr-addr --network --arb-blockchain --acc-blockchain --btc-amount --xmr-amount --maker-role --cancel-timelock --punish-timelock --fee-strategy --public-ip-addr --bind-ip-addr --port --overlay --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 
-                --arb-addr)
+                --btc-addr)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --acc-addr)
+                --xmr-addr)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -261,11 +261,11 @@ _swap-cli() {
                     COMPREPLY=($(compgen -W "Monero" -- "${cur}"))
                     return 0
                     ;;
-                --arb-amount)
+                --btc-amount)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --acc-amount)
+                --xmr-amount)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -451,18 +451,18 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__take)
-            opts=" -o -w -h -V -d -v -T -m -x  --arb-addr --acc-addr --offer --without-validation --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  "
+            opts=" -o -w -h -V -d -v -T -m -x  --btc-addr --xmr-addr --offer --without-validation --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 
-                --arb-addr)
+                --btc-addr)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --acc-addr)
+                --xmr-addr)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/shell/swap-cli.bash
+++ b/shell/swap-cli.bash
@@ -357,13 +357,93 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__make)
-            opts=" -h -V -d -v -T -m -x  --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  <ARBITRATING_ADDR> <ACCORDANT_ADDR> <NETWORK> <ARBITRATING_BLOCKCHAIN> <ACCORDANT_BLOCKCHAIN> <ARBITRATING_AMOUNT> <ACCORDANT_AMOUNT> <MAKER_ROLE> <CANCEL_TIMELOCK> <PUNISH_TIMELOCK> <FEE_STRATEGY> <PUBLIC_IP_ADDR> <BIND_IP_ADDR> <PORT> <OVERLAY> "
+            opts=" -n -r -I -b -p -h -V -d -v -T -m -x  --arb-addr --acc-addr --network --arb-blockchain --acc-blockchain --arb-amount --acc-amount --maker-role --cancel-timelock --punish-timelock --fee-strategy --public-ip-addr --bind-ip-addr --port --overlay --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 
+                --arb-addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --acc-addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --network)
+                    COMPREPLY=($(compgen -W "Testnet Mainnet Local" -- "${cur}"))
+                    return 0
+                    ;;
+                -n)
+                    COMPREPLY=($(compgen -W "Testnet Mainnet Local" -- "${cur}"))
+                    return 0
+                    ;;
+                --arb-blockchain)
+                    COMPREPLY=($(compgen -W "ECDSA" -- "${cur}"))
+                    return 0
+                    ;;
+                --acc-blockchain)
+                    COMPREPLY=($(compgen -W "Monero" -- "${cur}"))
+                    return 0
+                    ;;
+                --arb-amount)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --acc-amount)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --maker-role)
+                    COMPREPLY=($(compgen -W "Alice Bob" -- "${cur}"))
+                    return 0
+                    ;;
+                -r)
+                    COMPREPLY=($(compgen -W "Alice Bob" -- "${cur}"))
+                    return 0
+                    ;;
+                --cancel-timelock)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --punish-timelock)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --fee-strategy)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --public-ip-addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -I)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --bind-ip-addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -b)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --port)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --overlay)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --data-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -545,13 +625,29 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__take)
-            opts=" -w -h -V -d -v -T -m -x  --without-validation --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  <BITCOIN_ADDRESS> <MONERO_ADDRESS> <PUBLIC_OFFER> "
+            opts=" -o -w -h -V -d -v -T -m -x  --arb-addr --acc-addr --offer --without-validation --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 
+                --arb-addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --acc-addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --offer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --data-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -84,32 +84,6 @@ impl Exec for Command {
                 runtime.report_response()?;
             }
 
-            Command::Listen {
-                ip_addr,
-                port,
-                overlay,
-            } => {
-                let socket = RemoteSocketAddr::with_ip_addr(overlay, ip_addr, port);
-                runtime.request(ServiceId::Farcasterd, Request::Listen(socket))?;
-                runtime.report_progress()?;
-            }
-
-            Command::Connect { peer: node_locator } => {
-                let peer = node_locator
-                    .to_node_addr(LIGHTNING_P2P_DEFAULT_PORT)
-                    .ok_or(internet2::presentation::Error::InvalidEndpoint)?;
-
-                runtime.request(ServiceId::Farcasterd, Request::ConnectPeer(peer))?;
-                runtime.report_progress()?;
-            }
-
-            Command::Ping { peer } => {
-                let node_addr = peer
-                    .to_node_addr(LIGHTNING_P2P_DEFAULT_PORT)
-                    .ok_or(internet2::presentation::Error::InvalidEndpoint)?;
-
-                runtime.request(ServiceId::Peer(node_addr), Request::PingPeer)?;
-            }
             Command::Make {
                 network,
                 arbitrating_blockchain,
@@ -214,11 +188,13 @@ impl Exec for Command {
                     runtime.report_progress()?;
                 }
             }
+
             Command::Progress { swapid } => {
                 runtime.request(ServiceId::Farcasterd, Request::ReadProgress(swapid))?;
                 runtime.report_progress()?;
             }
         }
+
         Ok(())
     }
 }

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -12,7 +12,7 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-use bitcoin::Address;
+use bitcoin::Address as BtcAddress;
 use clap::{AppSettings, Clap};
 use monero::Address as XmrAddress;
 use std::net::IpAddr;
@@ -54,12 +54,14 @@ impl Opts {
         self.shared.process();
     }
 }
+
 /// Command-line commands:
 #[derive(Clap, Clone, PartialEq, Eq, Debug, Display)]
 pub enum Command {
     /// Bind to a socket and start listening for incoming LN peer connections,
     /// Maker's action
     #[display("listen<{overlay}://{ip_addr}:{port}>")]
+    #[clap(setting = AppSettings::ColoredHelp)]
     Listen {
         /// IPv4 or IPv6 address to bind to
         #[clap(short, long = "ip", default_value = "0.0.0.0")]
@@ -75,6 +77,7 @@ pub enum Command {
     },
 
     /// Connect to the remote lightning network peer
+    #[clap(setting = AppSettings::ColoredHelp)]
     Connect {
         /// Address of the remote node, in
         /// '<public_key>@<ipv4>|<ipv6>|<onionv2>|<onionv3>[:<port>]' format
@@ -82,6 +85,7 @@ pub enum Command {
     },
 
     /// Ping remote peer (must be already connected)
+    #[clap(setting = AppSettings::ColoredHelp)]
     Ping {
         /// Address of the remote node, in
         /// '<public_key>@<ipv4>|<ipv6>|<onionv2>|<onionv3>[:<port>]' format
@@ -89,6 +93,7 @@ pub enum Command {
     },
 
     /// General information about the running node
+    #[clap(setting = AppSettings::ColoredHelp)]
     Info {
         /// Remote peer address or temporary/permanent/short channel id. If
         /// absent, returns information about the node itself
@@ -96,98 +101,116 @@ pub enum Command {
     },
 
     /// Lists existing peer connections
+    #[clap(setting = AppSettings::ColoredHelp)]
     Peers,
 
     /// Lists running swaps
+    #[clap(setting = AppSettings::ColoredHelp)]
     Ls,
 
-    /// Maker creates offer and start listening. Command used to to print a hex
-    /// representation of the offer that shall be shared with Taker.
-    /// Additionally it spins up the listener awaiting for connection related to
-    /// this offer. Example usage:
-    /// `make tb1q4gj53tuew3e6u4a32kdtle2q72su8te39dpceq
+    /// Maker creates offer and start listening for incoming connections. Command used to to print
+    /// the resulting public offer that shall be shared with Taker. Additionally it spins up the
+    /// listener awaiting for connection related to this offer.
+    ///
+    /// Example usage:
+    ///
+    /// make --arb-addr tb1q4gj53tuew3e6u4a32kdtle2q72su8te39dpceq --acc-addr
     /// 55LTR8KniP4LQGJSPtbYDacR7dz8RBFnsfAKMaMuwUNYX6aQbBcovzDPyrQF9KXF9tVU6Xk3K8no1BywnJX6GvZX8yJsXvt
-    /// Testnet ECDSA Monero
-    /// "0.00001350 BTC" "0.001 XMR" Alice 10 30 "1 satoshi/vByte"
-    /// "127.0.0.1" "0.0.0.0" 9745`
+    /// --arb-amount "0.0000135 BTC" --acc-amount "0.001 XMR"
+    #[clap(setting = AppSettings::ColoredHelp)]
     Make {
-        /// Bitcoin address used as destination or refund address
-        arbitrating_addr: Address,
+        /// Bitcoin address used as destination or refund address.
+        #[clap(long = "arb-addr")]
+        arbitrating_addr: BtcAddress,
 
-        /// Monero address used as destination or refund address
+        /// Monero address used as destination or refund address.
+        #[clap(long = "acc-addr")]
         accordant_addr: XmrAddress,
 
-        /// Network to use
-        #[clap(default_value = "Testnet", possible_values = &["Testnet", "Mainnet", "Local"])]
+        /// Network to use to execute the swap between the chosen blockchains.
+        #[clap(
+            short,
+            long,
+            default_value = "Testnet",
+            possible_values = &["Testnet", "Mainnet", "Local"]
+        )]
         network: Network,
 
-        /// The chosen arbitrating blockchain
-        #[clap(default_value = "ECDSA", possible_values = &["ECDSA"])]
+        /// The chosen arbitrating blockchain.
+        #[clap(long = "arb-blockchain", default_value = "ECDSA", possible_values = &["ECDSA"])]
         arbitrating_blockchain: Bitcoin<SegwitV0>,
 
-        /// The chosen accordant blockchain
-        #[clap(default_value = "Monero", possible_values = &["Monero"])]
+        /// The chosen accordant blockchain.
+        #[clap(long = "acc-blockchain", default_value = "Monero", possible_values = &["Monero"])]
         accordant_blockchain: Monero,
 
-        /// Amount of arbitrating assets to exchanged
-        #[clap(default_value = "0.00001350 BTC")]
+        /// Amount of arbitrating assets to exchanged.
+        #[clap(long = "arb-amount")]
         arbitrating_amount: bitcoin::Amount,
 
-        /// Amount of accordant assets to exchanged
-        #[clap(default_value = "0.001 XMR")]
+        /// Amount of accordant assets to exchanged.
+        #[clap(long = "acc-amount")]
         accordant_amount: monero::Amount,
 
-        /// The future maker swap role
-        #[clap(default_value = "Bob", possible_values = &["Alice", "Bob"])]
+        /// The future maker swap role, either Alice of Bob. This will dictate with asset will be
+        /// exchanged for which asset. Alice will sell accordant assets for arbitrating ones and
+        /// Bob the inverse, sell arbitrating assets for accordant ones.
+        #[clap(short = 'r', long, default_value = "Bob", possible_values = &["Alice", "Bob"])]
         maker_role: SwapRole,
 
-        /// The cancel timelock parameter of the arbitrating blockchain
-        #[clap(default_value = "16")]
+        /// The cancel timelock parameter of the arbitrating blockchain.
+        #[clap(long, default_value = "4")]
         cancel_timelock: CSVTimelock,
 
-        /// The punish timelock parameter of the arbitrating blockchain
-        #[clap(default_value = "64")]
+        /// The punish timelock parameter of the arbitrating blockchain.
+        #[clap(long, default_value = "5")]
         punish_timelock: CSVTimelock,
 
-        /// The chosen fee strategy for the arbitrating transactions
-        #[clap(default_value = "2 satoshi/vByte")]
+        /// The chosen fee strategy for the arbitrating transactions.
+        #[clap(long, default_value = "1 satoshi/vByte")]
         fee_strategy: FeeStrategy<SatPerVByte>,
 
-        /// public IPv4 or IPv6 address for public offer
-        #[clap(default_value = "127.0.0.1")]
+        /// Public IPv4 or IPv6 address present in the public offer allowing taker to connect.
+        #[clap(short = 'I', long, default_value = "127.0.0.1")]
         public_ip_addr: IpAddr,
 
-        /// IPv4 or IPv6 address to bind to
-        #[clap(default_value = "0.0.0.0")]
+        /// IPv4 or IPv6 address to bind to, listening for takers.
+        #[clap(short, long, default_value = "0.0.0.0")]
         bind_ip_addr: IpAddr,
 
         /// Port to use; defaults to the native LN port.
-        #[clap(default_value = "9735")]
+        #[clap(short, long, default_value = "9735")]
         port: u16,
 
-        /// Use overlay protocol (http, websocket etc)
-        #[clap(default_value = "tcp")]
+        /// Use overlay protocol (http, websocket etc).
+        #[clap(long, default_value = "tcp")]
         overlay: FramingProtocol,
     },
-    /// Taker accepts offer and connects to Maker's daemon.
-    Take {
-        /// bitcoin address used as destination or refund address
-        bitcoin_address: Address,
 
-        /// monero address used as destination or refund address
+    /// Taker accepts offer and connects to maker's daemon to start the trade.
+    #[clap(setting = AppSettings::ColoredHelp)]
+    Take {
+        /// Bitcoin address used as destination or refund address.
+        #[clap(long = "arb-addr")]
+        bitcoin_address: BtcAddress,
+
+        /// Monero address used as destination or refund address.
+        #[clap(long = "acc-addr")]
         monero_address: XmrAddress,
 
-        /// Hex encoded offer
+        /// An encoded public offer.
+        #[clap(short = 'o', long = "offer")]
         public_offer: PublicOffer<BtcXmr>,
-        /// Accept Offer without validation
 
+        /// Accept the public offer without validation.
         #[clap(short, long)]
         without_validation: bool,
     },
 
-    /// Request Swap progress report
+    /// Request swap progress report.
+    #[clap(setting = AppSettings::ColoredHelp)]
     Progress {
-        /// SwapId
+        /// The swap id requested.
         swapid: SwapId,
     },
 }

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -81,17 +81,17 @@ pub enum Command {
     ///
     /// Example usage:
     ///
-    /// make --arb-addr tb1q4gj53tuew3e6u4a32kdtle2q72su8te39dpceq --acc-addr
+    /// make --btc-addr tb1q4gj53tuew3e6u4a32kdtle2q72su8te39dpceq --xmr-addr
     /// 55LTR8KniP4LQGJSPtbYDacR7dz8RBFnsfAKMaMuwUNYX6aQbBcovzDPyrQF9KXF9tVU6Xk3K8no1BywnJX6GvZX8yJsXvt
-    /// --arb-amount "0.0000135 BTC" --acc-amount "0.001 XMR"
+    /// --btc-amount "0.0000135 BTC" --xmr-amount "0.001 XMR"
     #[clap(setting = AppSettings::ColoredHelp)]
     Make {
         /// Bitcoin address used as destination or refund address.
-        #[clap(long = "arb-addr")]
+        #[clap(long = "btc-addr")]
         arbitrating_addr: BtcAddress,
 
         /// Monero address used as destination or refund address.
-        #[clap(long = "acc-addr")]
+        #[clap(long = "xmr-addr")]
         accordant_addr: XmrAddress,
 
         /// Network to use to execute the swap between the chosen blockchains.
@@ -112,11 +112,11 @@ pub enum Command {
         accordant_blockchain: Monero,
 
         /// Amount of arbitrating assets to exchanged.
-        #[clap(long = "arb-amount")]
+        #[clap(long = "btc-amount")]
         arbitrating_amount: bitcoin::Amount,
 
         /// Amount of accordant assets to exchanged.
-        #[clap(long = "acc-amount")]
+        #[clap(long = "xmr-amount")]
         accordant_amount: monero::Amount,
 
         /// The future maker swap role, either Alice of Bob. This will dictate with asset will be
@@ -158,11 +158,11 @@ pub enum Command {
     #[clap(setting = AppSettings::ColoredHelp)]
     Take {
         /// Bitcoin address used as destination or refund address.
-        #[clap(long = "arb-addr")]
+        #[clap(long = "btc-addr")]
         bitcoin_address: BtcAddress,
 
         /// Monero address used as destination or refund address.
-        #[clap(long = "acc-addr")]
+        #[clap(long = "xmr-addr")]
         monero_address: XmrAddress,
 
         /// An encoded public offer.

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -18,7 +18,7 @@ use monero::Address as XmrAddress;
 use std::net::IpAddr;
 use std::str::FromStr;
 
-use internet2::{FramingProtocol, PartialNodeAddr};
+use internet2::FramingProtocol;
 
 use farcaster_core::{
     bitcoin::{fee::SatPerVByte, segwitv0::SegwitV0, timelock::CSVTimelock, Bitcoin},
@@ -58,41 +58,8 @@ impl Opts {
 /// Command-line commands:
 #[derive(Clap, Clone, PartialEq, Eq, Debug, Display)]
 pub enum Command {
-    /// Bind to a socket and start listening for incoming LN peer connections,
-    /// Maker's action
-    #[display("listen<{overlay}://{ip_addr}:{port}>")]
-    #[clap(setting = AppSettings::ColoredHelp)]
-    Listen {
-        /// IPv4 or IPv6 address to bind to
-        #[clap(short, long = "ip", default_value = "0.0.0.0")]
-        ip_addr: IpAddr,
-
-        /// Port to use; defaults to the native LN port.
-        #[clap(short, long, default_value = "9735")]
-        port: u16,
-
-        /// Use overlay protocol (http, websocket etc)
-        #[clap(short, long, default_value = "tcp")]
-        overlay: FramingProtocol,
-    },
-
-    /// Connect to the remote lightning network peer
-    #[clap(setting = AppSettings::ColoredHelp)]
-    Connect {
-        /// Address of the remote node, in
-        /// '<public_key>@<ipv4>|<ipv6>|<onionv2>|<onionv3>[:<port>]' format
-        peer: PartialNodeAddr,
-    },
-
-    /// Ping remote peer (must be already connected)
-    #[clap(setting = AppSettings::ColoredHelp)]
-    Ping {
-        /// Address of the remote node, in
-        /// '<public_key>@<ipv4>|<ipv6>|<onionv2>|<onionv3>[:<port>]' format
-        peer: PartialNodeAddr,
-    },
-
     /// General information about the running node
+    #[display("info<{subject:?}>")]
     #[clap(setting = AppSettings::ColoredHelp)]
     Info {
         /// Remote peer address or temporary/permanent/short channel id. If
@@ -208,6 +175,7 @@ pub enum Command {
     },
 
     /// Request swap progress report.
+    #[display("progress<{swapid}>")]
     #[clap(setting = AppSettings::ColoredHelp)]
     Progress {
         /// The swap id requested.

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,7 +109,7 @@ pub fn parse_config(path: &str) -> Result<Config, Error> {
         settings.merge(config::File::with_name(config_file).required(true))?;
         settings.try_into::<Config>().map_err(Into::into)
     } else {
-        info!("No configuration file found, generate default config");
+        info!("No configuration file found, generating default config");
         let config = Config::default();
         let mut file = File::create(path)?;
         file.write_all(toml::to_vec(&config).unwrap().as_ref())?;

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -513,6 +513,7 @@ impl Runtime {
                     self.spawning_services.remove(&source);
                 }
             }
+
             Request::SwapSuccess(success) => {
                 let swapid = get_swap_id(&source)?;
                 self.clean_up_after_swap(&swapid, senders)?;
@@ -526,6 +527,7 @@ impl Runtime {
                 self.stats.success_rate();
                 senders.send_to(ServiceBus::Ctl, self.identity(), source, request)?;
             }
+
             Request::LaunchSwap(LaunchSwap {
                 maker_node_id,
                 local_trade_role,
@@ -588,6 +590,7 @@ impl Runtime {
                     return Err(Error::Farcaster(msg));
                 }
             }
+
             Request::Keys(Keys(sk, pk, id)) if self.pending_requests.contains_key(&id) => {
                 trace!("received peerd keys");
                 if let Some((request, source)) = self.pending_requests.remove(&id) {
@@ -612,6 +615,7 @@ impl Runtime {
                     error!("Received unexpected peer keys");
                 }
             }
+
             Request::GetInfo => {
                 senders.send_to(
                     ServiceBus::Ctl,
@@ -643,6 +647,7 @@ impl Runtime {
                     Request::PeerList(self.connections.iter().cloned().collect()),
                 )?;
             }
+
             Request::ListSwaps => {
                 senders.send_to(
                     ServiceBus::Ctl,
@@ -652,84 +657,6 @@ impl Runtime {
                 )?;
             }
 
-            // Request::Listen(addr) => {
-            //     let addr_str = addr.addr();
-            //     if self.listens.contains(&addr) {
-            //         let msg = format!("Listener on {} already exists, ignoring request", addr);
-            //         warn!("{}", msg.err());
-            //         report_to.push((
-            //             Some(source.clone()),
-            //             Request::Failure(Failure { code: 1, info: msg }),
-            //         ));
-            //     } else {
-            //         let (_, sk) = self.peerd_keys()?;
-            //         let resp = self.listen(&addr, sk);
-            //         self.listens.insert(addr);
-            //         info!(
-            //             "{} for incoming LN peer connections on {}",
-            //             "Starting listener".bright_blue_bold(),
-            //             addr_str
-            //         );
-            //         match resp {
-            //             Ok(_) => info!(
-            //                 "Connection daemon {} for incoming LN peer connections on {}",
-            //                 "listens".bright_green_bold(),
-            //                 addr_str
-            //             ),
-            //             Err(ref err) => error!("{}", err.err()),
-            //         }
-
-            //         senders.send_to(
-            //             ServiceBus::Ctl,
-            //             ServiceId::Farcasterd,
-            //             source.clone(),
-            //             resp.into_progress_or_failure(),
-            //         )?;
-            //         report_to.push((
-            //             Some(source.clone()),
-            //             Request::Success(OptionDetails::with(format!(
-            //                 "Node {} listens for connections on {}",
-            //                 self.node_ids()[0], // FIXME
-            //                 addr
-            //             ))),
-            //         ));
-            //     }
-            // }
-
-            // Request::ConnectPeer(addr) => {
-            //     info!(
-            //         "{} to remote peer {}",
-            //         "Connecting".bright_blue_bold(),
-            //         addr.bright_blue_italic()
-            //     );
-            //     let resp = self.connect_peer(source.clone(), &addr);
-            //     match resp {
-            //         Ok(_) => {}
-            //         Err(ref err) => error!("{}", err.err()),
-            //     }
-            //     report_to.push((Some(source.clone()), resp.into_progress_or_failure()));
-            // }
-
-            // Request::OpenSwapWith(request::CreateSwap {
-            //     swap_req,
-            //     peerd,
-            //     report_to,
-            // }) => {
-            //     info!(
-            //         "{} by request from {}",
-            //         "Creating channel".bright_blue_bold(),
-            //         source.bright_blue_italic()
-            //     );
-            //     let resp = self.create_swap(peerd, report_to, swap_req,
-            // false);     match resp {
-            //         Ok(_) => {}
-            //         Err(ref err) => error!("{}", err.err()),
-            //     }
-            //     notify_cli.push(Some((
-            //         Some(source.clone()),
-            //         resp.into_progress_or_failure(),
-            //     ));
-            // }
             Request::MakeOffer(request::ProtoPublicOffer {
                 offer,
                 public_addr,
@@ -916,6 +843,7 @@ impl Runtime {
                     }
                 }
             }
+
             Request::Progress(..) | Request::Success(..) | Request::Failure(..) => {
                 if !self.progress.contains_key(&source) {
                     self.progress.insert(source.clone(), none!());
@@ -923,6 +851,7 @@ impl Runtime {
                 let queue = self.progress.get_mut(&source).expect("checked/added above");
                 queue.push_back(request);
             }
+
             Request::ReadProgress(swapid) => {
                 if let Some(queue) = self.progress.get_mut(&ServiceId::Swap(swapid)) {
                     let n = queue.len();

--- a/tests/functional-swap.rs
+++ b/tests/functional-swap.rs
@@ -455,9 +455,9 @@ fn make_offer_args(
         .into_iter()
         .chain(vec![
             "make".to_string(),
-            "--arb-addr".to_string(),
+            "--btc-addr".to_string(),
             btc_addr,
-            "--acc-addr".to_string(),
+            "--xmr-addr".to_string(),
             xmr_addr,
             "--network".to_string(),
             "Local".to_string(),
@@ -465,9 +465,9 @@ fn make_offer_args(
             "ECDSA".to_string(),
             "--acc-blockchain".to_string(),
             "Monero".to_string(),
-            "--arb-amount".to_string(),
+            "--btc-amount".to_string(),
             btc_amount,
-            "--acc-amount".to_string(),
+            "--xmr-amount".to_string(),
             xmr_amount,
             "--maker-role".to_string(),
             role,
@@ -497,9 +497,9 @@ fn take_offer_args(
         .into_iter()
         .chain(vec![
             "take".to_string(),
-            "--arb-addr".to_string(),
+            "--btc-addr".to_string(),
             btc_addr,
-            "--acc-addr".to_string(),
+            "--xmr-addr".to_string(),
             xmr_addr,
             "--offer".to_string(),
             offer,

--- a/tests/functional-swap.rs
+++ b/tests/functional-swap.rs
@@ -455,19 +455,33 @@ fn make_offer_args(
         .into_iter()
         .chain(vec![
             "make".to_string(),
+            "--arb-addr".to_string(),
             btc_addr,
+            "--acc-addr".to_string(),
             xmr_addr,
+            "--network".to_string(),
             "Local".to_string(),
+            "--arb-blockchain".to_string(),
             "ECDSA".to_string(),
+            "--acc-blockchain".to_string(),
             "Monero".to_string(),
+            "--arb-amount".to_string(),
             btc_amount,
+            "--acc-amount".to_string(),
             xmr_amount,
+            "--maker-role".to_string(),
             role,
+            "--cancel-timelock".to_string(),
             "10".to_string(),
+            "--punish-timelock".to_string(),
             "30".to_string(),
+            "--fee-strategy".to_string(),
             "1 satoshi/vByte".to_string(),
+            "--public-ip-addr".to_string(),
             "127.0.0.1".to_string(),
+            "--bind-ip-addr".to_string(),
             "0.0.0.0".to_string(),
+            "--port".to_string(),
             "9376".to_string(),
         ])
         .collect()
@@ -483,8 +497,11 @@ fn take_offer_args(
         .into_iter()
         .chain(vec![
             "take".to_string(),
+            "--arb-addr".to_string(),
             btc_addr,
+            "--acc-addr".to_string(),
             xmr_addr,
+            "--offer".to_string(),
             offer,
             "--without-validation".to_string(),
         ])

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -45,19 +45,23 @@ fn spawn_swap() {
     cmd.args(data_dir_maker.clone());
     cmd.args(vec![
                 "make",
+                "--arb-addr",
                 "tb1q4gj53tuew3e6u4a32kdtle2q72su8te39dpceq",
+                "--acc-addr",
                 "55LTR8KniP4LQGJSPtbYDacR7dz8RBFnsfAKMaMuwUNYX6aQbBcovzDPyrQF9KXF9tVU6Xk3K8no1BywnJX6GvZX8yJsXvt",
-                "Testnet",
-                "ECDSA",
-                "Monero",
+                "--arb-amount",
                 "101 BTC",
+                "--acc-amount",
                 "100 XMR",
+                "-r",
                 "Alice",
+                "--cancel-timelock",
                 "10",
+                "--punish-timelock",
                 "30",
+                "--fee-strategy",
                 "1 satoshi/vByte",
-                "127.0.0.1",
-                "0.0.0.0",
+                "-p",
                 "9376",
             ]);
 

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -45,13 +45,13 @@ fn spawn_swap() {
     cmd.args(data_dir_maker.clone());
     cmd.args(vec![
                 "make",
-                "--arb-addr",
+                "--btc-addr",
                 "tb1q4gj53tuew3e6u4a32kdtle2q72su8te39dpceq",
-                "--acc-addr",
+                "--xmr-addr",
                 "55LTR8KniP4LQGJSPtbYDacR7dz8RBFnsfAKMaMuwUNYX6aQbBcovzDPyrQF9KXF9tVU6Xk3K8no1BywnJX6GvZX8yJsXvt",
-                "--arb-amount",
+                "--btc-amount",
                 "101 BTC",
-                "--acc-amount",
+                "--xmr-amount",
                 "100 XMR",
                 "-r",
                 "Alice",


### PR DESCRIPTION
Fix #262, fix #216

Change swap-cli make|take command to use named arguments an allow better usage of default values (some have been updated). Remove default values for exchanged amounts.

Update overall documentation for docker with new config and new command line arguments.