### PR TITLE
Core update and Display/FromStr improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,9 +904,9 @@ checksum = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 
 [[package]]
 name = "farcaster_core"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd591f5878444ae926fbffca99e8dbeb621abc636541d2051093fe89e6076a2"
+checksum = "e47646480ef8724d6e7e1e2a3d5af7329c79380f771569ca6c7a13e6322616ec"
 dependencies = [
  "amplify",
  "base58-monero",

--- a/README.md
+++ b/README.md
@@ -132,14 +132,12 @@ To create an offer and spawn a listening `peerd` accepting incoming connections,
 swap-cli make --btc-addr tb1q935eq5fl2a3ajpqp0e3d7z36g7vctcgv05f5lf\
     --xmr-addr 54EYTy2HYFcAXwAbFQ3HmAis8JLNmxRdTC9DwQL7sGJd4CAUYimPxuQHYkMNg1EELNP85YqFwqraLd4ovz6UeeekFLoCKiu\
     --btc-amount "0.0000135 BTC" --xmr-amount "0.001 XMR"\
-    --network Testnet --arb-blockchain ECDSA --acc-blockchain Monero\
+    --network testnet --arb-blockchain bitcoin --acc-blockchain monero\
     --maker-role Bob --cancel-timelock 4 --punish-timelock 5 --fee-strategy "1 satoshi/vByte"\
     --public-ip-addr 1.2.3.4 --bind-ip-addr 0.0.0.0 --port 9735 --overlay tcp
 ```
 
 Network and assets by default are Bitcoin and Monero on testnet. The first arguments `--btc-addr` and `--xmr-addr` are the Bitcoin and Monero addresses used to get the bitcoins and moneros as a refund or when the swap completes depending on the role. They are followed by the amounts exchanged.
-
-:mag_right: Default value `ECDSA` for `--arb-blockchain` is a temporary hack, but it represents `Bitcoin<ECDSA>`, as Bitcoin can take many forms.
 
 The role for the maker is specified in the offer with `--maker-role`. `Alice` sells moneros for bitcoins, `Bob` sells bitcoins for moneros. Timelock parameters are set to **4** and **5** for cancel and punish and the transaction fee that must be applied is **1 satoshi per vByte**.
 

--- a/doc/local-swap.md
+++ b/doc/local-swap.md
@@ -76,8 +76,6 @@ swap1-cli make --btc-addr tb1q4gj53tuew3e6u4a32kdtle2q72su8te39dpceq\
     --xmr-amount "0.001 XMR"
 ```
 
-:mag_right: Default value `ECDSA` for `--arb-blockchain` is a temporary hack, but it represents `Bitcoin<ECDSA>`, as Bitcoin can take many forms.
-
 The command will create a public offer based on the chosen parameters, spin up a listening `peerd` (in that case `0.0.0.0:9735`), and return the encoded offer (starting with `Offer:...`).
 
 This public offer should be shared by maker with taker. It also contains information on how to connect to maker (in that case `127.0.0.1:9735`). Additionally, it adds the public offers to the set of public offers in `farcasterd` that will be later used to initiate the swap upon takers requests.

--- a/shell/_swap-cli
+++ b/shell/_swap-cli
@@ -97,10 +97,10 @@ _arguments "${_arguments_options[@]}" \
 _arguments "${_arguments_options[@]}" \
 '--btc-addr=[Bitcoin address used as destination or refund address]' \
 '--xmr-addr=[Monero address used as destination or refund address]' \
-'-n+[Network to use to execute the swap between the chosen blockchains]: :(Testnet Mainnet Local)' \
-'--network=[Network to use to execute the swap between the chosen blockchains]: :(Testnet Mainnet Local)' \
-'--arb-blockchain=[The chosen arbitrating blockchain]: :(ECDSA)' \
-'--acc-blockchain=[The chosen accordant blockchain]: :(Monero)' \
+'-n+[Network to use to execute the swap between the chosen blockchains]: :(Testnet testnet Mainnet mainnet Local local)' \
+'--network=[Network to use to execute the swap between the chosen blockchains]: :(Testnet testnet Mainnet mainnet Local local)' \
+'--arb-blockchain=[The chosen arbitrating blockchain]: :(Bitcoin bitcoin ECDSA)' \
+'--acc-blockchain=[The chosen accordant blockchain]: :(Monero monero)' \
 '--btc-amount=[Amount of arbitrating assets to exchanged]' \
 '--xmr-amount=[Amount of accordant assets to exchanged]' \
 '-r+[The future maker swap role, either Alice of Bob. This will dictate with asset will be exchanged for which asset. Alice will sell accordant assets for arbitrating ones and Bob the inverse, sell arbitrating assets for accordant ones]: :(Alice Bob)' \

--- a/shell/swap-cli.bash
+++ b/shell/swap-cli.bash
@@ -246,19 +246,19 @@ _swap-cli() {
                     return 0
                     ;;
                 --network)
-                    COMPREPLY=($(compgen -W "Testnet Mainnet Local" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "Testnet testnet Mainnet mainnet Local local" -- "${cur}"))
                     return 0
                     ;;
                 -n)
