### PR TITLE
Extract auto funding in config

### DIFF
--- a/farcasterd.toml
+++ b/farcasterd.toml
@@ -1,3 +1,24 @@
+# Farcasterd configuration
+# configures farcasterd specific behaviors such as auto-funding swaps
+
+# Defines auto-funding
+[farcasterd.auto_funding]
+# Set this to true if you want to enable auto-funding, default to false
+# if set to true you need to register the parameter for the networks you
+# want to support: mainnet, testnet, or local
+auto_fund = false
+
+# Auto-funding testnet parameters
+[farcasterd.auto_funding.testnet]
+# The bitcoin node to use to auto-send funds when swap funding is required
+# the node should have a wallet with spendable funds
+bitcoin_rpc = "http://localhost:18334"
+# The path to the cookie file to connect to the bitcoin node
+bitcoin_cookie_path = "~/.bitcoin/testnet3/.cookie"
+# The monero wallet to use to auto-send funds when swap funding is required
+# the wallet should have spendable funds
+monero_rpc_wallet = "http://localhost:38084"
+
 # Syncers configuration
 # configures the Bitcoin and Monero syncers for the three
 # networks.

--- a/shell/_farcasterd
+++ b/shell/_farcasterd
@@ -31,8 +31,6 @@ _farcasterd() {
 '--version[Print version information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-'-a[Data directory path]' \
-'--auto-fund[Data directory path]' \
 && ret=0
     
 }

--- a/shell/_farcasterd.ps1
+++ b/shell/_farcasterd.ps1
@@ -36,8 +36,6 @@ Register-ArgumentCompleter -Native -CommandName 'farcasterd' -ScriptBlock {
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('-a', 'a', [CompletionResultType]::ParameterName, 'Data directory path')
-            [CompletionResult]::new('--auto-fund', 'auto-fund', [CompletionResultType]::ParameterName, 'Data directory path')
             break
         }
     })

--- a/shell/farcasterd.bash
+++ b/shell/farcasterd.bash
@@ -20,7 +20,7 @@ _farcasterd() {
 
     case "${cmd}" in
         farcasterd)
