### PR TITLE
Use GH action services for functional tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,7 @@ jobs:
         run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features --no-fail-fast --verbose -- --ignored --test-threads=1
         env:
           BITCOIN_COOKIE: /data/regtest/.cookie
-          BITCOIN_HOST: bitcoind
+          BITCOIN_HOST: bitcoin-core
           ELECTRS_HOST: electrs
           MONERO_DAEMON_HOST: monerod
           MONERO_WALLET_HOST_1: monero-wallet-rpc-1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,66 +47,94 @@ jobs:
           file: ${{ steps.coverage.outputs.report }}
           directory: ./coverage/reports/
 
-  functional-syncer-test:
-    name: Functional syncer tests
+  functional-test:
+    name: Functional tests
+    timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
-        test: [
-          bitcoin,
-          monero,
-        ]
+        test: [bitcoin, monero, swap]
+        include:
+          - test: swap
+            logs: true
     runs-on: ubuntu-latest
+    container:
+      image: rust:slim-buster
+      volumes:
+        - bitcoind-data:/data
+
+    services:
+      bitcoin-core:
+        image: ghcr.io/farcaster-project/containers/bitcoin-core:0.21.1
+        env:
+          NETWORK: regtest
+          RPC_PORT: 18443
+          FALLBACKFEE: "0.00001"
+        volumes:
+          - bitcoind-data:/data
+        ports:
+          - 18443:18443
+          - 18444:18444
+      electrs:
+        image: ghcr.io/farcaster-project/containers/electrs:0.8.11
+        env:
+          NETWORK: regtest
+          DAEMON_RPC_ADDR: bitcoin-core:18443
+          ELECTRUM_RPC_PORT: 50001
+        volumes:
+          - bitcoind-data:/data
+        ports:
+          - 50001:50001
+      monerod:
+        image: ghcr.io/farcaster-project/containers/monerod:0.17.2.3
+        env:
+          NETWORK: regtest
+          MONEROD_RPC_PORT: 18081
+          OFFLINE: --offline
+          DIFFICULTY: 1
+        ports:
+          - 18081:18081
+      monero-wallet-rpc-1:
+        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3
+        env:
+          MONEROD_ADDRESS: monerod:18081
+        ports:
+          - 18083:18083
+      monero-wallet-rpc-2:
+        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3
+        env:
+          MONEROD_ADDRESS: monerod:18081
+        ports:
+          - 18084:18083
+      monero-wallet-rpc-3:
+        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3
+        env:
+          MONEROD_ADDRESS: monerod:18081
+        ports:
+          - 18085:18083
+
     steps:
       - uses: actions/checkout@v2
+
+      - name: Refresh cache and add apt-utils
+        run: apt-get update -y && apt-get install -y --no-install-recommends apt-utils
       - name: Install dependencies
-        run: sudo apt-get install -y cmake libzmq3-dev docker-compose
-
-      - name: Compose docker services
-        run: cd tests && docker-compose up -d
-
-      - name: Install Rust stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
-      - name: Correct permissions
-        run: sudo chown -R $USER tests
+        run: DEBIAN_FRONTEND=noninteractive apt-get install -y libsqlite3-dev libssl-dev libzmq3-dev pkg-config build-essential cmake
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v1.3.0
         with:
           key: test-${{ matrix.test }}
 
-      - name: Cargo test
-        uses: actions-rs/cargo@v1
+      - name: Cargo swap test
+        run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features --no-fail-fast --verbose -- --ignored --test-threads=1
+        env:
+          BITCOIN_DATA_DIR: /data/regtests/.cookie
+
+      - name: Archive farcasterd logs
+        uses: actions/upload-artifact@v2
+        if: ${{ matrix.logs }}
         with:
