### PR TITLE
Use vendored zmq

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,6 @@
 
 # Rust code coverage-specific
 /kcov-build/
+
+# Project specific
+/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install -y cmake libzmq3-dev
+        run: sudo apt-get install -y cmake
 
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
@@ -109,7 +109,7 @@ jobs:
       - name: Refresh cache and add apt-utils
         run: apt-get update -y && apt-get install -y --no-install-recommends apt-utils
       - name: Install dependencies
-        run: DEBIAN_FRONTEND=noninteractive apt-get install -y libsqlite3-dev libssl-dev libzmq3-dev pkg-config build-essential cmake
+        run: DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev pkg-config build-essential cmake
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v1.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ sysinfo = { version = "0.18.2" }
 tokio = { version = "1.12.0", features = ["full"] }
 toml = { version = "0.5", optional = true }
 # IPC
-zmq = "0.9"
+zmq = { version = "0.9.2", features = ["vendored"] }
 
 [build-dependencies]
 farcaster_core = { version = "0.4.0", features = ["serde"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,7 @@ ARG BUILDER_DIR
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends apt-utils
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        libsqlite3-dev \
         libssl-dev \
-        libzmq3-dev \
         pkg-config \
         build-essential \
         cmake


### PR DESCRIPTION
Fix #323

Remove requirement to have libzmq accessible on the machine at build time and use the vendored feature.