### PR TITLE
Attempt to curryfy log for syncer

### DIFF
--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -54,6 +54,10 @@ use hex;
 const RETRY_TIMEOUT: u64 = 5;
 const PING_WAIT: u8 = 2;
 
+fn info(p: String) -> impl Fn(String) {
+    move |s| info!("{} {}", p.bright_white_bold(), s)
+}
+
 pub struct ElectrumRpc {
     client: Client,
     height: u64,
@@ -642,7 +646,7 @@ fn height_polling(
 
             let mut state_guard = state.lock().await;
             state_guard
-                .change_height(rpc.height, rpc.block_hash.to_vec())
+                .change_height(rpc.height, rpc.block_hash.to_vec(), info("Bitcoin".to_string()))
                 .await;
             drop(state_guard);
             // inner loop actually polls
@@ -666,7 +670,7 @@ fn height_polling(
                 let mut block_change = false;
                 for block_notif in blocks.drain(..) {
                     block_change = state_guard
-                        .change_height(block_notif.height, block_notif.block_hash.to_vec())
+                        .change_height(block_notif.height, block_notif.block_hash.to_vec(), info("Bitcoin".to_string()))
                         .await;
                 }
                 drop(state_guard);

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -36,6 +36,10 @@ use tokio::sync::Mutex;
 
 use hex;
 
+fn info(p: String) -> impl Fn(String) {
+    move |s| info!("{} {}", p.bright_white_bold(), s)
+}
+
 #[derive(Debug, Clone)]
 pub struct MoneroRpc {
     height: u64,
@@ -471,7 +475,7 @@ fn height_polling(
             if let Some(block_notif) = block_notif {
                 let mut state_guard = state.lock().await;
                 state_guard
-                    .change_height(block_notif.height, block_notif.block_hash)
+                    .change_height(block_notif.height, block_notif.block_hash, info("Monero".to_string()))
                     .await;
                 let mut transactions = state_guard.transactions.clone();
                 drop(state_guard);

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -327,7 +327,7 @@ impl SyncerState {
         self.tasks_sources.insert(self.task_count.into(), source);
     }
 
-    pub async fn change_height(&mut self, height: u64, block: Vec<u8>) -> bool {
+    pub async fn change_height(&mut self, height: u64, block: Vec<u8>, log: impl Fn(String)) -> bool {
         if self.block_height != height || self.block_hash != block {
             self.block_height = height;
             self.block_hash = block.clone();
@@ -336,6 +336,7 @@ impl SyncerState {
 
             // Emit a height_changed event
             for (id, task) in self.watch_height.iter() {
+                log(format!("new height: {}", self.block_height));
                 send_event(
                     &self.tx_event,
                     &mut vec![(


### PR DESCRIPTION
An attempt to see how we can improve the logging stack.

As @TheCharlatan pointed out, in `log` there is the `target` argument in macro where we should be able to change the prefix (default to rust module), but I don't manage to change the target correctly yet.