-            opts=" -h -V -d -v -T -m -x -a -c  --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket --auto-fund --config  "
+            opts=" -h -V -d -v -T -m -x -c  --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket --config  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/src/farcasterd/opts.rs
+++ b/src/farcasterd/opts.rs
@@ -34,19 +34,6 @@ pub struct Opts {
     #[clap(flatten)]
     pub shared: crate::opts::Opts,
 
-    /// Data directory path
-    ///
-    /// Path to the directory that contains Farcaster Node data, and where ZMQ
-    /// RPC socket files are located.
-    #[clap(
-        short,
-        long,
-        global = true,
-        env = "FARCASTER_AUTO_FUND",
-        takes_value = false
-    )]
-    pub auto_fund: bool,
-
     /// Path to the configuration file.
     #[clap(
         short,

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -84,10 +84,15 @@ use std::str::FromStr;
 pub fn run(
     service_config: ServiceConfig,
     config: Config,
-    opts: Opts,
+    _opts: Opts,
     wallet_token: Token,
 ) -> Result<(), Error> {
     let _walletd = launch("walletd", &["--token", &wallet_token.to_string()])?;
+
+    if config.is_auto_funding_enable() {
+        info!("farcasterd will attempt to fund automatically");
+    }
+
     let runtime = Runtime {
         identity: ServiceId::Farcasterd,
         listens: none!(),
@@ -111,12 +116,7 @@ pub fn run(
         funding_xmr: none!(),
         funding_btc: none!(),
         config,
-        auto_fund: opts.auto_fund,
     };
-
-    if opts.auto_fund {
-        info!("farcasterd will attempt to fund automatically");
-    }
 
     let broker = true;
     Service::run(service_config, runtime, broker)
@@ -145,7 +145,6 @@ pub struct Runtime {
     funding_xmr: HashMap<SwapId, (monero::Address, monero::Amount)>,
     stats: Stats,
     config: Config,
-    auto_fund: bool,
 }
 
 struct Stats {
@@ -915,32 +914,38 @@ impl Runtime {
                     )?;
                 }
             }
-            Request::FundingInfo(info) => {
-                match info {
-                    FundingInfo::Bitcoin(BitcoinFundingInfo {
-                        swap_id,
-                        address,
-                        amount,
-                    }) if self.auto_fund => {
+            Request::FundingInfo(info) => match info {
+                FundingInfo::Bitcoin(BitcoinFundingInfo {
+                    swap_id,
+                    address,
+                    amount,
+                }) => {
+                    let network = match address.network {
+                        bitcoin::Network::Bitcoin => Network::Mainnet,
+                        bitcoin::Network::Testnet => Network::Testnet,
+                        bitcoin::Network::Signet => Network::Testnet,
+                        bitcoin::Network::Regtest => Network::Local,
+                    };
+                    if let Some(auto_fund_config) = self.config.get_auto_funding_config(network) {
                         info!(
                             "{} | Attempting to auto-fund Bitcoin",
                             swap_id.bright_blue_italic()
                         );
+                        debug!(
+                            "{} | Auto funding config: {:#?}",
+                            swap_id.bright_blue_italic(),
+                            auto_fund_config
+                        );
+
                         use bitcoincore_rpc::{Auth, Client, RpcApi};
                         use std::env;
                         use std::path::PathBuf;
                         use std::str::FromStr;
 
-                        let path = match env::var("BITCOIN_COOKIE") {
-                            Ok(cookie) => PathBuf::from_str(&cookie).unwrap(),
-                            Err(_) => PathBuf::from(
-                                shellexpand::tilde("~/.bitcoin/testnet3/.cookie").to_string(),
-                            ),
-                        };
-                        let host = env::var("BITCOIN_HOST").unwrap_or("localhost".into());
-                        let bitcoin_rpc =
-                            Client::new(&format!("http://{}:18334", host), Auth::CookieFile(path))
-                                .unwrap();
+                        let cookie = auto_fund_config.bitcoin_cookie_path;
+                        let path = PathBuf::from_str(&shellexpand::tilde(&cookie)).unwrap();
+                        let host = auto_fund_config.bitcoin_rpc;
+                        let bitcoin_rpc = Client::new(&host, Auth::CookieFile(path)).unwrap();
 
                         match bitcoin_rpc
                             .send_to_address(&address, amount, None, None, None, None, None, None)
@@ -958,22 +963,29 @@ impl Runtime {
                                 self.funding_btc.insert(swap_id, (address, amount));
                             }
                         }
-                    }
-                    FundingInfo::Bitcoin(BitcoinFundingInfo {
-                        swap_id,
-                        address,
-                        amount,
-                    }) => {
+                    } else {
                         self.funding_btc.insert(swap_id, (address, amount));
                     }
-                    FundingInfo::Monero(MoneroFundingInfo {
-                        swap_id,
-                        address,
-                        amount,
-                    }) if self.auto_fund => {
+                }
+                FundingInfo::Monero(MoneroFundingInfo {
+                    swap_id,
+                    address,
+                    amount,
+                }) => {
+                    let network = match address.network {
+                        monero::Network::Mainnet => Network::Mainnet,
+                        monero::Network::Stagenet => Network::Testnet,
+                        monero::Network::Testnet => Network::Local,
+                    };
+                    if let Some(auto_fund_config) = self.config.get_auto_funding_config(network) {
                         info!(
                             "{} | Attempting to auto-fund Monero",
                             swap_id.bright_blue_italic()
+                        );
+                        debug!(
+                            "{} | Auto funding config: {:#?}",
+                            swap_id.bright_blue_italic(),
+                            auto_fund_config
                         );
                         use tokio::runtime::Builder;
                         let rt = Builder::new_multi_thread()
@@ -982,43 +994,39 @@ impl Runtime {
                             .build()
                             .unwrap();
                         rt.block_on(async {
-                        let wallet_client =
-                            monero_rpc::RpcClient::new("http://localhost:18083".to_string());
-                        let wallet = wallet_client.wallet();
-                        let options = monero_rpc::TransferOptions::default();
-                        let mut destination = HashMap::new();
-                        destination.insert(address, amount.as_pico());
-                        match wallet
-                            .transfer(
-                                destination.clone(),
-                                monero_rpc::TransferPriority::Default,
-                                options.clone(),
-                            )
-                            .await
-                        {
-                            Ok(tx) => {
-                                info!(
-                                    "{} | Auto-funded Monero with txid: {}",
-                                    &swap_id.bright_blue_italic(),
-                                    tx.tx_hash.to_string()
-                                );
+                            let host = auto_fund_config.monero_rpc_wallet;
+                            let wallet_client =
+                                monero_rpc::RpcClient::new(host);
+                            let wallet = wallet_client.wallet();
+                            let options = monero_rpc::TransferOptions::default();
+                            let mut destination = HashMap::new();
+                            destination.insert(address, amount.as_pico());
+                            match wallet
+                                .transfer(
+                                    destination.clone(),
+                                    monero_rpc::TransferPriority::Default,
+                                    options.clone(),
+                                )
+                                .await
+                            {
+                                Ok(tx) => {
+                                    info!(
+                                        "{} | Auto-funded Monero with txid: {}",
+                                        &swap_id.bright_blue_italic(),
+                                        tx.tx_hash.to_string()
+                                    );
+                                }
+                                Err(_) => {
+                                    error!("{} | Auto-funding Monero transaction failed, pushing to cli", &swap_id.bright_blue_italic());
+                                    self.funding_xmr.insert(swap_id, (address, amount));
+                                }
                             }
-                            Err(_) => {
-                                error!("{} | Auto-funding Monero transaction failed, pushing to cli", &swap_id.bright_blue_italic());
-                                self.funding_xmr.insert(swap_id, (address, amount));
-                            }
-                        }
-                    });
-                    }
-                    FundingInfo::Monero(MoneroFundingInfo {
-                        swap_id,
-                        address,
-                        amount,
-                    }) => {
+                        });
+                    } else {
                         self.funding_xmr.insert(swap_id, (address, amount));
                     }
                 }
-            }
+            },
 
             Request::FundingCompleted(swap_id) => {
                 info!("{} | Funding completed", swap_id.bright_blue_italic());


### PR DESCRIPTION
Move the `--auto-fund` parameter from cmd line argument to `farcasterd.toml` config file and added list of node and paramter to use per network when auto-funding is enable.

The funding logic stays exactly the same, just where parameters come from has changed. The pattern matching has changed to include the network selection to see if auto-funding is configure or not.

**Auto-funding will work only if `auto_fund` is set to true and if the network is registered in the config, otherwise manual funding is used.**