### PR TITLE
Make progress serializable - alternative

### DIFF
--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -218,7 +218,8 @@ impl Exec for Command {
 
             Command::Progress { swapid } => {
                 runtime.request(ServiceId::Farcasterd, Request::ReadProgress(swapid))?;
-                runtime.report_progress()?;
+                // runtime.report_progress()?;
+                runtime.report_response()?;
             }
 
             Command::NeedsFunding { coin } => {

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -218,7 +218,6 @@ impl Exec for Command {
 
             Command::Progress { swapid } => {
                 runtime.request(ServiceId::Farcasterd, Request::ReadProgress(swapid))?;
-                // runtime.report_progress()?;
                 runtime.report_response()?;
             }
 

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -585,7 +585,10 @@ impl Runtime {
                     );
                     report_to.push((
                         swap_params.report_to.clone(), // walletd
-                        Request::Progress(format!("Swap daemon {} operational", source)),
+                        Request::Progress(request::Progress::ProgressMessage(format!(
+                            "Swap daemon {} operational",
+                            source
+                        ))),
                     ));
                     let swapid = get_swap_id(&source)?;
                     // when online, Syncers say Hello, then they get registered to self.syncers
@@ -628,7 +631,10 @@ impl Runtime {
                     );
                     report_to.push((
                         swap_params.report_to.clone(), // walletd
-                        Request::Progress(format!("Swap daemon {} operational", source)),
+                        Request::Progress(request::Progress::ProgressMessage(format!(
+                            "Swap daemon {} operational",
+                            source
+                        ))),
                     ));
                     match swap_params.local_params {
                         Params::Alice(_) => {}
@@ -1069,12 +1075,12 @@ impl Runtime {
                     };
                     for (_i, req) in queue.iter().enumerate() {
                         match req {
-                            Request::Progress(x) | Request::Success(OptionDetails(Some(x))) => {
-                                if x.contains("State") {
-                                    swap_progress.state_transitions.push(x.clone());
-                                } else {
-                                    swap_progress.messages.push(x.clone());
-                                }
+                            Request::Progress(request::Progress::ProgressMessage(x))
+                            | Request::Success(OptionDetails(Some(x))) => {
+                                swap_progress.messages.push(x.clone());
+                            }
+                            Request::Progress(request::Progress::StateTransition(x)) => {
+                                swap_progress.state_transitions.push(x.clone());
                             }
                             Request::Failure(Failure { code: _, info: x }) => {
                                 swap_progress.failure = Some(x.clone());

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -1062,8 +1062,6 @@ impl Runtime {
 
             Request::ReadProgress(swapid) => {
                 if let Some(queue) = self.progress.get_mut(&ServiceId::Swap(swapid)) {
-                    // let n = queue.len();
-
                     let mut swap_progress = SwapProgress {
                         failure: None,
                         messages: vec![],
@@ -1083,12 +1081,6 @@ impl Runtime {
                             }
                             _ => unreachable!("not handled here"),
                         };
-                        // let req = if i < n - 1 {
-                        // Request::Progress(x.clone())
-                        // } else {
-                        // Request::Success(OptionDetails(Some(x.clone())))
-                        // };
-                        // report_to.push((Some(source.clone()), req));
                     }
                     senders.send_to(
                         ServiceBus::Ctl,

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -14,6 +14,7 @@
 // If not, see <https://opensource.org/licenses/MIT>.
 
 use crate::farcasterd::runtime::request::MadeOffer;
+use crate::farcasterd::runtime::request::SwapProgress;
 use crate::farcasterd::runtime::request::TookOffer;
 use crate::{
     clap::Parser,
@@ -1061,22 +1062,40 @@ impl Runtime {
 
             Request::ReadProgress(swapid) => {
                 if let Some(queue) = self.progress.get_mut(&ServiceId::Swap(swapid)) {
-                    let n = queue.len();
+                    // let n = queue.len();
 
-                    for (i, req) in queue.iter().enumerate() {
-                        let x = match req {
-                            Request::Progress(x)
-                            | Request::Success(OptionDetails(Some(x)))
-                            | Request::Failure(Failure { code: _, info: x }) => x,
+                    let mut swap_progress = SwapProgress {
+                        failure: None,
+                        messages: vec![],
+                        state_transitions: vec![],
+                    };
+                    for (_i, req) in queue.iter().enumerate() {
+                        match req {
+                            Request::Progress(x) | Request::Success(OptionDetails(Some(x))) => {
+                                if x.contains("State") {
+                                    swap_progress.state_transitions.push(x.clone());
+                                } else {
+                                    swap_progress.messages.push(x.clone());
+                                }
+                            }
+                            Request::Failure(Failure { code: _, info: x }) => {
+                                swap_progress.failure = Some(x.clone());
+                            }
                             _ => unreachable!("not handled here"),
                         };
-                        let req = if i < n - 1 {
-                            Request::Progress(x.clone())
-                        } else {
-                            Request::Success(OptionDetails(Some(x.clone())))
-                        };
-                        report_to.push((Some(source.clone()), req));
+                        // let req = if i < n - 1 {
+                        // Request::Progress(x.clone())
+                        // } else {
+                        // Request::Success(OptionDetails(Some(x.clone())))
+                        // };
+                        // report_to.push((Some(source.clone()), req));
                     }
+                    senders.send_to(
+                        ServiceBus::Ctl,
+                        self.identity(),
+                        source,
+                        Request::SwapProgress(swap_progress),
+                    )?;
                 } else {
                     let info = if self.making_swaps.contains_key(&ServiceId::Swap(swapid))
                         || self.taking_swaps.contains_key(&ServiceId::Swap(swapid))

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -1082,7 +1082,7 @@ impl Runtime {
                             _ => unreachable!("not handled here"),
                         };
                     }
-                    senders.send_to(
+                    endpoints.send_to(
                         ServiceBus::Ctl,
                         self.identity(),
                         source,

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -87,22 +87,14 @@ impl Client {
 
     pub fn report_failure(&mut self) -> Result<Request, Error> {
         match self.response()? {
-            Request::Failure(fail) =>
-            // // Errors reported on swap-cli binary
-            // eprintln!(
-            //     "{}: {}",
-            //     "Request failure".err(),
-            //     fail.err_details()
-            // );
-            {
-                Err(Error::from(fail))
-            }
+            Request::Failure(fail) => Err(Error::from(fail)),
             resp => Ok(resp),
         }
     }
 
     pub fn report_response(&mut self) -> Result<(), Error> {
         let resp = self.report_failure()?;
+        // note: this triggers the yaml formatting when implemented
         println!("{:#}", resp);
         Ok(())
     }

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -505,10 +505,17 @@ pub enum Request {
     #[api(type = 1004)]
     #[display("{0}")]
     String(String),
+
     #[api(type = 1002)]
     #[display("progress({0})")]
     Progress(String),
 
+    #[api(type = 1005)]
+    #[display("swap_progress({0})", alt = "{0:#}")]
+    SwapProgress(SwapProgress),
+    // #[api(type = 207)]
+    // #[display("took_offer({0})", alt = "{0:#}")]
+    // TookOffer(TookOffer),
     #[api(type = 1003)]
     #[display("read_progress({0})")]
     ReadProgress(SwapId),
@@ -860,6 +867,20 @@ pub struct TookOffer {
 }
 
 #[cfg_attr(feature = "serde", serde_as)]
+#[derive(Clone, PartialEq, Eq, Debug, Display, Default, StrictEncode, StrictDecode)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
+#[display(SwapProgress::to_yaml_string)]
+pub struct SwapProgress {
+    pub failure: Option<String>,
+    pub state_transitions: Vec<String>,
+    pub messages: Vec<String>,
+}
+
+#[cfg_attr(feature = "serde", serde_as)]
 #[derive(Clone, PartialEq, Eq, Debug, Display, StrictEncode, StrictDecode)]
 #[cfg_attr(
     feature = "serde",
@@ -938,6 +959,8 @@ impl ToYamlString for SyncerInfo {}
 impl ToYamlString for MadeOffer {}
 #[cfg(feature = "serde")]
 impl ToYamlString for TookOffer {}
+#[cfg(feature = "serde")]
+impl ToYamlString for SwapProgress {}
 
 #[derive(Wrapper, Clone, PartialEq, Eq, Debug, From, StrictEncode, StrictDecode)]
 #[wrapper(IndexRange)]

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -513,9 +513,7 @@ pub enum Request {
     #[api(type = 1005)]
     #[display("swap_progress({0})", alt = "{0:#}")]
     SwapProgress(SwapProgress),
-    // #[api(type = 207)]
-    // #[display("took_offer({0})", alt = "{0:#}")]
-    // TookOffer(TookOffer),
+
     #[api(type = 1003)]
     #[display("read_progress({0})")]
     ReadProgress(SwapId),

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -32,7 +32,7 @@ use lazy_static::lazy_static;
 use lightning_encoding::{strategies::AsStrict, LightningDecode, LightningEncode};
 use monero::consensus::{Decodable as MoneroDecodable, Encodable as MoneroEncodable};
 #[cfg(feature = "serde")]
-use serde_with::{DisplayFromStr, DurationSeconds, Same};
+use serde_with::{skip_serializing_none, DisplayFromStr, DurationSeconds, Same};
 use std::{collections::BTreeMap, convert::TryInto};
 use std::{
     fmt::{self, Debug, Display, Formatter},
@@ -875,6 +875,7 @@ pub struct TookOffer {
 )]
 #[display(SwapProgress::to_yaml_string)]
 pub struct SwapProgress {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub failure: Option<String>,
     pub state_transitions: Vec<String>,
     pub messages: Vec<String>,

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -508,7 +508,7 @@ pub enum Request {
 
     #[api(type = 1002)]
     #[display("progress({0})")]
-    Progress(String),
+    Progress(Progress),
 
     #[api(type = 1005)]
     #[display("swap_progress({0})", alt = "{0:#}")]
@@ -766,6 +766,13 @@ pub struct InitSwap {
     pub swap_id: SwapId,
     pub remote_commit: Option<Commit>,
     pub funding_address: Option<bitcoin::Address>,
+}
+
+#[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
+#[display("progress {}")]
+pub enum Progress {
+    ProgressMessage(String),
+    StateTransition(String),
 }
 
 #[cfg_attr(feature = "serde", serde_as)]
@@ -1042,7 +1049,7 @@ pub trait IntoSuccessOrFailure {
 impl IntoProgressOrFailure for Result<String, crate::Error> {
     fn into_progress_or_failure(self) -> Request {
         match self {
-            Ok(val) => Request::Progress(val),
+            Ok(val) => Request::Progress(Progress::ProgressMessage(val)),
             Err(err) => Request::from(err),
         }
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -322,7 +322,7 @@ where
                 ServiceBus::Ctl,
                 self.identity(),
                 dest,
-                Request::Progress(Progress::ProgressMessage(msg.to_string())),
+                Request::Progress(Progress::Message(msg.to_string())),
             )?;
         }
         Ok(())

--- a/src/service.rs
+++ b/src/service.rs
@@ -12,6 +12,7 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
+use crate::rpc::request::Progress;
 use crate::syncerd::opts::Coin;
 use std::convert::TryInto;
 use std::fmt::{self, Display, Formatter};
@@ -310,7 +311,7 @@ where
         Ok(())
     }
 
-    fn report_progress_to(
+    fn report_progress_message_to(
         &mut self,
         senders: &mut Endpoints,
         dest: impl TryToServiceId,
@@ -321,7 +322,24 @@ where
                 ServiceBus::Ctl,
                 self.identity(),
                 dest,
-                Request::Progress(msg.to_string()),
+                Request::Progress(Progress::ProgressMessage(msg.to_string())),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn report_state_transition_progress_message_to(
+        &mut self,
+        senders: &mut Endpoints,
+        dest: impl TryToServiceId,
+        msg: impl ToString,
+    ) -> Result<(), Error> {
+        if let Some(dest) = dest.try_to_service_id() {
+            senders.send_to(
+                ServiceBus::Ctl,
+                self.identity(),
+                dest,
+                Request::Progress(Progress::StateTransition(msg.to_string())),
             )?;
         }
         Ok(())

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -2709,6 +2709,16 @@ impl Runtime {
             self.swap_id().bright_blue_italic(),
             "Proposing to take swap".bright_white_bold(),
         );
+
+        let msg = format!(
+            "Proposing to take swap {} to Maker remote peer",
+            self.swap_id()
+        );
+        let enquirer = self.enquirer.clone();
+        // Ignoring possible reporting errors here and after: do not want to
+        // halt the swap just because the client disconnected
+        let _ = self.report_progress_message_to(endpoints, &enquirer, msg);
+
         let engine = CommitmentEngine;
         let commitment = match params {
             Params::Bob(params) => request::Commit::BobParameters(
@@ -2718,11 +2728,6 @@ impl Runtime {
                 CommitAliceParameters::commit_to_bundle(self.swap_id(), &engine, params),
             ),
         };
-        // Ignoring possible reporting errors here and after: do not want to
-        // halt the swap just because the client disconnected
-        let enquirer = self.enquirer.clone();
-        let msg = format!("Proposing to take swap to Maker remote peer",);
-        let _ = self.report_progress_message_to(endpoints, &enquirer, msg);
 
         Ok(commitment)
     }
@@ -2736,18 +2741,18 @@ impl Runtime {
     ) -> Result<request::Commit, Error> {
         info!(
             "{} | {} as Maker from Taker through peerd {}",
-            "Accepting swap".bright_white_bold(),
             swap_id.bright_blue_italic(),
+            "Accepting swap".bright_white_bold(),
             peerd.bright_blue_italic()
         );
 
-        // Ignoring possible reporting errors here and after: do not want to
-        // halt the channel just because the client disconnected
         let msg = format!(
             "Accepting swap {} as Maker from Taker through peerd {}",
             swap_id, peerd
         );
         let enquirer = self.enquirer.clone();
+        // Ignoring possible reporting errors here and after: do not want to
+        // halt the swap just because the client disconnected
         let _ = self.report_progress_message_to(endpoints, &enquirer, msg);
 
         let engine = CommitmentEngine;
@@ -2759,6 +2764,7 @@ impl Runtime {
                 CommitAliceParameters::commit_to_bundle(self.swap_id(), &engine, params),
             ),
         };
+
         Ok(commitment)
     }
 }

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -1061,7 +1061,7 @@ impl Runtime {
         );
         let msg = format!("{} -> {}", self.state, next_state,);
         self.state = next_state;
-        self.report_success_to(endpoints, self.enquirer.clone(), Some(msg))?;
+        self.report_state_transition_progress_message_to(endpoints, self.enquirer.clone(), msg)?;
         Ok(())
     }
 
@@ -2722,7 +2722,7 @@ impl Runtime {
         // halt the swap just because the client disconnected
         let enquirer = self.enquirer.clone();
         let msg = format!("Proposing to take swap to Maker remote peer",);
-        let _ = self.report_progress_to(endpoints, &enquirer, msg);
+        let _ = self.report_progress_message_to(endpoints, &enquirer, msg);
 
         Ok(commitment)
     }
@@ -2748,7 +2748,7 @@ impl Runtime {
             swap_id, peerd
         );
         let enquirer = self.enquirer.clone();
-        let _ = self.report_progress_to(endpoints, &enquirer, msg);
+        let _ = self.report_progress_message_to(endpoints, &enquirer, msg);
 
         let engine = CommitmentEngine;
         let commitment = match params.clone() {

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -2734,7 +2734,7 @@ impl Runtime {
         params: &Params,
     ) -> Result<request::Commit, Error> {
         let msg = format!(
-            "{} {} as Maker from Taker remote peer {}",
+            "{} {} as Maker from Taker through peerd {}",
             "Accepting swap".bright_white_bold(),
             swap_id.bright_blue_italic(),
             peerd.bright_blue_italic()
@@ -2755,14 +2755,6 @@ impl Runtime {
                 CommitAliceParameters::commit_to_bundle(self.swap_id(), &engine, params),
             ),
         };
-
-        let msg = format!(
-            "{} swap {:#} from remote peer Taker {}",
-            "Making".bright_green_bold(),
-            swap_id.bright_green_italic(),
-            peerd.bright_green_italic()
-        );
-        let _ = self.report_success_to(endpoints, &enquirer, Some(msg));
         Ok(commitment)
     }
 }

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -1052,13 +1052,14 @@ impl Runtime {
         }
     }
 
-    fn state_update(&mut self, endpoints: &mut Endpoints, next_state: State) -> Result<(), Error> {
-        let msg = format!(
-            "State transition: {} -> {}",
+    fn state_update(&mut self, endpoints: &mut Senders, next_state: State) -> Result<(), Error> {
+        info!(
+            "{} | State transition: {} -> {}",
+            self.swap_id.bright_blue_italic(),
             self.state.bright_white_bold(),
-            next_state.bright_white_bold()
+            next_state.bright_white_bold(),
         );
-        info!("{} | {}", self.swap_id.bright_blue_italic(), &msg);
+        let msg = format!("{} -> {}", self.state, next_state,);
         self.state = next_state;
         self.report_success_to(endpoints, self.enquirer.clone(), Some(msg))?;
         Ok(())
@@ -2703,12 +2704,11 @@ impl Runtime {
         endpoints: &mut Endpoints,
         params: Params,
     ) -> Result<request::Commit, Error> {
-        let msg = format!(
-            "{} {} to Maker remote peer",
+        info!(
+            "{} | {} to Maker remote peer",
+            self.swap_id().bright_blue_italic(),
             "Proposing to take swap".bright_white_bold(),
-            self.swap_id().bright_blue_italic()
         );
-        info!("{} | {}", self.swap_id.bright_blue_italic(), &msg);
         let engine = CommitmentEngine;
         let commitment = match params {
             Params::Bob(params) => request::Commit::BobParameters(
@@ -2721,7 +2721,8 @@ impl Runtime {
         // Ignoring possible reporting errors here and after: do not want to
         // halt the swap just because the client disconnected
         let enquirer = self.enquirer.clone();
-        let _ = self.report_progress_to(endpoints, &enquirer, msg);
+        let msg = format!("Proposing to take swap to Maker remote peer",);
+        let _ = self.report_progress_to(senders, &enquirer, msg);
 
         Ok(commitment)
     }
@@ -2733,16 +2734,19 @@ impl Runtime {
         swap_id: SwapId,
         params: &Params,
     ) -> Result<request::Commit, Error> {
-        let msg = format!(
-            "{} {} as Maker from Taker through peerd {}",
+        info!(
+            "{} | {} as Maker from Taker through peerd {}",
             "Accepting swap".bright_white_bold(),
             swap_id.bright_blue_italic(),
             peerd.bright_blue_italic()
         );
-        info!("{} | {}", self.swap_id.bright_blue_italic(), msg);
 
         // Ignoring possible reporting errors here and after: do not want to
         // halt the channel just because the client disconnected
+        let msg = format!(
+            "Accepting swap {} as Maker from Taker through peerd {}",
+            swap_id, peerd
+        );
         let enquirer = self.enquirer.clone();
         let _ = self.report_progress_to(endpoints, &enquirer, msg);
 

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -1052,7 +1052,7 @@ impl Runtime {
         }
     }
 
-    fn state_update(&mut self, endpoints: &mut Senders, next_state: State) -> Result<(), Error> {
+    fn state_update(&mut self, endpoints: &mut Endpoints, next_state: State) -> Result<(), Error> {
         info!(
             "{} | State transition: {} -> {}",
             self.swap_id.bright_blue_italic(),
@@ -2722,7 +2722,7 @@ impl Runtime {
         // halt the swap just because the client disconnected
         let enquirer = self.enquirer.clone();
         let msg = format!("Proposing to take swap to Maker remote peer",);
-        let _ = self.report_progress_to(senders, &enquirer, msg);
+        let _ = self.report_progress_to(endpoints, &enquirer, msg);
 
         Ok(commitment)
     }

--- a/src/syncerd/runtime.rs
+++ b/src/syncerd/runtime.rs
@@ -207,7 +207,7 @@ impl Runtime {
                     source.clone(),
                     Request::TaskList(self.tasks.iter().cloned().collect()),
                 )?;
-                let resp = Request::Progress(Progress::ProgressMessage("ListedTasks?".to_string()));
+                let resp = Request::Progress(Progress::Message("ListedTasks?".to_string()));
                 notify_cli = Some((Some(source), resp));
             }
 

--- a/src/syncerd/runtime.rs
+++ b/src/syncerd/runtime.rs
@@ -16,6 +16,7 @@ use crate::service::Endpoints;
 use crate::syncerd::bitcoin_syncer::BitcoinSyncer;
 use crate::syncerd::monero_syncer::MoneroSyncer;
 use crate::syncerd::opts::{Coin, Opts};
+use crate::syncerd::runtime::request::Progress;
 use amplify::Wrapper;
 use farcaster_core::blockchain::Network;
 use std::collections::{HashMap, HashSet};
@@ -206,7 +207,7 @@ impl Runtime {
                     source.clone(),
                     Request::TaskList(self.tasks.iter().cloned().collect()),
                 )?;
-                let resp = Request::Progress("ListedTasks?".to_string());
+                let resp = Request::Progress(Progress::ProgressMessage("ListedTasks?".to_string()));
                 notify_cli = Some((Some(source), resp));
             }
 


### PR DESCRIPTION
Similar but slightly different approach from #438

Result:
```
swap-cli progress 0x32e3cdb8ab4b58be737def0fe6c75cc1cf045a7593df975f64a0dc60177a6fa8
---
progress:
  - message: this is a message
  - transition: state1 -> state2
  - success: swap is successful
  - failure:
      code: 1
      info: info error here
```