### PR TITLE
Clippy warns and msrv

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,2 @@
+msrv = "1.55.0"
 enum-variant-size-threshold = 4000

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -47,4 +47,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all --all-targets --all-features -- -D warnings
+          args: --all --all-targets --all-features


### PR DESCRIPTION
Relax clippy validation because of Rust 1.57 and add msrv in clippy for future potential breaking rules with our current minimal stable Rust version 1.55.