-          command: test
-          args: ${{ matrix.test }} --workspace --all-targets --all-features --no-fail-fast --verbose -- --ignored --test-threads=1
-
-  functional-swap-test:
-    name: Functional swap tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: sudo apt-get install -y cmake libzmq3-dev docker-compose
-
-      - name: Compose docker services
-        run: cd tests && docker-compose up -d
-
-      - name: Install Rust stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
-      - name: Correct permissions
-        run: sudo chown -R $USER tests
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v1.3.0
-
-      - name: Cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: swap_test --workspace --all-targets --all-features --no-fail-fast --verbose -- --ignored --test-threads=1
+          name: faracsterd-logs
+          path: |
+            tests/*.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,9 +72,6 @@ jobs:
           FALLBACKFEE: "0.00001"
         volumes:
           - bitcoind-data:/data
-        ports:
-          - 18443:18443
-          - 18444:18444
       electrs:
         image: ghcr.io/farcaster-project/containers/electrs:0.8.11
         env:
@@ -83,8 +80,6 @@ jobs:
           ELECTRUM_RPC_PORT: 50001
         volumes:
           - bitcoind-data:/data
-        ports:
-          - 50001:50001
       monerod:
         image: ghcr.io/farcaster-project/containers/monerod:0.17.2.3
         env:
@@ -92,26 +87,21 @@ jobs:
           MONEROD_RPC_PORT: 18081
           OFFLINE: --offline
           DIFFICULTY: 1
-        ports:
-          - 18081:18081
       monero-wallet-rpc-1:
         image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3
         env:
           MONEROD_ADDRESS: monerod:18081
-        ports:
-          - 18083:18083
+          WALLET_RPC_PORT: 18083
       monero-wallet-rpc-2:
         image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3
         env:
           MONEROD_ADDRESS: monerod:18081
-        ports:
-          - 18084:18083
+          WALLET_RPC_PORT: 18084
       monero-wallet-rpc-3:
         image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3
         env:
           MONEROD_ADDRESS: monerod:18081
-        ports:
-          - 18085:18083
+          WALLET_RPC_PORT: 18085
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
 
   functional-test:
     name: Functional tests
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Cargo swap test
         run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features --no-fail-fast --verbose -- --ignored --test-threads=1
         env:
-          BITCOIN_DATA_DIR: /data/regtests/.cookie
+          BITCOIN_COOKIE: /data/regtest/.cookie
 
       - name: Archive farcasterd logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
         with:
           key: test-${{ matrix.test }}
 
-      - name: Cargo swap test
+      - name: Cargo functional test
         run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features --no-fail-fast --verbose -- --ignored --test-threads=1
         env:
           BITCOIN_COOKIE: /data/regtest/.cookie

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,11 @@ jobs:
         run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features --no-fail-fast --verbose -- --ignored --test-threads=1
         env:
           BITCOIN_COOKIE: /data/regtest/.cookie
+          BITCOIN_HOST: bitcoind
+          ELECTRS_HOST: electrs
+          MONERO_DAEMON_HOST: monerod
+          MONERO_WALLET_HOST_1: monero-wallet-rpc-1
+          MONERO_WALLET_HOST_2: monero-wallet-rpc-2
 
       - name: Archive farcasterd logs
         uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,7 @@
 
 # Functional tests: generated folders
 /tests/data_dir
-/tests/.farcaster_node_0
-/tests/.farcaster_node_1
+/tests/.farcaster_1
+/tests/farcasterd_1.log
+/tests/.farcaster_2
+/tests/farcasterd_2.log

--- a/tests/.farcasterd_1.ci.toml
+++ b/tests/.farcasterd_1.ci.toml
@@ -1,0 +1,5 @@
+[syncers.local]
+electrum_server = "tcp://electrs:50001"
+monero_daemon = "http://monerod:18081"
+monero_rpc_wallet = "http://monero-wallet-rpc-2:18084"
+

--- a/tests/.farcasterd_2.ci.toml
+++ b/tests/.farcasterd_2.ci.toml
@@ -1,0 +1,5 @@
+[syncers.local]
+electrum_server = "tcp://electrs:50001"
+monero_daemon = "http://monerod:18081"
+monero_rpc_wallet = "http://monero-wallet-rpc-3:18085"
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,11 +1,28 @@
 # Running functional tests
 
-Run the tests with:
+Start needed containers for supporting the tests with:
 
 ```
 docker-compose up -d
 sudo chown -R $USER data_dir
-cargo test --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1
+```
+
+Run `bitcoin` tests:
+
+```
+cargo test bitcoin --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1
+```
+
+Run `monero` tests:
+
+```
+cargo test monero --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1
+```
+
+Run `swap` tests:
+
+```
+cargo test swap --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1
 ```
 
 ## Steps

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -13,7 +13,10 @@ services:
             - 18444:18444
     electrs:
         image: ghcr.io/farcaster-project/containers/electrs:0.8.11
-        command: "/usr/bin/electrs -vv --network regtest --daemon-dir /data --daemon-rpc-addr bitcoin-core:18443 --electrum-rpc-addr 0.0.0.0:50001 --txid-limit 100000"
+        environment:
+            NETWORK: regtest
+            DAEMON_RPC_ADDR: bitcoin-core:18443
+            ELECTRUM_RPC_PORT: 50001
         depends_on:
             - "bitcoin-core"
         volumes:

--- a/tests/functional-swap.rs
+++ b/tests/functional-swap.rs
@@ -14,6 +14,8 @@ use sysinfo::{ProcessExt, System, SystemExt};
 use tokio::sync::Mutex;
 
 use std::collections::HashMap;
+use std::env;
+use std::path::PathBuf;
 use std::str;
 use std::str::FromStr;
 
@@ -24,7 +26,7 @@ const ALLOWED_RETRIES: u32 = 120;
 #[tokio::test]
 #[timeout(600000)]
 #[ignore]
-async fn swap_test_bob_maker() {
+async fn swap_bob_maker() {
     let execution_mutex = Arc::new(Mutex::new(0));
     let bitcoin_rpc = Arc::new(bitcoin_setup());
     let (monero_regtest, monero_wallet) = monero_setup().await;
@@ -62,7 +64,7 @@ async fn swap_test_bob_maker() {
 #[tokio::test]
 #[timeout(600000)]
 #[ignore]
-async fn swap_test_alice_maker() {
+async fn swap_alice_maker() {
     let execution_mutex = Arc::new(Mutex::new(0));
     let bitcoin_rpc = Arc::new(bitcoin_setup());
     let (monero_regtest, monero_wallet) = monero_setup().await;
@@ -100,7 +102,7 @@ async fn swap_test_alice_maker() {
 #[tokio::test]
 #[timeout(600000)]
 #[ignore]
-async fn swap_test_parallel() {
+async fn swap_parallel() {
     let execution_mutex = Arc::new(Mutex::new(0));
     let bitcoin_rpc = Arc::new(bitcoin_setup());
     let (monero_regtest, monero_wallet) = monero_setup().await;
@@ -207,21 +209,19 @@ async fn swap_test_parallel() {
 
 async fn setup_farcaster_clients() -> (process::Child, Vec<String>, process::Child, Vec<String>) {
     // data directories
-    let data_dir_maker = vec!["-d".to_string(), "tests/.farcaster_node_0".to_string()];
-    let data_dir_taker = vec!["-d".to_string(), "tests/.farcaster_node_1".to_string()];
+    let data_dir_maker = vec!["-d".to_string(), "tests/.farcaster_1".to_string()];
+    let data_dir_taker = vec!["-d".to_string(), "tests/.farcaster_2".to_string()];
 
-    let server_args_maker = vec!["-vv", "--config", "tests/.farcasterd_1.toml"]
-        .iter()
-        .map(|i| i.to_string())
-        .collect();
-
-    let server_args_taker = vec!["-vv", "--config", "tests/.farcasterd_2.toml"]
-        .iter()
-        .map(|i| i.to_string())
-        .collect();
-
-    let farcasterd_maker_args = farcasterd_args(data_dir_maker.clone(), server_args_maker);
-    let farcasterd_taker_args = farcasterd_args(data_dir_taker.clone(), server_args_taker);
+    let farcasterd_maker_args = farcasterd_args(
+        data_dir_maker.clone(),
+        vec!["-vv", "--config", "tests/.farcasterd_1.toml"],
+        vec!["2>&1", "|", "tee", "-a", "tests/farcasterd_1.log"],
+    );
+    let farcasterd_taker_args = farcasterd_args(
+        data_dir_taker.clone(),
+        vec!["-vv", "--config", "tests/.farcasterd_2.toml"],
+        vec!["2>&1", "|", "tee", "-a", "tests/farcasterd_2.log"],
+    );
 
     let farcasterd_maker = launch("../farcasterd", farcasterd_maker_args).unwrap();
     let farcasterd_taker = launch("../farcasterd", farcasterd_taker_args).unwrap();
@@ -439,8 +439,12 @@ fn info_args(data_dir: Vec<String>) -> Vec<String> {
         .collect()
 }
 
-fn farcasterd_args(data_dir: Vec<String>, server_args: Vec<String>) -> Vec<String> {
-    data_dir.into_iter().chain(server_args).collect()
+fn farcasterd_args(data_dir: Vec<String>, server_args: Vec<&str>, extra: Vec<&str>) -> Vec<String> {
+    data_dir
+        .into_iter()
+        .chain(server_args.into_iter().map(|s| s.into()))
+        .chain(extra.into_iter().map(|s| s.into()))
+        .collect()
 }
 
 fn make_offer_args(
@@ -636,7 +640,8 @@ async fn retry_until_finish_state_transition(
 }
 
 fn bitcoin_setup() -> bitcoincore_rpc::Client {
-    let path = std::path::PathBuf::from_str("tests/data_dir/regtest/.cookie").unwrap();
+    let cookie = env::var("BITCOIN_DATA_DIR").unwrap_or("tests/data_dir/regtest/.cookie".into());
+    let path = PathBuf::from_str(&cookie).unwrap();
     let bitcoin_rpc = Client::new("http://localhost:18443", Auth::CookieFile(path)).unwrap();
 
     // make sure a wallet is created and loaded
@@ -755,32 +760,30 @@ pub fn run(
     Ok((stdout, stderr))
 }
 
-pub fn launch(
-    name: &str,
-    args: impl IntoIterator<Item = impl AsRef<OsStr>>,
-) -> io::Result<process::Child> {
+pub fn launch(name: &str, args: impl IntoIterator<Item = String>) -> io::Result<process::Child> {
     let mut bin_path = std::env::current_exe().map_err(|err| {
         error!("Unable to detect binary directory: {}", err);
         err
     })?;
     bin_path.pop();
-
     bin_path.push(name);
-    #[cfg(target_os = "windows")]
-    bin_path.set_extension("exe");
 
-    debug!(
+    println!(
         "Launching {} as a separate process using `{}` as binary",
         name,
         bin_path.to_string_lossy()
     );
 
-    let mut cmd = process::Command::new(bin_path);
+    let cmdargs = args.into_iter().collect::<Vec<String>>().join(" ");
+    println!("Command arguments: \"{}\"", cmdargs);
 
-    cmd.args(args);
+    let mut shell = process::Command::new("sh");
+    shell
+        .arg("-c")
+        .arg(format!("{} {}", bin_path.to_string_lossy(), cmdargs));
 
-    trace!("Executing `{:?}`", cmd);
-    cmd.spawn().map_err(|err| {
+    println!("Executing `{:?}`", shell);
+    shell.spawn().map_err(|err| {
         error!("Error launching {}: {}", name, err);
         err
     })

--- a/tests/functional-swap.rs
+++ b/tests/functional-swap.rs
@@ -640,7 +640,7 @@ async fn retry_until_finish_state_transition(
 }
 
 fn bitcoin_setup() -> bitcoincore_rpc::Client {
-    let cookie = env::var("BITCOIN_DATA_DIR").unwrap_or("tests/data_dir/regtest/.cookie".into());
+    let cookie = env::var("BITCOIN_COOKIE").unwrap_or("tests/data_dir/regtest/.cookie".into());
     let path = PathBuf::from_str(&cookie).unwrap();
     let bitcoin_rpc = Client::new("http://localhost:18443", Auth::CookieFile(path)).unwrap();
 

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -27,6 +27,8 @@ use ntest::timeout;
 
 use bitcoin::hashes::Hash;
 use internet2::{CreateUnmarshaller, Unmarshall};
+use std::env;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use farcaster_core::blockchain::Network;
@@ -869,7 +871,8 @@ fn find_coinbase_transaction_amount(txs: Vec<bitcoin::Transaction>) -> u64 {
 }
 
 fn bitcoin_setup() -> bitcoincore_rpc::Client {
-    let path = std::path::PathBuf::from_str("tests/data_dir/regtest/.cookie").unwrap();
+    let cookie = env::var("BITCOIN_DATA_DIR").unwrap_or("tests/data_dir/regtest/.cookie".into());
+    let path = PathBuf::from_str(&cookie).unwrap();
     let bitcoin_rpc = Client::new("http://localhost:18443", Auth::CookieFile(path)).unwrap();
 
     // make sure a wallet is created and loaded

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -1575,12 +1575,13 @@ fn create_monero_syncer(socket_name: &str) -> (std::sync::mpsc::Sender<SyncerdTa
     rx_event.bind(&addr).unwrap();
     let mut syncer = MoneroSyncer::new();
 
+    let dhost = env::var("MONERO_DAEMON_HOST").unwrap_or("localhost".into());
     let whost = env::var("MONERO_WALLET_HOST_2").unwrap_or("localhost".into());
     let opts = Opts::parse_from(vec!["syncerd"].into_iter().chain(vec![
         "--coin",
         "Monero",
         "--monero-daemon",
-        "http://localhost:18081",
+        &format!("http://{}:18081", dhost),
         "--monero-rpc-wallet",
         &format!("http://{}:18084", whost),
     ]));

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -830,11 +830,12 @@ fn create_bitcoin_syncer(
     rx_event.bind(&addr).unwrap();
     let mut syncer = BitcoinSyncer::new();
 
+    let ehost = env::var("ELECTRS_HOST").unwrap_or("localhost".into());
     let opts = Opts::parse_from(vec!["syncerd"].into_iter().chain(vec![
         "--coin",
         "Bitcoin",
         "--electrum-server",
-        "tcp://localhost:50001",
+        &format!("tcp://{}:50001", ehost),
     ]));
 
     syncer
@@ -873,7 +874,9 @@ fn find_coinbase_transaction_amount(txs: Vec<bitcoin::Transaction>) -> u64 {
 fn bitcoin_setup() -> bitcoincore_rpc::Client {
     let cookie = env::var("BITCOIN_COOKIE").unwrap_or("tests/data_dir/regtest/.cookie".into());
     let path = PathBuf::from_str(&cookie).unwrap();
-    let bitcoin_rpc = Client::new("http://localhost:18443", Auth::CookieFile(path)).unwrap();
+    let host = env::var("BITCOIN_HOST").unwrap_or("localhost".into());
+    let bitcoin_rpc =
+        Client::new(&format!("http://{}:18443", host), Auth::CookieFile(path)).unwrap();
 
     // make sure a wallet is created and loaded
     if bitcoin_rpc
@@ -1545,10 +1548,12 @@ async fn monero_syncer_broadcast_tx_test() {
 }
 
 async fn setup_monero() -> (monero_rpc::RegtestDaemonClient, monero_rpc::WalletClient) {
-    let daemon_client = monero_rpc::RpcClient::new("http://localhost:18081".to_string());
+    let dhost = env::var("MONERO_DAEMON_HOST").unwrap_or("localhost".into());
+    let daemon_client = monero_rpc::RpcClient::new(format!("http://{}:18081", dhost));
     let daemon = daemon_client.daemon();
     let regtest = daemon.regtest();
-    let wallet_client = monero_rpc::RpcClient::new("http://localhost:18083".to_string());
+    let whost = env::var("MONERO_WALLET_HOST_1").unwrap_or("localhost".into());
+    let wallet_client = monero_rpc::RpcClient::new(format!("http://{}:18083", whost));
     let wallet = wallet_client.wallet();
     // Ignore if fails, maybe the wallet already exists
     let _ = wallet
@@ -1570,13 +1575,14 @@ fn create_monero_syncer(socket_name: &str) -> (std::sync::mpsc::Sender<SyncerdTa
     rx_event.bind(&addr).unwrap();
     let mut syncer = MoneroSyncer::new();
 
+    let whost = env::var("MONERO_WALLET_HOST_2").unwrap_or("localhost".into());
     let opts = Opts::parse_from(vec!["syncerd"].into_iter().chain(vec![
         "--coin",
         "Monero",
         "--monero-daemon",
         "http://localhost:18081",
         "--monero-rpc-wallet",
-        "http://localhost:18084",
+        &format!("http://{}:18084", whost),
     ]));
 
     syncer

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -871,7 +871,7 @@ fn find_coinbase_transaction_amount(txs: Vec<bitcoin::Transaction>) -> u64 {
 }
 
 fn bitcoin_setup() -> bitcoincore_rpc::Client {
-    let cookie = env::var("BITCOIN_DATA_DIR").unwrap_or("tests/data_dir/regtest/.cookie".into());
+    let cookie = env::var("BITCOIN_COOKIE").unwrap_or("tests/data_dir/regtest/.cookie".into());
     let path = PathBuf::from_str(&cookie).unwrap();
     let bitcoin_rpc = Client::new("http://localhost:18443", Auth::CookieFile(path)).unwrap();
 


### PR DESCRIPTION
- Use services instead of docker-compose (compose is still use and documented for local tests)
- Use one matrix for all three tests: `bitcoin`, `monero`, and `swap`
- Log output of farcaster daemon for `swap` tests and upload the artifact