### PR TITLE
Swapd: Lower xmr finality threshold to 1

### DIFF
--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -127,7 +127,7 @@ pub fn run(
         punish_timelock: punish_timelock.as_u32(),
         btc_finality_thr: 1,
         race_thr: 3,
-        xmr_finality_thr: 5,
+        xmr_finality_thr: 1,
         sweep_monero_thr,
     };
 


### PR DESCRIPTION
Bitcoin testnet is too fast at the moment, leading to all swaps being cancelled.
Should we put it to 0 even?