### PR TITLE
Auto fund

### DIFF
--- a/shell/_farcasterd
+++ b/shell/_farcasterd
@@ -31,6 +31,8 @@ _farcasterd() {
 '--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
+'-a[Data directory path]' \
+'--auto-fund[Data directory path]' \
 && ret=0
     
 }

--- a/shell/_farcasterd.ps1
+++ b/shell/_farcasterd.ps1
@@ -36,6 +36,8 @@ Register-ArgumentCompleter -Native -CommandName 'farcasterd' -ScriptBlock {
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
+            [CompletionResult]::new('-a', 'a', [CompletionResultType]::ParameterName, 'Data directory path')
+            [CompletionResult]::new('--auto-fund', 'auto-fund', [CompletionResultType]::ParameterName, 'Data directory path')
             break
         }
     })

--- a/shell/_swap-cli
+++ b/shell/_swap-cli
@@ -192,6 +192,25 @@ _arguments "${_arguments_options[@]}" \
 ':swapid -- The swap id requested:' \
 && ret=0
 ;;
+(needs-funding)
+_arguments "${_arguments_options[@]}" \
+'-d+[Data directory path]: :_files -/' \
+'--data-dir=[Data directory path]: :_files -/' \
+'-T+[Use Tor]: :_hosts' \
+'--tor-proxy=[Use Tor]: :_hosts' \
+'-m+[ZMQ socket name/address to forward all incoming protocol messages]: :_files' \
+'--msg-socket=[ZMQ socket name/address to forward all incoming protocol messages]: :_files' \
+'-x+[ZMQ socket name/address for daemon control interface]: :_files' \
+'--ctl-socket=[ZMQ socket name/address for daemon control interface]: :_files' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
+'*-v[Set verbosity level]' \
+'*--verbose[Set verbosity level]' \
+':coin:' \
+&& ret=0
+;;
 (help)
 _arguments "${_arguments_options[@]}" \
 '-d+[Data directory path]: :_files -/' \
