### PR TITLE
Fee estimation

### DIFF
--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -2413,6 +2413,9 @@ impl Runtime {
                     Event::TransactionRetrieved(event) => {
                         debug!("{}", event)
                     }
+                    Event::FeeEstimation(event) => {
+                        debug!("{}", event)
+                    }
                 }
             }
             Request::Protocol(Msg::CoreArbitratingSetup(core_arb_setup)) if self.state.reveal() => {

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -755,12 +755,7 @@ fn estimate_fee(
             }) {
                 Ok(fee) => {
                     let fee = format!("{:.8} BTC", fee);
-                    let amount =
-                        if let Ok(amount) = bitcoin::Amount::from_str_with_denomination(&fee) {
-                            Some(amount)
-                        } else {
-                            None
-                        };
+                    let amount = bitcoin::Amount::from_str_with_denomination(&fee).ok();
                     tx_event
                         .send(SyncerdBridgeEvent {
                             event: Event::FeeEstimation(FeeEstimation {

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -344,6 +344,9 @@ async fn run_syncerd_task_receiver(
                         Task::GetTx(_) => {
                             error!("get tx not implemented for monero syncer");
                         }
+                        Task::EstimateFee(_) => {
+                            error!("estimate fee not implemented for monero syncer");
+                        }
                         Task::SweepAddress(task) => match task.addendum.clone() {
                             SweepAddressAddendum::Monero(sweep) => {
                                 let addr = sweep.address;

--- a/src/syncerd/types.rs
+++ b/src/syncerd/types.rs
@@ -204,6 +204,13 @@ pub struct GetTx {
     pub hash: Vec<u8>,
 }
 
+#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[display(Debug)]
+pub struct EstimateFee {
+    pub id: TaskId,
+    pub blocks_until_confirmation: usize,
+}
+
 /// Tasks created by the daemon and handle by syncers to process a blockchain
 /// and generate [`Event`] back to the syncer.
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
@@ -216,6 +223,7 @@ pub enum Task {
     BroadcastTransaction(BroadcastTransaction),
     SweepAddress(SweepAddress),
     GetTx(GetTx),
+    EstimateFee(EstimateFee),
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
@@ -277,6 +285,13 @@ pub struct TransactionRetrieved {
     pub tx: Option<bitcoin::Transaction>,
 }
 
+#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[display(Debug)]
+pub struct FeeEstimation {
+    pub id: TaskId,
+    pub btc_per_kbyte: Option<bitcoin::Amount>,
+}
+
 /// Events returned by syncers to the daemon to update the blockchain states.
 /// Events are identified with a unique 32-bits integer that match the [`Task`]
 /// id.
@@ -293,4 +308,5 @@ pub enum Event {
     /// Carries the status for the task abortion.
     TaskAborted(TaskAborted),
     TransactionRetrieved(TransactionRetrieved),
+    FeeEstimation(FeeEstimation),
 }


### PR DESCRIPTION
Based on #388

@zkao , I am loosing quite some precision with the amount parsing. The reason I'm using the bitcoin amount type is that sending a float in the emitted Event is kind of hard to get right, since we can't hash floats. Do you want a string instead, that can then be parsed into a float?