### PR TITLE
Append swap id in walletd logs

### DIFF
--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -740,7 +740,7 @@ impl Runtime {
                         serialized_offer.bright_yellow_bold()
                     );
                     info!(
-                        "{}: {:#?}",
+                        "{}: {:#}",
                         "Public offer registered".bright_green_bold(),
                         pub_offer_id.bright_yellow_bold()
                     );
@@ -833,7 +833,7 @@ impl Runtime {
 
                     if peer_connected_is_ok {
                         let offer_registered = format!(
-                            "{}: {:#?}",
+                            "{}: {:#}",
                             "Public offer registered".bright_green_bold(),
                             &public_offer.id().bright_yellow_bold()
                         );

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -740,8 +740,8 @@ impl Runtime {
                         serialized_offer.bright_yellow_bold()
                     );
                     info!(
-                        "{} {}",
-                        "Public offer registered:".bright_blue_bold(),
+                        "{}: {:#?}",
+                        "Public offer registered".bright_green_bold(),
                         pub_offer_id.bright_yellow_bold()
                     );
                     report_to.push((
@@ -833,9 +833,9 @@ impl Runtime {
 
                     if peer_connected_is_ok {
                         let offer_registered = format!(
-                            "{} {}",
-                            "Public offer registered:".bright_blue_bold(),
-                            &public_offer.id().bright_white_bold()
+                            "{}: {:#?}",
+                            "Public offer registered".bright_green_bold(),
+                            &public_offer.id().bright_yellow_bold()
                         );
                         // not yet in the set
                         self.public_offers.insert(public_offer.clone());

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -1357,7 +1357,8 @@ impl Runtime {
                     _ => success.err(),
                 };
                 info!(
-                    "{} in swap {}, cleaning up data",
+                    "{} | {} in swap {}, cleaning up data",
+                    swap_id.bright_blue_italic(),
                     &success,
                     &swap_id.bright_blue_italic(),
                 );

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -812,7 +812,7 @@ impl Runtime {
                     }
                 } else {
                     error!(
-                        "{} | Unknown wallet and swap_id {:#?}",
+                        "{:#} | Unknown wallet and swap_id {:#}",
                         swap_id.bright_blue_italic(),
                         swap_id.bright_white_bold(),
                     );

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -1098,7 +1098,10 @@ impl Runtime {
                 })) = self.wallets.get_mut(&swap_id)
                 {
                     if funding.was_seen() {
-                        warn!("funding was previously updated, ignoring");
+                        warn!(
+                            "{} | funding was previously updated, ignoring",
+                            swap_id.bright_blue_italic(),
+                        );
                         return Ok(());
                     }
                     funding_update(funding, tx)?;


### PR DESCRIPTION
Fix #296

- Add for _INFO, DEBUG, ERROR, WARN_ log levels the `{short swap id} | ...` prefix
- Print full offer id when registered in farcasterd (same format as starting swaps)