### PR TITLE
Update finality threshold for btc/xmr

### DIFF
--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -125,9 +125,9 @@ pub fn run(
     let temporal_safety = TemporalSafety {
         cancel_timelock: cancel_timelock.as_u32(),
         punish_timelock: punish_timelock.as_u32(),
-        btc_finality_thr: 0,
+        btc_finality_thr: 1,
         race_thr: 3,
-        xmr_finality_thr: 0,
+        xmr_finality_thr: 5,
         sweep_monero_thr,
     };
 


### PR DESCRIPTION
Replace #175 

Set btc to 1 block to consider final and xmr to 5 blocks (even if not spendable before 10).

This is temporary and will be changed towards #320.