### PR TITLE
Modify Dockerfile for farcasterd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,6 @@ VOLUME "$DATA_DIR"
 
 EXPOSE 9735 9981
 
-ENTRYPOINT ["farcasterd", "--data-dir", "/var/lib/farcaster", "-x", "lnpz://0.0.0.0:9981/?api=esb"]
+ENTRYPOINT ["farcasterd"]
 
-CMD ["--help"]
+CMD ["--data-dir", "/var/lib/farcaster", "-x", "lnpz://0.0.0.0:9981/?api=esb", "--help"]


### PR DESCRIPTION
This is needed to have easier installation methods.

Move arguments in command to add flexibility for docker compose