@@ -225,6 +244,7 @@ _swap-cli_commands() {
 'make:Maker creates offer and start listening for incoming connections. Command used to to print the resulting public offer that shall be shared with Taker. Additionally it spins up the listener awaiting for connection related to this offer' \
 'take:Taker accepts offer and connects to maker'\''s daemon to start the trade' \
 'progress:Request swap progress report' \
+'needs-funding:' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'swap-cli commands' commands "$@"
@@ -253,6 +273,11 @@ _swap-cli__list-swaps_commands() {
 _swap-cli__make_commands() {
     local commands; commands=()
     _describe -t commands 'swap-cli make commands' commands "$@"
+}
+(( $+functions[_swap-cli__needs-funding_commands] )) ||
+_swap-cli__needs-funding_commands() {
+    local commands; commands=()
+    _describe -t commands 'swap-cli needs-funding commands' commands "$@"
 }
 (( $+functions[_swap-cli__peers_commands] )) ||
 _swap-cli__peers_commands() {

--- a/shell/_swap-cli.ps1
+++ b/shell/_swap-cli.ps1
@@ -41,6 +41,7 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('make', 'make', [CompletionResultType]::ParameterValue, 'Maker creates offer and start listening for incoming connections. Command used to to print the resulting public offer that shall be shared with Taker. Additionally it spins up the listener awaiting for connection related to this offer')
             [CompletionResult]::new('take', 'take', [CompletionResultType]::ParameterValue, 'Taker accepts offer and connects to maker''s daemon to start the trade')
             [CompletionResult]::new('progress', 'progress', [CompletionResultType]::ParameterValue, 'Request swap progress report')
+            [CompletionResult]::new('needs-funding', 'needs-funding', [CompletionResultType]::ParameterValue, 'needs-funding')
             [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
             break
         }
@@ -173,6 +174,23 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             break
         }
         'swap-cli;progress' {
+            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
+            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
+            [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')
+            [CompletionResult]::new('--tor-proxy', 'tor-proxy', [CompletionResultType]::ParameterName, 'Use Tor')
+            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
+            [CompletionResult]::new('--msg-socket', 'msg-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
+            [CompletionResult]::new('-x', 'x', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
+            [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
+            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
+            break
+        }
+        'swap-cli;needs-funding' {
             [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')

--- a/shell/farcasterd.bash
+++ b/shell/farcasterd.bash
@@ -20,7 +20,7 @@ _farcasterd() {
 
     case "${cmd}" in
         farcasterd)
-            opts=" -h -V -d -v -T -m -x -c  --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket --config  "
+            opts=" -h -V -d -v -T -m -x -a -c  --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket --auto-fund --config  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/shell/swap-cli.bash
+++ b/shell/swap-cli.bash
@@ -28,6 +28,9 @@ _swap-cli() {
             make)
                 cmd+="__make"
                 ;;
+            needs-funding)
+                cmd+="__needs__funding"
+                ;;
             peers)
                 cmd+="__peers"
                 ;;
@@ -44,7 +47,7 @@ _swap-cli() {
 
     case "${cmd}" in
         swap__cli)
-            opts=" -h -V -d -v -T -m -x  --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  info peers list-swaps list-offers make take progress help"
+            opts=" -h -V -d -v -T -m -x  --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  info peers list-swaps list-offers make take progress needs-funding help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -367,6 +370,53 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --data-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --tor-proxy)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -T)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --msg-socket)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -m)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ctl-socket)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -x)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        swap__cli__needs__funding)
+            opts=" -h -V -d -v -T -m -x  --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket  <COIN> "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
                 --data-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -208,7 +208,7 @@ impl Exec for Command {
             }
 
             Command::NeedsFunding { coin } => {
-                runtime.request(ServiceId::Farcasterd, Request::ReadFunding(coin))?;
+                runtime.request(ServiceId::Farcasterd, Request::NeedsFunding(coin))?;
                 runtime.report_response()?;
             }
         }

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -33,7 +33,10 @@ use farcaster_core::{
 use strict_encoding::ReadExt;
 
 use super::Command;
-use crate::rpc::{request, Client, Request};
+use crate::{
+    rpc::{request, Client, Request},
+    syncerd::Coin,
+};
 use crate::{Error, LogStyle, ServiceId};
 
 impl Exec for Command {
@@ -202,6 +205,11 @@ impl Exec for Command {
             Command::Progress { swapid } => {
                 runtime.request(ServiceId::Farcasterd, Request::ReadProgress(swapid))?;
                 runtime.report_progress()?;
+            }
+
+            Command::NeedsFunding { coin } => {
+                runtime.request(ServiceId::Farcasterd, Request::ReadFunding(coin))?;
+                runtime.report_response()?;
             }
         }
 

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -29,6 +29,8 @@ use farcaster_core::{
     swap::{btcxmr::BtcXmr, SwapId},
 };
 
+use crate::syncerd::Coin;
+
 /// Command-line tool for working with Farcaster node
 #[derive(Clap, Clone, PartialEq, Eq, Debug)]
 #[clap(
@@ -196,6 +198,10 @@ pub enum Command {
     Progress {
         /// The swap id requested.
         swapid: SwapId,
+    },
+
+    NeedsFunding {
+        coin: Coin
     },
 }
 

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -201,7 +201,7 @@ pub enum Command {
     },
 
     NeedsFunding {
-        coin: Coin
+        coin: Coin,
     },
 }
 

--- a/src/farcasterd/opts.rs
+++ b/src/farcasterd/opts.rs
@@ -34,6 +34,19 @@ pub struct Opts {
     #[clap(flatten)]
     pub shared: crate::opts::Opts,
 
+    /// Data directory path
+    ///
+    /// Path to the directory that contains Farcaster Node data, and where ZMQ
+    /// RPC socket files are located.
+    #[clap(
+        short,
+        long,
+        global = true,
+        env = "FARCASTER_AUTO_FUND",
+        takes_value = false
+    )]
+    pub auto_fund: bool,
+
     /// Path to the configuration file.
     #[clap(
         short,

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -111,7 +111,7 @@ pub fn run(
         funding_xmr: none!(),
         funding_btc: none!(),
         config,
-        auto_fund: false,
+        auto_fund: true,
     };
 
     let broker = true;

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -917,7 +917,7 @@ impl Runtime {
                     address,
                     amount,
                 }) if self.auto_fund => {
-                    println!("attempting to auto fund bitcoin address");
+                    info!("attempting to auto fund bitcoin address");
                     use bitcoincore_rpc::{Auth, Client, RpcApi};
                     use std::env;
                     use std::path::PathBuf;
@@ -935,7 +935,7 @@ impl Runtime {
                         .send_to_address(&address, amount, None, None, None, None, None, None)
                         .unwrap();
 
-                    println!("bitcoin auto funded with tx id: {:?}", txid);
+                    info!("bitcoin auto funded with tx id: {:?}", txid);
                 }
                 FundingInfo::Bitcoin(BitcoinFundingInfo {
                     swap_id,
@@ -949,7 +949,7 @@ impl Runtime {
                     address,
                     amount,
                 }) if self.auto_fund => {
-                    println!("attempting to auto fund monero address");
+                    info!("attempting to auto-fund monero lock address");
                     use tokio::runtime::Builder;
                     let rt = Builder::new_multi_thread()
                         .worker_threads(1)
@@ -972,7 +972,7 @@ impl Runtime {
                             .await
                         {
                             Ok(_) => {
-                                info!("auto-funded monero transaction");
+                                info!("auto-funded monero lock address");
                             }
                             Err(_) => {
                                 info!("auto-funding monero transaction failed, pushing to cli");
@@ -1003,8 +1003,7 @@ impl Runtime {
                     .iter()
                     .enumerate()
                     .map(|(i, (swapid, (addr, amount)))| {
-                        let mut res =
-                            format!("{} needs funding {} with amount {}", swapid, addr, amount);
+                        let mut res = format!("{:#?} needs {} to {}", swapid, amount, addr);
                         if i < len - 1 {
                             res.push('\n');
                         }
@@ -1025,10 +1024,7 @@ impl Runtime {
                     .iter()
                     .enumerate()
                     .map(|(i, (swapid, (addr, amount)))| {
-                        let mut res = format!(
-                            "{:#?} needs funding {} with amount {}",
-                            swapid, addr, amount
-                        );
+                        let mut res = format!("{:#?} needs {} to {}", swapid, amount, addr);
                         if i < len - 1 {
                             res.push('\n');
                         }

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -111,7 +111,7 @@ pub fn run(
         funding_xmr: none!(),
         funding_btc: none!(),
         config,
-        auto_fund: true,
+        auto_fund: false,
     };
 
     let broker = true;

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -84,7 +84,7 @@ use std::str::FromStr;
 pub fn run(
     service_config: ServiceConfig,
     config: Config,
-    _opts: Opts,
+    opts: Opts,
     wallet_token: Token,
 ) -> Result<(), Error> {
     let _walletd = launch("walletd", &["--token", &wallet_token.to_string()])?;
@@ -111,8 +111,10 @@ pub fn run(
         funding_xmr: none!(),
         funding_btc: none!(),
         config,
-        auto_fund: false,
+        auto_fund: opts.auto_fund,
     };
+
+    info!("funding automatically {:?}", opts.auto_fund);
 
     let broker = true;
     Service::run(service_config, runtime, broker)

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -925,9 +925,12 @@ impl Runtime {
                     use std::path::PathBuf;
                     use std::str::FromStr;
 
-                    let cookie = env::var("BITCOIN_COOKIE")
-                        .unwrap_or("/home/drgrid/.bitcoin/testnet3/.cookie".into());
-                    let path = PathBuf::from_str(&cookie).unwrap();
+                    let path = match env::var("BITCOIN_COOKIE") {
+                        Ok(cookie) => PathBuf::from_str(&cookie).unwrap(),
+                        Err(_) => PathBuf::from(
+                            shellexpand::tilde("~/.bitcoin/testnet3/.cookie").to_string(),
+                        ),
+                    };
                     let host = env::var("BITCOIN_HOST").unwrap_or("localhost".into());
                     let bitcoin_rpc =
                         Client::new(&format!("http://{}:18334", host), Auth::CookieFile(path))

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -923,7 +923,7 @@ impl Runtime {
                 }
             },
 
-            Request::ReadFunding(Coin::Monero) if !self.funding_xmr.is_empty() => {
+            Request::NeedsFunding(Coin::Monero) if !self.funding_xmr.is_empty() => {
                 use tokio::runtime::Builder;
                 let rt = Builder::new_multi_thread()
                     .worker_threads(1)
@@ -938,7 +938,7 @@ impl Runtime {
                     //     .create_wallet("test".to_string(), None, "English".to_string())
                     //     .await;
                     wallet
-                        .open_wallet("~/.monero_wallets/stagenet".to_string(), None)
+                        .open_wallet("stagenet".to_string(), None)
                         .await
                         .expect("The wallet exists, created the line before");
 
@@ -957,7 +957,7 @@ impl Runtime {
                     }
                 });
             }
-            Request::ReadFunding(Coin::Bitcoin) if !self.funding_btc.is_empty() => {
+            Request::NeedsFunding(Coin::Bitcoin) if !self.funding_btc.is_empty() => {
                 // let mut res: String = s!("");
                 let len = self.funding_btc.len();
                 let prefix = s!("bitcoin-cli -testnet sendtoaddress ");
@@ -984,7 +984,7 @@ impl Runtime {
                     Request::String(res),
                 )?;
             }
-            Request::ReadFunding(_) => {
+            Request::NeedsFunding(_) => {
                 senders.send_to(
                     ServiceBus::Ctl,
                     self.identity(),

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -532,7 +532,7 @@ pub enum Request {
 
     #[api(type = 1107)]
     #[display("read_funding")]
-    ReadFunding(crate::syncerd::Coin),
+    NeedsFunding(crate::syncerd::Coin),
 
     #[api(type = 1108)]
     #[display("read_funding")]

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -456,6 +456,9 @@ pub enum Request {
 
     // Responses to CLI
     // ----------------
+    #[api(type = 1004)]
+    #[display("{0}")]
+    String(String),
     #[api(type = 1002)]
     #[display("progress({0})")]
     Progress(String),
@@ -522,6 +525,18 @@ pub enum Request {
     // #[display("offer_list({0})", alt = "{0:#}")]
     // #[from]
     // OfferIdList(List<PublicOfferId>),
+    #[api(type = 1106)]
+    #[display("funding_info({0})", alt = "{0:#}")]
+    #[from]
+    FundingInfo(FundingInfo),
+
+    #[api(type = 1107)]
+    #[display("read_funding")]
+    ReadFunding(crate::syncerd::Coin),
+
+    #[api(type = 1108)]
+    #[display("read_funding")]
+    WriteText(List<String>),
 
     // #[api(type = 1203)]
     // #[display("channel_funding({0})", alt = "{0:#}")]
@@ -560,6 +575,12 @@ pub enum Outcome {
     Refund,
     #[display("Failure(Punished)")]
     Punish,
+}
+#[derive(Clone, Debug, Display, StrictDecode, StrictEncode)]
+#[display("funding_info")]
+pub enum FundingInfo {
+    Bitcoin(SwapId, bitcoin::Address, bitcoin::Amount),
+    Monero(SwapId, String, u64),
 }
 
 impl rpc_connection::Request for Request {}

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -525,16 +525,16 @@ pub enum Request {
     // #[display("offer_list({0})", alt = "{0:#}")]
     // #[from]
     // OfferIdList(List<PublicOfferId>),
-    #[api(type = 1106)]
+    #[api(type = 1108)]
     #[display("funding_info({0})", alt = "{0:#}")]
     #[from]
     FundingInfo(FundingInfo),
 
-    #[api(type = 1107)]
+    #[api(type = 1109)]
     #[display("read_funding")]
     NeedsFunding(crate::syncerd::Coin),
 
-    #[api(type = 1108)]
+    #[api(type = 1110)]
     #[display("read_funding")]
     WriteText(List<String>),
 

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -538,6 +538,10 @@ pub enum Request {
     #[display("read_funding")]
     WriteText(List<String>),
 
+    #[api(type = 1111)]
+    #[display("read_funding")]
+    FundingCompleted(SwapId),
+
     // #[api(type = 1203)]
     // #[display("channel_funding({0})", alt = "{0:#}")]
     // #[from]

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -1143,15 +1143,6 @@ impl Runtime {
                                 pending_requests.push(pending_request);
 
                                 if let Some(addr) = self.state.b_address().cloned() {
-                                    let msg = format!(
-                                        "Send {} to {}",
-                                        self.syncer_state
-                                            .bitcoin_amount
-                                            .to_string()
-                                            .bright_green_bold(),
-                                        addr,
-                                    );
-
                                     let fees = bitcoin::Amount::from_sat(150); // FIXME
                                     let req = Request::FundingInfo(FundingInfo::Bitcoin(
                                         BitcoinFundingInfo {
@@ -1168,7 +1159,6 @@ impl Runtime {
                                             req,
                                         )?
                                     }
-                                    // let _ = self.report_progress_to(senders, &enquirer, msg);
                                 }
                             }
                         }
@@ -1883,20 +1873,6 @@ impl Runtime {
                                         self.syncer_state.network.into(),
                                         &viewpair,
                                     );
-                                    let msg = format!(
-                                        "Send {} to {}",
-                                        self.syncer_state
-                                            .monero_amount
-                                            .to_string()
-                                            .bright_green_bold(),
-                                        address.addr(),
-                                    );
-                                    info!("{} | {}", self.swap_id.bright_blue_italic(), msg);
-                                    self.report_success_to(
-                                        senders,
-                                        self.enquirer.clone(),
-                                        Some(msg),
-                                    )?;
                                     let funding_request =
                                         Request::FundingInfo(FundingInfo::Monero(MoneroFundingInfo{
                                             swap_id: self.swap_id(),

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -14,8 +14,8 @@
 // If not, see <https://opensource.org/licenses/MIT>.
 
 use crate::{
-    rpc::request::Outcome,
     rpc::request::FundingInfo,
+    rpc::request::Outcome,
     syncerd::{
         opts::Coin, Abort, GetTx, HeightChanged, SweepAddress, SweepAddressAddendum, SweepSuccess,
         SweepXmrAddress, TaskId, TaskTarget, TransactionRetrieved, WatchHeight, XmrAddressAddendum,
@@ -1143,16 +1143,15 @@ impl Runtime {
                                 pending_requests.push(pending_request);
 
                                 if let Some(addr) = self.state.b_address().cloned() {
-                                    // let msg = format!(
-                                    //     "{} {}",
-                                    //     "Funding address:".bright_white_bold(),
-                                    //     addr.bright_yellow_bold()
-                                    // );
                                     let msg = format!(
-                                        "{} {}",
-                                        "Funding address:".bright_white_bold(),
-                                        addr.bright_yellow_bold()
+                                        "Send {} to {}",
+                                        self.syncer_state
+                                            .bitcoin_amount
+                                            .to_string()
+                                            .bright_green_bold(),
+                                        addr,
                                     );
+
                                     let fees = bitcoin::Amount::from_sat(150); // FIXME
                                     let req = Request::FundingInfo(FundingInfo::Bitcoin(
                                         self.swap_id(),

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -1557,6 +1557,12 @@ impl Runtime {
                         senders.send_to(
                             ServiceBus::Ctl,
                             self.identity(),
+                            ServiceId::Farcasterd,
+                            Request::FundingCompleted(self.swap_id()),
+                        )?;
+                        senders.send_to(
+                            ServiceBus::Ctl,
+                            self.identity(),
                             self.syncer_state.monero_syncer(),
                             Request::SyncerTask(task),
                         )?;
@@ -1575,6 +1581,12 @@ impl Runtime {
                             );
                             return Ok(());
                         }
+                        senders.send_to(
+                            ServiceBus::Ctl,
+                            self.identity(),
+                            ServiceId::Farcasterd,
+                            Request::FundingCompleted(self.swap_id()),
+                        )?;
                         if let Some(tx_label) = self.syncer_state.tasks.watched_addrs.remove(id) {
                             let watch_tx = self.syncer_state.watch_tx_xmr(hash.clone(), tx_label);
                             senders.send_to(
@@ -1735,7 +1747,7 @@ impl Runtime {
                         tx,
                     }) if self.syncer_state.tasks.watched_addrs.get(id).is_some() => {
                         let tx = bitcoin::Transaction::deserialize(tx)?;
-                        trace!(
+                        info!(
                             "Received AddressTransaction, processing tx {}",
                             &tx.txid().addr()
                         );
@@ -1743,6 +1755,12 @@ impl Runtime {
                         match txlabel {
                             TxLabel::Funding => {
                                 log_tx_seen(self.swap_id, txlabel, &tx.txid());
+                                senders.send_to(
+                                    ServiceBus::Ctl,
+                                    self.identity(),
+                                    ServiceId::Farcasterd,
+                                    Request::FundingCompleted(self.swap_id()),
+                                )?;
                                 let req = Request::Tx(Tx::Funding(tx));
                                 self.send_wallet(ServiceBus::Ctl, senders, req)?;
                             }

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -14,8 +14,8 @@
 // If not, see <https://opensource.org/licenses/MIT>.
 
 use crate::{
-    rpc::request::FundingInfo,
     rpc::request::Outcome,
+    rpc::request::{BitcoinFundingInfo, FundingInfo, MoneroFundingInfo},
     syncerd::{
         opts::Coin, Abort, GetTx, HeightChanged, SweepAddress, SweepAddressAddendum, SweepSuccess,
         SweepXmrAddress, TaskId, TaskTarget, TransactionRetrieved, WatchHeight, XmrAddressAddendum,
@@ -1154,9 +1154,11 @@ impl Runtime {
 
                                     let fees = bitcoin::Amount::from_sat(150); // FIXME
                                     let req = Request::FundingInfo(FundingInfo::Bitcoin(
-                                        self.swap_id(),
-                                        addr,
-                                        self.syncer_state.bitcoin_amount + fees,
+                                        BitcoinFundingInfo {
+                                            swap_id: self.swap_id(),
+                                            address: addr,
+                                            amount: self.syncer_state.bitcoin_amount + fees,
+                                        },
                                     ));
                                     if let Some(enquirer) = self.enquirer.clone() {
                                         senders.send_to(
@@ -1878,11 +1880,11 @@ impl Runtime {
                                         Some(msg),
                                     )?;
                                     let funding_request =
-                                        Request::FundingInfo(FundingInfo::Monero(
-                                            self.swap_id(),
-                                            address.to_string(),
-                                            self.syncer_state.monero_amount.as_pico(),
-                                        ));
+                                        Request::FundingInfo(FundingInfo::Monero(MoneroFundingInfo{
+                                            swap_id: self.swap_id(),
+                                            address,
+                                            amount: self.syncer_state.monero_amount,
+                                        }));
                                     if let Some(enquirer) = self.enquirer.clone() {
                                         senders.send_to(
                                             ServiceBus::Ctl,

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -15,6 +15,7 @@
 
 use crate::{
     rpc::request::Outcome,
+    rpc::request::FundingInfo,
     syncerd::{
         opts::Coin, Abort, GetTx, HeightChanged, SweepAddress, SweepAddressAddendum, SweepSuccess,
         SweepXmrAddress, TaskId, TaskTarget, TransactionRetrieved, WatchHeight, XmrAddressAddendum,
@@ -96,6 +97,7 @@ pub fn run(
         maker_role, // SwapRole of maker (Alice or Bob)
         network,
         accordant_amount: monero_amount,
+        arbitrating_amount: bitcoin_amount,
         ..
     } = public_offer.offer;
     // alice or bob
@@ -150,6 +152,7 @@ pub fn run(
         bitcoin_syncer: ServiceId::Syncer(Coin::Bitcoin, network),
         monero_syncer: ServiceId::Syncer(Coin::Monero, network),
         monero_amount,
+        bitcoin_amount,
     };
 
     let runtime = Runtime {
@@ -287,6 +290,7 @@ struct SyncerState {
     bitcoin_syncer: ServiceId,
     monero_syncer: ServiceId,
     monero_amount: monero::Amount,
+    bitcoin_amount: bitcoin::Amount,
 }
 
 #[derive(Display, Clone)]
@@ -1139,13 +1143,31 @@ impl Runtime {
                                 pending_requests.push(pending_request);
 
                                 if let Some(addr) = self.state.b_address().cloned() {
+                                    // let msg = format!(
+                                    //     "{} {}",
+                                    //     "Funding address:".bright_white_bold(),
+                                    //     addr.bright_yellow_bold()
+                                    // );
                                     let msg = format!(
                                         "{} {}",
                                         "Funding address:".bright_white_bold(),
                                         addr.bright_yellow_bold()
                                     );
-                                    let enquirer = self.enquirer.clone();
-                                    let _ = self.report_progress_to(senders, &enquirer, msg);
+                                    let fees = bitcoin::Amount::from_sat(150); // FIXME
+                                    let req = Request::FundingInfo(FundingInfo::Bitcoin(
+                                        self.swap_id(),
+                                        addr,
+                                        self.syncer_state.bitcoin_amount + fees,
+                                    ));
+                                    if let Some(enquirer) = self.enquirer.clone() {
+                                        senders.send_to(
+                                            ServiceBus::Ctl,
+                                            self.identity(),
+                                            enquirer,
+                                            req,
+                                        )?
+                                    }
+                                    // let _ = self.report_progress_to(senders, &enquirer, msg);
                                 }
                             }
                         }
@@ -1856,6 +1878,21 @@ impl Runtime {
                                         self.enquirer.clone(),
                                         Some(msg),
                                     )?;
+                                    let funding_request =
+                                        Request::FundingInfo(FundingInfo::Monero(
+                                            self.swap_id(),
+                                            address.to_string(),
+                                            self.syncer_state.monero_amount.as_pico(),
+                                        ));
+                                    if let Some(enquirer) = self.enquirer.clone() {
+                                        senders.send_to(
+                                            ServiceBus::Ctl,
+                                            self.identity(),
+                                            enquirer,
+                                            funding_request,
+                                        )?
+                                    }
+
                                     let watch_addr_task = self.syncer_state.watch_addr_xmr(
                                         spend,
                                         view,

--- a/src/syncerd/mod.rs
+++ b/src/syncerd/mod.rs
@@ -22,6 +22,6 @@ pub mod opts;
 pub mod runtime;
 
 #[cfg(feature = "shell")]
-pub use opts::Opts;
+pub use opts::{Coin, Opts};
 pub use runtime::run;
 pub use types::*;

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -263,7 +263,9 @@ impl Runtime {
             // after TakerCommit, blocks TakerCommit, as `self.btc_addrs.contains_key(&swap_id) ==
             // false`
             Request::BitcoinAddress(BitcoinAddress(swapid, btc_addr)) => {
-                self.btc_addrs.insert(swapid, btc_addr);
+                if self.btc_addrs.insert(swapid, btc_addr).is_some() {
+                    error!("btc_addrs rm accidentally")
+                };
             }
 
             // Handled in Msg to avoid race condition between Msg and Ctl bus (2 msgs sent
@@ -272,7 +274,9 @@ impl Runtime {
             // after TakerCommit, blocks TakerCommit, as `self.xmr_addrs.contains_key(&swap_id) ==
             // false`
             Request::MoneroAddress(MoneroAddress(swapid, xmr_addr)) => {
-                self.xmr_addrs.insert(swapid, xmr_addr);
+                if self.xmr_addrs.insert(swapid, xmr_addr).is_some() {
+                    error!("xmr_addrs rm accidentally")
+                };
             }
             // 1st protocol message received through peer connection, and last
             // handled by farcasterd, receiving taker commit because we are

--- a/tests/functional-swap.rs
+++ b/tests/functional-swap.rs
@@ -369,7 +369,9 @@ async fn run_refund_swap_kill_alice_after_funding(
         .unwrap();
 
     // run until bob has the btc funding address
-    let address = retry_until_bitcoin_funding_address(cli_bob_needs_funding_args.clone()).await;
+    let address =
+        retry_until_bitcoin_funding_address(swap_id.clone(), cli_bob_needs_funding_args.clone())
+            .await;
 
     // fund the bitcoin address
     let lock = execution_mutex.lock().await;
@@ -380,7 +382,7 @@ async fn run_refund_swap_kill_alice_after_funding(
 
     // run until the alice has the monero funding address and fund it
     let monero_address =
-        retry_until_monero_funding_address(cli_alice_needs_funding_args.clone()).await;
+        retry_until_monero_funding_address(swap_id, cli_alice_needs_funding_args.clone()).await;
     send_monero(Arc::clone(&monero_wallet), monero_address, 1000000000000).await;
 
     // kill alice
@@ -445,7 +447,9 @@ async fn run_refund_swap_alice_does_not_fund(
         .unwrap();
 
     // run until bob has the btc funding address
-    let address = retry_until_bitcoin_funding_address(cli_bob_needs_funding_args.clone()).await;
+    let address =
+        retry_until_bitcoin_funding_address(swap_id.clone(), cli_bob_needs_funding_args.clone())
+            .await;
 
     // fund the bitcoin address
     let lock = execution_mutex.lock().await;
@@ -455,7 +459,7 @@ async fn run_refund_swap_alice_does_not_fund(
         .unwrap();
 
     // run until the alice has the monero funding address, but do not fund it
-    retry_until_monero_funding_address(cli_alice_needs_funding_args.clone()).await;
+    retry_until_monero_funding_address(swap_id, cli_alice_needs_funding_args.clone()).await;
 
     // generate some bitcoin blocks for confirmations
     bitcoin_rpc
@@ -521,7 +525,9 @@ async fn run_punish_swap_kill_bob_before_monero_funding(
         .unwrap();
 
     // run until bob has the btc funding address
-    let address = retry_until_bitcoin_funding_address(cli_bob_needs_funding_args.clone()).await;
+    let address =
+        retry_until_bitcoin_funding_address(swap_id.clone(), cli_bob_needs_funding_args.clone())
+            .await;
 
     // fund the bitcoin address
     let lock = execution_mutex.lock().await;
@@ -541,7 +547,7 @@ async fn run_punish_swap_kill_bob_before_monero_funding(
 
     // run until the alice has the monero funding address
     let monero_address =
-        retry_until_monero_funding_address(cli_alice_needs_funding_args.clone()).await;
+        retry_until_monero_funding_address(swap_id, cli_alice_needs_funding_args.clone()).await;
     send_monero(Arc::clone(&monero_wallet), monero_address, 1000000000000).await;
 
     tokio::time::sleep(time::Duration::from_secs(20)).await;
@@ -672,11 +678,14 @@ async fn run_swap(
         .generate_to_address(1, &reusable_btc_address())
         .unwrap();
 
+    let lock = execution_mutex.lock().await;
+
     // run until bob has the btc funding address
-    let address = retry_until_bitcoin_funding_address(cli_bob_needs_funding_args.clone()).await;
+    let address =
+        retry_until_bitcoin_funding_address(swap_id.clone(), cli_bob_needs_funding_args.clone())
+            .await;
 
     // fund the bitcoin address
-    let lock = execution_mutex.lock().await;
     let amount = bitcoin::Amount::ONE_SAT * 100000150;
     bitcoin_rpc
         .send_to_address(&address, amount, None, None, None, None, None, None)
@@ -688,7 +697,7 @@ async fn run_swap(
 
     // run until the alice has the monero funding address
     let monero_address =
-        retry_until_monero_funding_address(cli_alice_needs_funding_args.clone()).await;
+        retry_until_monero_funding_address(swap_id, cli_alice_needs_funding_args.clone()).await;
     send_monero(Arc::clone(&monero_wallet), monero_address, 1000000000000).await;
 
     // generate some bitcoin blocks for confirmations
@@ -989,7 +998,10 @@ async fn retry_until_swap_id(args: Vec<String>, previous_swap_ids: HashSet<Strin
     panic!("timeout before any swapid could be retrieved");
 }
 
-async fn retry_until_bitcoin_funding_address(args: Vec<String>) -> bitcoin::Address {
+async fn retry_until_bitcoin_funding_address(
+    swap_id: String,
+    args: Vec<String>,
+) -> bitcoin::Address {
     for _ in 0..ALLOWED_RETRIES {
         let (stdout, _stderr) = run("../swap-cli", args.clone()).unwrap();
 
@@ -997,11 +1009,12 @@ async fn retry_until_bitcoin_funding_address(args: Vec<String>) -> bitcoin::Addr
         let bitcoin_address: Vec<String> = stdout
             .iter()
             .filter_map(|element| {
-                println!("element: {:?}", element);
-                if let Some(pos) = element.find("bcr") {
-                    let len = element.to_string().len();
-                    let swap_id = element[pos..len].to_string();
-                    Some(swap_id)
+                let content: Vec<&str> = element.split(" ").collect();
+                if content.len() < 5 {
+                    return None;
+                }
+                if content[5].contains("bcr") && content[0] == &swap_id {
+                    Some(content[5].to_string())
                 } else {
                     None
                 }
@@ -1016,7 +1029,7 @@ async fn retry_until_bitcoin_funding_address(args: Vec<String>) -> bitcoin::Addr
     panic!("timeout before any bitcoin funding address could be retrieved");
 }
 
-async fn retry_until_monero_funding_address(args: Vec<String>) -> monero::Address {
+async fn retry_until_monero_funding_address(swap_id: String, args: Vec<String>) -> monero::Address {
     for _ in 0..ALLOWED_RETRIES {
         let (stdout, _stderr) = run("../swap-cli", args.clone()).unwrap();
 
@@ -1024,9 +1037,12 @@ async fn retry_until_monero_funding_address(args: Vec<String>) -> monero::Addres
         let monero_addresses: Vec<String> = stdout
             .iter()
             .filter_map(|element| {
-                if let Some(pos) = element.find("XMR to 4") {
-                    let monero_address = element[pos + 7..].to_string();
-                    Some(monero_address)
+                let content: Vec<&str> = element.split(" ").collect();
+                if content.len() < 5 {
+                    return None;
+                }
+                if content[5].contains("4") && content[0] == &swap_id {
+                    Some(content[5].to_string())
                 } else {
                     None
                 }

--- a/tests/functional-swap.rs
+++ b/tests/functional-swap.rs
@@ -358,8 +358,6 @@ async fn run_refund_swap_kill_alice_after_funding(
     execution_mutex: Arc<Mutex<u8>>,
     alice_farcasterd: std::process::Child,
 ) {
-    let cli_alice_progress_args: Vec<String> =
-        progress_args(data_dir_alice.clone(), swap_id.clone());
     let cli_bob_progress_args: Vec<String> = progress_args(data_dir_bob.clone(), swap_id.clone());
     let cli_bob_needs_funding_args: Vec<String> =
         needs_funding_args(data_dir_bob, "bitcoin".to_string());
@@ -381,7 +379,8 @@ async fn run_refund_swap_kill_alice_after_funding(
         .unwrap();
 
     // run until the alice has the monero funding address and fund it
-    let monero_address = retry_until_monero_funding_address(cli_alice_progress_args.clone()).await;
+    let monero_address =
+        retry_until_monero_funding_address(cli_alice_needs_funding_args.clone()).await;
     send_monero(Arc::clone(&monero_wallet), monero_address, 1000000000000).await;
 
     // kill alice
@@ -433,15 +432,20 @@ async fn run_refund_swap_alice_does_not_fund(
     funding_btc_address: bitcoin::Address,
     execution_mutex: Arc<Mutex<u8>>,
 ) {
-    let cli_alice_progress_args: Vec<String> = progress_args(data_dir_alice, swap_id.clone());
-    let cli_bob_progress_args: Vec<String> = progress_args(data_dir_bob, swap_id.clone());
+    let cli_alice_progress_args: Vec<String> =
+        progress_args(data_dir_alice.clone(), swap_id.clone());
+    let cli_bob_progress_args: Vec<String> = progress_args(data_dir_bob.clone(), swap_id.clone());
+    let cli_bob_needs_funding_args: Vec<String> =
+        needs_funding_args(data_dir_bob, "bitcoin".to_string());
+    let cli_alice_needs_funding_args: Vec<String> =
+        needs_funding_args(data_dir_alice, "monero".to_string());
 
     bitcoin_rpc
         .generate_to_address(1, &reusable_btc_address())
         .unwrap();
 
     // run until bob has the btc funding address
-    let address = retry_until_bitcoin_funding_address(cli_bob_progress_args.clone()).await;
+    let address = retry_until_bitcoin_funding_address(cli_bob_needs_funding_args.clone()).await;
 
     // fund the bitcoin address
     let lock = execution_mutex.lock().await;
@@ -451,7 +455,7 @@ async fn run_refund_swap_alice_does_not_fund(
         .unwrap();
 
     // run until the alice has the monero funding address, but do not fund it
-    retry_until_monero_funding_address(cli_alice_progress_args.clone()).await;
+    retry_until_monero_funding_address(cli_alice_needs_funding_args.clone()).await;
 
     // generate some bitcoin blocks for confirmations
     bitcoin_rpc
@@ -505,15 +509,19 @@ async fn run_punish_swap_kill_bob_before_monero_funding(
     execution_mutex: Arc<Mutex<u8>>,
     bob_farcasterd: std::process::Child,
 ) {
-    let cli_alice_progress_args: Vec<String> = progress_args(data_dir_alice, swap_id.clone());
-    let cli_bob_progress_args: Vec<String> = progress_args(data_dir_bob, swap_id.clone());
+    let cli_alice_progress_args: Vec<String> =
+        progress_args(data_dir_alice.clone(), swap_id.clone());
+    let cli_bob_needs_funding_args: Vec<String> =
+        needs_funding_args(data_dir_bob, "bitcoin".to_string());
+    let cli_alice_needs_funding_args: Vec<String> =
+        needs_funding_args(data_dir_alice, "monero".to_string());
 
     bitcoin_rpc
         .generate_to_address(1, &reusable_btc_address())
         .unwrap();
 
     // run until bob has the btc funding address
-    let address = retry_until_bitcoin_funding_address(cli_bob_progress_args.clone()).await;
+    let address = retry_until_bitcoin_funding_address(cli_bob_needs_funding_args.clone()).await;
 
     // fund the bitcoin address
     let lock = execution_mutex.lock().await;
@@ -532,7 +540,8 @@ async fn run_punish_swap_kill_bob_before_monero_funding(
     cleanup_processes(vec![bob_farcasterd]);
 
     // run until the alice has the monero funding address
-    let monero_address = retry_until_monero_funding_address(cli_alice_progress_args.clone()).await;
+    let monero_address =
+        retry_until_monero_funding_address(cli_alice_needs_funding_args.clone()).await;
     send_monero(Arc::clone(&monero_wallet), monero_address, 1000000000000).await;
 
     tokio::time::sleep(time::Duration::from_secs(20)).await;
@@ -651,16 +660,20 @@ async fn run_swap(
     monero_dest_wallet_name: String,
     execution_mutex: Arc<Mutex<u8>>,
 ) {
-    // let btc_address = bitcoin_rpc.get_new_address(None, None).unwrap();
-    let cli_alice_progress_args: Vec<String> = progress_args(data_dir_alice, swap_id.clone());
-    let cli_bob_progress_args: Vec<String> = progress_args(data_dir_bob, swap_id.clone());
+    let cli_alice_progress_args: Vec<String> =
+        progress_args(data_dir_alice.clone(), swap_id.clone());
+    let cli_bob_progress_args: Vec<String> = progress_args(data_dir_bob.clone(), swap_id.clone());
+    let cli_bob_needs_funding_args: Vec<String> =
+        needs_funding_args(data_dir_bob, "bitcoin".to_string());
+    let cli_alice_needs_funding_args: Vec<String> =
+        needs_funding_args(data_dir_alice, "monero".to_string());
 
     bitcoin_rpc
         .generate_to_address(1, &reusable_btc_address())
         .unwrap();
 
     // run until bob has the btc funding address
-    let address = retry_until_bitcoin_funding_address(cli_bob_progress_args.clone()).await;
+    let address = retry_until_bitcoin_funding_address(cli_bob_needs_funding_args.clone()).await;
 
     // fund the bitcoin address
     let lock = execution_mutex.lock().await;
@@ -674,7 +687,8 @@ async fn run_swap(
         .unwrap();
 
     // run until the alice has the monero funding address
-    let monero_address = retry_until_monero_funding_address(cli_alice_progress_args.clone()).await;
+    let monero_address =
+        retry_until_monero_funding_address(cli_alice_needs_funding_args.clone()).await;
     send_monero(Arc::clone(&monero_wallet), monero_address, 1000000000000).await;
 
     // generate some bitcoin blocks for confirmations
@@ -983,6 +997,7 @@ async fn retry_until_bitcoin_funding_address(args: Vec<String>) -> bitcoin::Addr
         let bitcoin_address: Vec<String> = stdout
             .iter()
             .filter_map(|element| {
+                println!("element: {:?}", element);
                 if let Some(pos) = element.find("bcr") {
                     let len = element.to_string().len();
                     let swap_id = element[pos..len].to_string();

--- a/tests/functional-swap.rs
+++ b/tests/functional-swap.rs
@@ -358,15 +358,20 @@ async fn run_refund_swap_kill_alice_after_funding(
     execution_mutex: Arc<Mutex<u8>>,
     alice_farcasterd: std::process::Child,
 ) {
-    let cli_alice_progress_args: Vec<String> = progress_args(data_dir_alice, swap_id.clone());
-    let cli_bob_progress_args: Vec<String> = progress_args(data_dir_bob, swap_id.clone());
+    let cli_alice_progress_args: Vec<String> =
+        progress_args(data_dir_alice.clone(), swap_id.clone());
+    let cli_bob_progress_args: Vec<String> = progress_args(data_dir_bob.clone(), swap_id.clone());
+    let cli_bob_needs_funding_args: Vec<String> =
+        needs_funding_args(data_dir_bob, "bitcoin".to_string());
+    let cli_alice_needs_funding_args: Vec<String> =
+        needs_funding_args(data_dir_alice, "monero".to_string());
 
     bitcoin_rpc
         .generate_to_address(1, &reusable_btc_address())
         .unwrap();
 
     // run until bob has the btc funding address
-    let address = retry_until_bitcoin_funding_address(cli_bob_progress_args.clone()).await;
+    let address = retry_until_bitcoin_funding_address(cli_bob_needs_funding_args.clone()).await;
 
     // fund the bitcoin address
     let lock = execution_mutex.lock().await;
@@ -918,6 +923,13 @@ fn progress_args(data_dir: Vec<String>, swap_id: String) -> Vec<String> {
     data_dir
         .into_iter()
         .chain(vec!["progress".to_string(), swap_id])
+        .collect()
+}
+
+fn needs_funding_args(data_dir: Vec<String>, currency: String) -> Vec<String> {
+    data_dir
+        .into_iter()
+        .chain(vec!["needs-funding".to_string(), currency])
         .collect()
 }
 

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -110,6 +110,7 @@ fn bicoin_syncer_retrieve_transaction_test() {
     let message = rx_event.recv_multipart(0).unwrap();
     let request = get_request_from_message(message);
     println!("received request: {:?}", request);
+    assert_transaction_received(request, txid);
 }
 
 fn assert_transaction_received(request: Request, expected_txid: bitcoin::Txid) {


### PR DESCRIPTION
To use auto fund:

1. Start a separate monero-wallet-rpc with for example:  `./monero-wallet-rpc --stagenet --disable-rpc-login --rpc-bind-port 18083 --trusted-daemon --daemon-host stagenet.melo.tools:38081 --wallet-file <WalletFile> --prompt-for-password`

Important here is that `--wallet-file` should be pointing to a wallet with preloaded monero.

2. Start bitcoind on testnet with: `./bitcoind -testnet -server -rest -rpcport=18334 -rpcallowip=127.0.0.1`

3. The hosts and cookies are currently hard-coded. The monero-wallet-rpc is expected to run on port 18083 and is expected to not conflict with the syncer's monero-wallet-rpc. The testnet bitcoin daemon is expeced to run on port 18334 and have a loaded and funded wallet. Additionally, the cookie file can either be passed by environment variable `BITCOIN_COOKIE`, or is expected to be in `~/.bitcoin/testnet3/.cookie`.

4. Run farcasterd with the `--auto-fund` toggle.