-                    COMPREPLY=($(compgen -W "Testnet Mainnet Local" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "Testnet testnet Mainnet mainnet Local local" -- "${cur}"))
                     return 0
                     ;;
                 --arb-blockchain)
-                    COMPREPLY=($(compgen -W "ECDSA" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "Bitcoin bitcoin ECDSA" -- "${cur}"))
                     return 0
                     ;;
                 --acc-blockchain)
-                    COMPREPLY=($(compgen -W "Monero" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "Monero monero" -- "${cur}"))
                     return 0
                     ;;
                 --btc-amount)

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -174,7 +174,7 @@ impl Exec for Command {
                         }
                     );
                     println!("Trade counterparty: {}@{}\n", &node_id, peer_address);
-                    println!("{:#?}\n", offer);
+                    println!("{}\n", offer);
                 }
                 if without_validation || take_offer() {
                     // pass offer to farcasterd to initiate the swap

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -98,17 +98,25 @@ pub enum Command {
         #[clap(
             short,
             long,
-            default_value = "Testnet",
-            possible_values = &["Testnet", "Mainnet", "Local"]
+            default_value = "testnet",
+            possible_values = &["Testnet", "testnet", "Mainnet", "mainnet", "Local", "local"]
         )]
         network: Network,
 
         /// The chosen arbitrating blockchain.
-        #[clap(long = "arb-blockchain", default_value = "ECDSA", possible_values = &["ECDSA"])]
+        #[clap(
+            long = "arb-blockchain",
+            default_value = "bitcoin",
+            possible_values = &["Bitcoin", "bitcoin", "ECDSA"])
+        ]
         arbitrating_blockchain: Bitcoin<SegwitV0>,
 
         /// The chosen accordant blockchain.
-        #[clap(long = "acc-blockchain", default_value = "Monero", possible_values = &["Monero"])]
+        #[clap(
+            long = "acc-blockchain",
+            default_value = "monero",
+            possible_values = &["Monero", "monero"])
+        ]
         accordant_blockchain: Monero,
 
         /// Amount of arbitrating assets to exchanged.


### PR DESCRIPTION
Fix #276

- Bump core from `0.4.0` to `0.4.2`
- Display offer upon taking nicely with new core Display impl
- Use new core `FromStr` variants for cmd line argument parsing, remove weird `ECDSA` for Bitcoin (keep old variants compatible)

New offer display:
```
Want to buy 0.00002450 BTC for 0.040000000000 XMR?

Carefully validate offer!

Trade counterparty: 0372fcf99da1a6f28714f10c35da3e869dc98672603e0a4c0f5bba06b91a507dff@127.0.0.1:9735

Network: Testnet
Blockchain: Bitcoin<SegwitV0>
- amount: 0.00002450 BTC
Blockchain: Monero
- amount: 0.040000000000 XMR
Timelocks
- cancel: 4 blocks
- punish: 5 blocks
Fee strategy: Fixed: 1 satoshi/vByte
Maker swap role: Bob


Take it? [y/n]
n
Rejecting offer
```