### PR TITLE
Peerd: Only send whitelisted Msg's over the bridge

### DIFF
--- a/src/peerd/runtime.rs
+++ b/src/peerd/runtime.rs
@@ -222,24 +222,15 @@ impl peer::Handler<Msg> for PeerReceiverRuntime {
                 error!("Unexpected pong received in PeerReceiverRuntime.")
             }
         }
-        // Forwarding received and whitelisted messages to the runtime
-        match *Arc::clone(&message) {
-            Msg::MakerCommit(_)
-            | Msg::TakerCommit(_)
-            | Msg::Reveal(_)
-            | Msg::RefundProcedureSignatures(_)
-            | Msg::CoreArbitratingSetup(_)
-            | Msg::BuyProcedureSignature(_)
-            | Msg::Ping(_)
-            | Msg::Pong(_) => self.send_over_bridge(message),
-            _ => {
-                debug!(
-                    "Ignoring message {}, did not match peer receiving whitelist",
-                    message
-                );
-                Ok(())
-            }
+        if message.on_receiver_whitelist() {
+            self.send_over_bridge(message)?;
+        } else {
+            debug!(
+                "Ignoring message {}, did not match peer receiving whitelist",
+                message
+            );
         }
+        Ok(())
     }
 
     fn handle_err(&mut self, err: Self::Error) -> Result<(), Self::Error> {

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -153,6 +153,20 @@ impl Msg {
             }
         }
     }
+
+    pub fn on_receiver_whitelist(&self) -> bool {
+        matches!(
+            self,
+            Msg::MakerCommit(_)
+                | Msg::TakerCommit(_)
+                | Msg::Reveal(_)
+                | Msg::RefundProcedureSignatures(_)
+                | Msg::CoreArbitratingSetup(_)
+                | Msg::BuyProcedureSignature(_)
+                | Msg::Ping(_)
+                | Msg::Pong(_)
+        )
+    }
 }
 
 impl LightningEncode for Msg {


### PR DESCRIPTION
Only some of the messages should be allowed through the PeerdReceiverRuntime to the peerd Runtime. I don't like this explicit listing of messages, is there some other method to select this subset of enum variants?