### PR TITLE
Bump CI container versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,13 +59,13 @@ jobs:
             logs: true
     runs-on: ubuntu-latest
     container:
-      image: rust:slim-buster
+      image: rust:slim-bullseye
       volumes:
         - bitcoind-data:/data
 
     services:
-      bitcoin-core:
-        image: ghcr.io/farcaster-project/containers/bitcoin-core:0.21.1
+      bitcoind:
+        image: ghcr.io/farcaster-project/containers/bitcoin-core:22.0
         env:
           NETWORK: regtest
           RPC_PORT: 18443
@@ -76,37 +76,36 @@ jobs:
         image: ghcr.io/farcaster-project/containers/electrs:0.8.11
         env:
           NETWORK: regtest
-          DAEMON_RPC_ADDR: bitcoin-core:18443
-          ELECTRUM_RPC_PORT: 50001
+          DAEMON_RPC_ADDR: bitcoind:18443
+          ELECTRUM_RPC_PORT: 60401
         volumes:
           - bitcoind-data:/data
       monerod:
-        image: ghcr.io/farcaster-project/containers/monerod:0.17.2.3
+        image: ghcr.io/farcaster-project/containers/monerod:0.17.3.2
         env:
           NETWORK: regtest
-          MONEROD_RPC_PORT: 18081
           OFFLINE: --offline
           DIFFICULTY: 1
       monero-wallet-rpc-1:
-        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3
+        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.3.2
         env:
-          MONEROD_ADDRESS: monerod:18081
+          MONERO_DAEMON_ADDRESS: monerod:18081
           WALLET_RPC_PORT: 18083
       monero-wallet-rpc-2:
-        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3
+        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.3.2
         env:
-          MONEROD_ADDRESS: monerod:18081
+          MONERO_DAEMON_ADDRESS: monerod:18081
           WALLET_RPC_PORT: 18084
       monero-wallet-rpc-3:
-        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3
+        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.3.2
         env:
-          MONEROD_ADDRESS: monerod:18081
-          WALLET_RPC_PORT: 18085
+          MONERO_DAEMON_ADDRESS: monerod:18081
+          WALLET_RPC_PORT: 18083
       monero-lws:
         image: ghcr.io/farcaster-project/containers/monero-lws:latest
         env:
-          MONERO_DAEMON_ADDRESS: monerod:18082
           NETWORK: main
+          MONERO_DAEMON_ADDRESS: monerod:18082
 
     steps:
       - uses: actions/checkout@v3
@@ -125,7 +124,7 @@ jobs:
         run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features --no-fail-fast --verbose -- --ignored --nocapture --test-threads=1
         env:
           BITCOIN_COOKIE: /data/regtest/.cookie
-          BITCOIN_HOST: bitcoin-core
+          BITCOIN_HOST: bitcoind
           ELECTRS_HOST: electrs
           MONERO_DAEMON_HOST: monerod
           MONERO_WALLET_HOST_1: monero-wallet-rpc-1

--- a/tests/.farcasterd_1.ci.toml
+++ b/tests/.farcasterd_1.ci.toml
@@ -1,5 +1,4 @@
 [syncers.local]
-electrum_server = "tcp://electrs:50001"
+electrum_server = "tcp://electrs:60401"
 monero_daemon = "http://monerod:18081"
 monero_rpc_wallet = "http://monero-wallet-rpc-2:18084"
-

--- a/tests/.farcasterd_1.toml
+++ b/tests/.farcasterd_1.toml
@@ -1,5 +1,4 @@
 [syncers.local]
-electrum_server = "tcp://localhost:50001"
+electrum_server = "tcp://localhost:60401"
 monero_daemon = "http://localhost:18081"
 monero_rpc_wallet = "http://localhost:18084"
-

--- a/tests/.farcasterd_2.ci.toml
+++ b/tests/.farcasterd_2.ci.toml
@@ -1,5 +1,4 @@
 [syncers.local]
-electrum_server = "tcp://electrs:50001"
+electrum_server = "tcp://electrs:60401"
 monero_daemon = "http://monerod:18081"
-monero_rpc_wallet = "http://monero-wallet-rpc-3:18085"
-
+monero_rpc_wallet = "http://monero-wallet-rpc-3:18083"

--- a/tests/.farcasterd_2.toml
+++ b/tests/.farcasterd_2.toml
@@ -1,5 +1,4 @@
 [syncers.local]
-electrum_server = "tcp://localhost:50001"
+electrum_server = "tcp://localhost:60401"
 monero_daemon = "http://localhost:18081"
 monero_rpc_wallet = "http://localhost:18085"
