### PR TITLE
Make progress serializable

### DIFF
--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -218,7 +218,8 @@ impl Exec for Command {
 
             Command::Progress { swapid } => {
                 runtime.request(ServiceId::Farcasterd, Request::ReadProgress(swapid))?;
-                runtime.report_progress()?;
+                // runtime.report_progress()?;
+                runtime.report_response()?;
             }
 
             Command::NeedsFunding { coin } => {

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -218,7 +218,6 @@ impl Exec for Command {
 
             Command::Progress { swapid } => {
                 runtime.request(ServiceId::Farcasterd, Request::ReadProgress(swapid))?;
-                // runtime.report_progress()?;
                 runtime.report_response()?;
             }
 

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -1031,8 +1031,6 @@ impl Runtime {
 
             Request::ReadProgress(swapid) => {
                 if let Some(queue) = self.progress.get_mut(&ServiceId::Swap(swapid)) {
-                    // let n = queue.len();
-
                     let mut swap_progress = SwapProgress {
                         failure: None,
                         messages: vec![],
@@ -1052,12 +1050,6 @@ impl Runtime {
                             }
                             _ => unreachable!("not handled here"),
                         };
-                        // let req = if i < n - 1 {
-                        // Request::Progress(x.clone())
-                        // } else {
-                        // Request::Success(OptionDetails(Some(x.clone())))
-                        // };
-                        // report_to.push((Some(source.clone()), req));
                     }
                     senders.send_to(
                         ServiceBus::Ctl,

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -555,7 +555,10 @@ impl Runtime {
                     );
                     report_to.push((
                         swap_params.report_to.clone(), // walletd
-                        Request::Progress(format!("Swap daemon {} operational", source)),
+                        Request::Progress(request::Progress::ProgressMessage(format!(
+                            "Swap daemon {} operational",
+                            source
+                        ))),
                     ));
                     let swapid = get_swap_id(&source)?;
                     // when online, Syncers say Hello, then they get registered to self.syncers
@@ -598,7 +601,10 @@ impl Runtime {
                     );
                     report_to.push((
                         swap_params.report_to.clone(), // walletd
-                        Request::Progress(format!("Swap daemon {} operational", source)),
+                        Request::Progress(request::Progress::ProgressMessage(format!(
+                            "Swap daemon {} operational",
+                            source
+                        ))),
                     ));
                     match swap_params.local_params {
                         Params::Alice(_) => {}
@@ -1038,12 +1044,12 @@ impl Runtime {
                     };
                     for (_i, req) in queue.iter().enumerate() {
                         match req {
-                            Request::Progress(x) | Request::Success(OptionDetails(Some(x))) => {
-                                if x.contains("State") {
-                                    swap_progress.state_transitions.push(x.clone());
-                                } else {
-                                    swap_progress.messages.push(x.clone());
-                                }
+                            Request::Progress(request::Progress::ProgressMessage(x))
+                            | Request::Success(OptionDetails(Some(x))) => {
+                                swap_progress.messages.push(x.clone());
+                            }
+                            Request::Progress(request::Progress::StateTransition(x)) => {
+                                swap_progress.state_transitions.push(x.clone());
                             }
                             Request::Failure(Failure { code: _, info: x }) => {
                                 swap_progress.failure = Some(x.clone());

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -1051,7 +1051,7 @@ impl Runtime {
                             _ => unreachable!("not handled here"),
                         };
                     }
-                    senders.send_to(
+                    endpoints.send_to(
                         ServiceBus::Ctl,
                         self.identity(),
                         source,

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -484,10 +484,17 @@ pub enum Request {
     #[api(type = 1004)]
     #[display("{0}")]
     String(String),
+
     #[api(type = 1002)]
     #[display("progress({0})")]
     Progress(String),
 
+    #[api(type = 1005)]
+    #[display("swap_progress({0})", alt = "{0:#}")]
+    SwapProgress(SwapProgress),
+    // #[api(type = 207)]
+    // #[display("took_offer({0})", alt = "{0:#}")]
+    // TookOffer(TookOffer),
     #[api(type = 1003)]
     #[display("read_progress({0})")]
     ReadProgress(SwapId),
@@ -837,6 +844,20 @@ pub struct TookOffer {
 }
 
 #[cfg_attr(feature = "serde", serde_as)]
+#[derive(Clone, PartialEq, Eq, Debug, Display, Default, StrictEncode, StrictDecode)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
+#[display(SwapProgress::to_yaml_string)]
+pub struct SwapProgress {
+    pub failure: Option<String>,
+    pub state_transitions: Vec<String>,
+    pub messages: Vec<String>,
+}
+
+#[cfg_attr(feature = "serde", serde_as)]
 #[derive(Clone, PartialEq, Eq, Debug, Display, StrictEncode, StrictDecode)]
 #[cfg_attr(
     feature = "serde",
@@ -915,6 +936,8 @@ impl ToYamlString for SyncerInfo {}
 impl ToYamlString for MadeOffer {}
 #[cfg(feature = "serde")]
 impl ToYamlString for TookOffer {}
+#[cfg(feature = "serde")]
+impl ToYamlString for SwapProgress {}
 
 #[derive(Wrapper, Clone, PartialEq, Eq, Debug, From, StrictEncode, StrictDecode)]
 #[wrapper(IndexRange)]

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -32,7 +32,7 @@ use lazy_static::lazy_static;
 use lightning_encoding::{strategies::AsStrict, LightningDecode, LightningEncode};
 use monero::consensus::{Decodable as MoneroDecodable, Encodable as MoneroEncodable};
 #[cfg(feature = "serde")]
-use serde_with::{DisplayFromStr, DurationSeconds, Same};
+use serde_with::{skip_serializing_none, DisplayFromStr, DurationSeconds, Same};
 use std::{collections::BTreeMap, convert::TryInto};
 use std::{
     fmt::{self, Debug, Display, Formatter},
@@ -852,6 +852,7 @@ pub struct TookOffer {
 )]
 #[display(SwapProgress::to_yaml_string)]
 pub struct SwapProgress {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub failure: Option<String>,
     pub state_transitions: Vec<String>,
     pub messages: Vec<String>,

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -487,7 +487,7 @@ pub enum Request {
 
     #[api(type = 1002)]
     #[display("progress({0})")]
-    Progress(String),
+    Progress(Progress),
 
     #[api(type = 1005)]
     #[display("swap_progress({0})", alt = "{0:#}")]
@@ -745,6 +745,13 @@ pub struct InitSwap {
     pub swap_id: SwapId,
     pub remote_commit: Option<Commit>,
     pub funding_address: Option<bitcoin::Address>,
+}
+
+#[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
+#[display("progress {}")]
+pub enum Progress {
+    ProgressMessage(String),
+    StateTransition(String),
 }
 
 #[cfg_attr(feature = "serde", serde_as)]
@@ -1019,7 +1026,7 @@ pub trait IntoSuccessOrFailure {
 impl IntoProgressOrFailure for Result<String, crate::Error> {
     fn into_progress_or_failure(self) -> Request {
         match self {
-            Ok(val) => Request::Progress(val),
+            Ok(val) => Request::Progress(Progress::ProgressMessage(val)),
             Err(err) => Request::from(err),
         }
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -12,6 +12,7 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
+use crate::rpc::request::Progress;
 use crate::syncerd::opts::Coin;
 use std::convert::TryInto;
 use std::fmt::{self, Display, Formatter};
@@ -304,7 +305,7 @@ where
         Ok(())
     }
 
-    fn report_progress_to(
+    fn report_progress_message_to(
         &mut self,
         senders: &mut Endpoints,
         dest: impl TryToServiceId,
@@ -315,7 +316,24 @@ where
                 ServiceBus::Ctl,
                 self.identity(),
                 dest,
-                Request::Progress(msg.to_string()),
+                Request::Progress(Progress::ProgressMessage(msg.to_string())),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn report_state_transition_progress_message_to(
+        &mut self,
+        senders: &mut Endpoints,
+        dest: impl TryToServiceId,
+        msg: impl ToString,
+    ) -> Result<(), Error> {
+        if let Some(dest) = dest.try_to_service_id() {
+            senders.send_to(
+                ServiceBus::Ctl,
+                self.identity(),
+                dest,
+                Request::Progress(Progress::StateTransition(msg.to_string())),
             )?;
         }
         Ok(())

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -1037,13 +1037,14 @@ impl Runtime {
         }
     }
 
-    fn state_update(&mut self, endpoints: &mut Endpoints, next_state: State) -> Result<(), Error> {
-        let msg = format!(
-            "State transition: {} -> {}",
+    fn state_update(&mut self, endpoints: &mut Senders, next_state: State) -> Result<(), Error> {
+        info!(
+            "{} | State transition: {} -> {}",
+            self.swap_id.bright_blue_italic(),
             self.state.bright_white_bold(),
-            next_state.bright_white_bold()
+            next_state.bright_white_bold(),
         );
-        info!("{} | {}", self.swap_id.bright_blue_italic(), &msg);
+        let msg = format!("{} -> {}", self.state, next_state,);
         self.state = next_state;
         self.report_success_to(endpoints, self.enquirer.clone(), Some(msg))?;
         Ok(())
@@ -2681,12 +2682,11 @@ impl Runtime {
         endpoints: &mut Endpoints,
         params: Params,
     ) -> Result<request::Commit, Error> {
-        let msg = format!(
-            "{} {} to Maker remote peer",
+        info!(
+            "{} | {} to Maker remote peer",
+            self.swap_id().bright_blue_italic(),
             "Proposing to take swap".bright_white_bold(),
-            self.swap_id().bright_blue_italic()
         );
-        info!("{} | {}", self.swap_id.bright_blue_italic(), &msg);
         let engine = CommitmentEngine;
         let commitment = match params {
             Params::Bob(params) => request::Commit::BobParameters(
@@ -2699,7 +2699,8 @@ impl Runtime {
         // Ignoring possible reporting errors here and after: do not want to
         // halt the swap just because the client disconnected
         let enquirer = self.enquirer.clone();
-        let _ = self.report_progress_to(endpoints, &enquirer, msg);
+        let msg = format!("Proposing to take swap to Maker remote peer",);
+        let _ = self.report_progress_to(senders, &enquirer, msg);
 
         Ok(commitment)
     }
@@ -2711,16 +2712,19 @@ impl Runtime {
         swap_id: SwapId,
         params: &Params,
     ) -> Result<request::Commit, Error> {
-        let msg = format!(
-            "{} {} as Maker from Taker through peerd {}",
+        info!(
+            "{} | {} as Maker from Taker through peerd {}",
             "Accepting swap".bright_white_bold(),
             swap_id.bright_blue_italic(),
             peerd.bright_blue_italic()
         );
-        info!("{} | {}", self.swap_id.bright_blue_italic(), msg);
 
         // Ignoring possible reporting errors here and after: do not want to
         // halt the channel just because the client disconnected
+        let msg = format!(
+            "Accepting swap {} as Maker from Taker through peerd {}",
+            swap_id, peerd
+        );
         let enquirer = self.enquirer.clone();
         let _ = self.report_progress_to(endpoints, &enquirer, msg);
 

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -1037,7 +1037,7 @@ impl Runtime {
         }
     }
 
-    fn state_update(&mut self, endpoints: &mut Senders, next_state: State) -> Result<(), Error> {
+    fn state_update(&mut self, endpoints: &mut Endpoints, next_state: State) -> Result<(), Error> {
         info!(
             "{} | State transition: {} -> {}",
             self.swap_id.bright_blue_italic(),
@@ -2700,7 +2700,7 @@ impl Runtime {
         // halt the swap just because the client disconnected
         let enquirer = self.enquirer.clone();
         let msg = format!("Proposing to take swap to Maker remote peer",);
-        let _ = self.report_progress_to(senders, &enquirer, msg);
+        let _ = self.report_progress_to(endpoints, &enquirer, msg);
 
         Ok(commitment)
     }

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -2712,7 +2712,7 @@ impl Runtime {
         params: &Params,
     ) -> Result<request::Commit, Error> {
         let msg = format!(
-            "{} {} as Maker from Taker remote peer {}",
+            "{} {} as Maker from Taker through peerd {}",
             "Accepting swap".bright_white_bold(),
             swap_id.bright_blue_italic(),
             peerd.bright_blue_italic()
@@ -2733,14 +2733,6 @@ impl Runtime {
                 CommitAliceParameters::commit_to_bundle(self.swap_id(), &engine, params),
             ),
         };
-
-        let msg = format!(
-            "{} swap {:#} from remote peer Taker {}",
-            "Making".bright_green_bold(),
-            swap_id.bright_green_italic(),
-            peerd.bright_green_italic()
-        );
-        let _ = self.report_success_to(endpoints, &enquirer, Some(msg));
         Ok(commitment)
     }
 }

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -1046,7 +1046,7 @@ impl Runtime {
         );
         let msg = format!("{} -> {}", self.state, next_state,);
         self.state = next_state;
-        self.report_success_to(endpoints, self.enquirer.clone(), Some(msg))?;
+        self.report_state_transition_progress_message_to(endpoints, self.enquirer.clone(), msg)?;
         Ok(())
     }
 
@@ -2700,7 +2700,7 @@ impl Runtime {
         // halt the swap just because the client disconnected
         let enquirer = self.enquirer.clone();
         let msg = format!("Proposing to take swap to Maker remote peer",);
-        let _ = self.report_progress_to(endpoints, &enquirer, msg);
+        let _ = self.report_progress_message_to(endpoints, &enquirer, msg);
 
         Ok(commitment)
     }
@@ -2726,7 +2726,7 @@ impl Runtime {
             swap_id, peerd
         );
         let enquirer = self.enquirer.clone();
-        let _ = self.report_progress_to(endpoints, &enquirer, msg);
+        let _ = self.report_progress_message_to(endpoints, &enquirer, msg);
 
         let engine = CommitmentEngine;
         let commitment = match params.clone() {

--- a/src/syncerd/runtime.rs
+++ b/src/syncerd/runtime.rs
@@ -16,6 +16,7 @@ use crate::service::Endpoints;
 use crate::syncerd::bitcoin_syncer::BitcoinSyncer;
 use crate::syncerd::monero_syncer::MoneroSyncer;
 use crate::syncerd::opts::{Coin, Opts};
+use crate::syncerd::runtime::request::Progress;
 use amplify::Wrapper;
 use farcaster_core::blockchain::Network;
 use std::collections::{HashMap, HashSet};
@@ -206,7 +207,7 @@ impl Runtime {
                     source.clone(),
                     Request::TaskList(self.tasks.iter().cloned().collect()),
                 )?;
-                let resp = Request::Progress("ListedTasks?".to_string());
+                let resp = Request::Progress(Progress::ProgressMessage("ListedTasks?".to_string()));
                 notify_cli = Some((Some(source), resp));
             }
 


### PR DESCRIPTION
Make the `progress` cli call serializable. Closes #285 . Based on #437 .


`progress` on current main:

```
swap1-cli progress 0x4102d9b10eb81644764e792e8f5fa3131121eb77fdf6ad3d2c18f1a6175ef9db                                                             ✔
Proposing to take swap 0x4102…f9db to Maker remote peer
State transition: AliceState(Start) -> AliceState(Commit)
Success: State transition: AliceState(Commit) -> AliceState(Reveal)
```


`progress` after this PR:

```
swap1-cli progress 0x2d1cc3c8c3a75c9a0e0192adb0975620685d7c510abc3c4e7a145a6ddeff3df3
---
state_transitions:
  - AliceState(Start) -> AliceState(Commit)
  - AliceState(Commit) -> AliceState(Reveal)
messages:
  - Proposing to take swap to Maker remote peer
```