-

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,6 +3,7 @@
 Start needed containers for supporting the tests with:
 
 ```
+docker-compose pull
 docker-compose up -d
 sudo chown -R $USER data_dir
 ```
@@ -10,19 +11,19 @@ sudo chown -R $USER data_dir
 Run `bitcoin` tests:
 
 ```
-cargo test bitcoin --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1
+cargo test bitcoin --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1 --nocapture
 ```
 
 Run `monero` tests:
 
 ```
-cargo test monero --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1
+cargo test monero --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1 --nocapture
 ```
 
 Run `swap` tests:
 
 ```
-cargo test swap --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1
+cargo test swap --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1 --nocapture
 ```
 
 ## Steps
@@ -37,6 +38,6 @@ Alternatively, the regtest setup can be run directly on the host, with the tests
 
 - Bitcoind rpc cookie at `./tests/data_dir/regtest/.cookie`
 - Bitcoind at `http://localhost:18443`
-- Electrs at `tcp://localhost:50001`
+- Electrs at `tcp://localhost:60401`
 - Monerod at `http://localhost:18081` run with arguments `--regtest --offline --fixed-difficulty 1`
-- Two instances of Monero-wallet-rpc at `http://localhost:18083` and `htp://localhost:18084` run with arguments `--disable-rpc-login --wallet-dir wallets`
+- Three instances of Monero-wallet-rpc at `http://localhost:18083|18084|18085` run with arguments `--disable-rpc-login --wallet-dir wallets`

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
-    bitcoin-core:
-        image: ghcr.io/farcaster-project/containers/bitcoin-core:0.21.1
+    bitcoind:
+        image: ghcr.io/farcaster-project/containers/bitcoin-core:22.0
         environment:
             NETWORK: regtest
             RPC_PORT: 18443
@@ -15,46 +15,45 @@ services:
         image: ghcr.io/farcaster-project/containers/electrs:0.8.11
         environment:
             NETWORK: regtest
-            DAEMON_RPC_ADDR: bitcoin-core:18443
-            ELECTRUM_RPC_PORT: 50001
+            DAEMON_RPC_ADDR: bitcoind:18443
+            ELECTRUM_RPC_PORT: 60401
         depends_on:
-            - "bitcoin-core"
+            - "bitcoind"
         volumes:
             - ./data_dir:/data
         ports:
-            - 50001:50001
+            - 60401:60401
     monerod:
-        image: ghcr.io/farcaster-project/containers/monerod:0.17.2.3
+        image: ghcr.io/farcaster-project/containers/monerod:0.17.3.2
         environment:
             NETWORK: regtest
-            MONEROD_RPC_PORT: 18081
             OFFLINE: --offline
             DIFFICULTY: 1
         ports:
             - 18081:18081
             - 18082:18082
     monero-wallet-rpc-1:
-        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3
+        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.3.2
         environment:
-            MONEROD_ADDRESS: monerod:18081
+            MONERO_DAEMON_ADDRESS: monerod:18081
             WALLET_RPC_PORT: 18083
         depends_on:
             - "monerod"
         ports:
             - 18083:18083
     monero-wallet-rpc-2:
-        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3
+        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.3.2
         environment:
-            MONEROD_ADDRESS: monerod:18081
+            MONERO_DAEMON_ADDRESS: monerod:18081
             WALLET_RPC_PORT: 18083
         depends_on:
             - "monerod"
         ports:
             - 18084:18083
     monero-wallet-rpc-3:
-        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3
+        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.3.2
         environment:
-            MONEROD_ADDRESS: monerod:18081
+            MONERO_DAEMON_ADDRESS: monerod:18081
             WALLET_RPC_PORT: 18083
         depends_on:
             - "monerod"
@@ -63,10 +62,9 @@ services:
     monero-lws-daemon:
         image: ghcr.io/farcaster-project/containers/monero-lws:latest
         environment:
-            MONERO_DAEMON_ADDRESS: monerod:18082
             NETWORK: main
+            MONERO_DAEMON_ADDRESS: monerod:18082
         depends_on:
             - "monerod"
         ports:
             - 38884:38884
-

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -931,7 +931,7 @@ fn create_bitcoin_syncer(
         "--coin",
         "Bitcoin",
         "--electrum-server",
-        &format!("tcp://{}:50001", ehost),
+        &format!("tcp://{}:60401", ehost),
     ]));
 
     syncer


### PR DESCRIPTION
Update the CI functional tests container versions:
- bump bitcoin to `22.0`
- bump monerod to `0.17.3.2`
- bump monero-wallet-rpc to `0.17.3.2`

Syncer and tests must be rewritten to work with bitcoin `23.0` and electrs `0.9.x`. This is out of scope of this PR.