### PR TITLE
feature: make progress waiting on new messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,6 @@ tonic = "0.7.2"
 prost = "0.10.3"
 
 [build-dependencies]
-
 # farcaster_core = { version = "0.4.4", features = ["serde"] }
 farcaster_core = { git = "https://github.com/farcaster-project/farcaster-core", branch = "main", features = ["serde"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ farcaster_core = { git = "https://github.com/farcaster-project/farcaster-core", 
 anyhow = "1"
 hex = "^0.4.3"
 
+rand = "0.8.4"
 # LNP/BP crates
 amplify = "3"
 amplify_derive = "2"
@@ -106,6 +107,8 @@ tonic = "0.7.2"
 prost = "0.10.3"
 
 [build-dependencies]
+
+rand = "0.8.4"
 # farcaster_core = { version = "0.4.4", features = ["serde"] }
 farcaster_core = { git = "https://github.com/farcaster-project/farcaster-core", branch = "main", features = ["serde"] }
 
@@ -147,7 +150,6 @@ features = ['peer']
 
 [dev-dependencies]
 ntest = "0.7.3"
-rand = "0.8.4"
 
 # Test
 strip-ansi-escapes = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ farcaster_core = { git = "https://github.com/farcaster-project/farcaster-core", 
 anyhow = "1"
 hex = "^0.4.3"
 
-rand = "0.8.4"
 # LNP/BP crates
 amplify = "3"
 amplify_derive = "2"
@@ -108,7 +107,6 @@ prost = "0.10.3"
 
 [build-dependencies]
 
-rand = "0.8.4"
 # farcaster_core = { version = "0.4.4", features = ["serde"] }
 farcaster_core = { git = "https://github.com/farcaster-project/farcaster-core", branch = "main", features = ["serde"] }
 
@@ -150,6 +148,7 @@ features = ['peer']
 
 [dev-dependencies]
 ntest = "0.7.3"
+rand = "0.8.4"
 
 # Test
 strip-ansi-escapes = "0.1.1"

--- a/shell/_swap-cli
+++ b/shell/_swap-cli
@@ -204,11 +204,30 @@ _arguments "${_arguments_options[@]}" \
 '--msg-socket=[ZMQ socket name/address to forward all incoming protocol messages]:MSG_SOCKET:_files' \
 '-x+[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
+'-f[Subscribe to progress and only return when progress is finished]' \
+'--follow[Subscribe to progress and only return when progress is finished]' \
 '-h[Print help information]' \
 '--help[Print help information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
 ':swapid -- The swap id requested:' \
+&& ret=0
+;;
+(test)
+_arguments "${_arguments_options[@]}" \
+'-d+[Data directory path]:DATA_DIR:_files -/' \
+'--data-dir=[Data directory path]:DATA_DIR:_files -/' \
+'-T+[Use Tor]:TOR_PROXY:_hosts' \
+'--tor-proxy=[Use Tor]:TOR_PROXY:_hosts' \
+'-m+[ZMQ socket name/address to forward all incoming protocol messages]:MSG_SOCKET:_files' \
+'--msg-socket=[ZMQ socket name/address to forward all incoming protocol messages]:MSG_SOCKET:_files' \
+'-x+[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
+'--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'*-v[Set verbosity level]' \
+'*--verbose[Set verbosity level]' \
+':swapid:' \
 && ret=0
 ;;
 (needs-funding)
@@ -225,7 +244,7 @@ _arguments "${_arguments_options[@]}" \
 '--help[Print help information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
-':coin:' \
+':coin -- The coin funding required needs to be checked against:' \
 && ret=0
 ;;
 (help)
@@ -260,6 +279,7 @@ _swap-cli_commands() {
 'take:Taker accepts offer and connects to maker'\''s daemon to start the trade' \
 'revoke-offer:Revoke offer accepts an offer and revokes it within the runtime' \
 'progress:Request swap progress report' \
+'test:' \
 'needs-funding:Returns addresses and amounts that require funding for coin' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
@@ -319,6 +339,11 @@ _swap-cli__revoke-offer_commands() {
 _swap-cli__take_commands() {
     local commands; commands=()
     _describe -t commands 'swap-cli take commands' commands "$@"
+}
+(( $+functions[_swap-cli__test_commands] )) ||
+_swap-cli__test_commands() {
+    local commands; commands=()
+    _describe -t commands 'swap-cli test commands' commands "$@"
 }
 
 _swap-cli "$@"

--- a/shell/_swap-cli
+++ b/shell/_swap-cli
@@ -213,23 +213,6 @@ _arguments "${_arguments_options[@]}" \
 ':swapid -- The swap id requested:' \
 && ret=0
 ;;
-(test)
-_arguments "${_arguments_options[@]}" \
-'-d+[Data directory path]:DATA_DIR:_files -/' \
-'--data-dir=[Data directory path]:DATA_DIR:_files -/' \
-'-T+[Use Tor]:TOR_PROXY:_hosts' \
-'--tor-proxy=[Use Tor]:TOR_PROXY:_hosts' \
-'-m+[ZMQ socket name/address to forward all incoming protocol messages]:MSG_SOCKET:_files' \
-'--msg-socket=[ZMQ socket name/address to forward all incoming protocol messages]:MSG_SOCKET:_files' \
-'-x+[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
-'--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
-'-h[Print help information]' \
-'--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
-':swapid:' \
-&& ret=0
-;;
 (needs-funding)
 _arguments "${_arguments_options[@]}" \
 '-d+[Data directory path]:DATA_DIR:_files -/' \
@@ -279,7 +262,6 @@ _swap-cli_commands() {
 'take:Taker accepts offer and connects to maker'\''s daemon to start the trade' \
 'revoke-offer:Revoke offer accepts an offer and revokes it within the runtime' \
 'progress:Request swap progress report' \
-'test:' \
 'needs-funding:Returns addresses and amounts that require funding for coin' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
@@ -339,11 +321,6 @@ _swap-cli__revoke-offer_commands() {
 _swap-cli__take_commands() {
     local commands; commands=()
     _describe -t commands 'swap-cli take commands' commands "$@"
-}
-(( $+functions[_swap-cli__test_commands] )) ||
-_swap-cli__test_commands() {
-    local commands; commands=()
-    _describe -t commands 'swap-cli test commands' commands "$@"
 }
 
 _swap-cli "$@"

--- a/shell/_swap-cli.ps1
+++ b/shell/_swap-cli.ps1
@@ -44,7 +44,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('take', 'take', [CompletionResultType]::ParameterValue, 'Taker accepts offer and connects to maker''s daemon to start the trade')
             [CompletionResult]::new('revoke-offer', 'revoke-offer', [CompletionResultType]::ParameterValue, 'Revoke offer accepts an offer and revokes it within the runtime')
             [CompletionResult]::new('progress', 'progress', [CompletionResultType]::ParameterValue, 'Request swap progress report')
-            [CompletionResult]::new('test', 'test', [CompletionResultType]::ParameterValue, 'test')
             [CompletionResult]::new('needs-funding', 'needs-funding', [CompletionResultType]::ParameterValue, 'Returns addresses and amounts that require funding for coin')
             [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
             break
@@ -206,21 +205,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'Subscribe to progress and only return when progress is finished')
             [CompletionResult]::new('--follow', 'follow', [CompletionResultType]::ParameterName, 'Subscribe to progress and only return when progress is finished')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            break
-        }
-        'swap-cli;test' {
-            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
-            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
-            [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')
-            [CompletionResult]::new('--tor-proxy', 'tor-proxy', [CompletionResultType]::ParameterName, 'Use Tor')
-            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
-            [CompletionResult]::new('--msg-socket', 'msg-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
-            [CompletionResult]::new('-x', 'x', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
-            [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')

--- a/shell/_swap-cli.ps1
+++ b/shell/_swap-cli.ps1
@@ -44,6 +44,7 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('take', 'take', [CompletionResultType]::ParameterValue, 'Taker accepts offer and connects to maker''s daemon to start the trade')
             [CompletionResult]::new('revoke-offer', 'revoke-offer', [CompletionResultType]::ParameterValue, 'Revoke offer accepts an offer and revokes it within the runtime')
             [CompletionResult]::new('progress', 'progress', [CompletionResultType]::ParameterValue, 'Request swap progress report')
+            [CompletionResult]::new('test', 'test', [CompletionResultType]::ParameterValue, 'test')
             [CompletionResult]::new('needs-funding', 'needs-funding', [CompletionResultType]::ParameterValue, 'Returns addresses and amounts that require funding for coin')
             [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
             break
@@ -195,6 +196,23 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             break
         }
         'swap-cli;progress' {
+            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
+            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
+            [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')
+            [CompletionResult]::new('--tor-proxy', 'tor-proxy', [CompletionResultType]::ParameterName, 'Use Tor')
+            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
+            [CompletionResult]::new('--msg-socket', 'msg-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
+            [CompletionResult]::new('-x', 'x', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
+            [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
+            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'Subscribe to progress and only return when progress is finished')
+            [CompletionResult]::new('--follow', 'follow', [CompletionResultType]::ParameterName, 'Subscribe to progress and only return when progress is finished')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
+            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
+            break
+        }
+        'swap-cli;test' {
             [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')

--- a/shell/swap-cli.bash
+++ b/shell/swap-cli.bash
@@ -45,9 +45,6 @@ _swap-cli() {
             take)
                 cmd+="__take"
                 ;;
-            test)
-                cmd+="__test"
-                ;;
             *)
                 ;;
         esac
@@ -55,7 +52,7 @@ _swap-cli() {
 
     case "${cmd}" in
         swap__cli)
-            opts="-h -V -d -v -T -m -x --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket info peers list-swaps list-offers list-listens make take revoke-offer progress test needs-funding help"
+            opts="-h -V -d -v -T -m -x --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket info peers list-swaps list-offers list-listens make take revoke-offer progress needs-funding help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -663,52 +660,6 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --data-dir)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -d)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --tor-proxy)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -T)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --msg-socket)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -m)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --ctl-socket)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -x)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        swap__cli__test)
-            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <SWAPID>"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
                 --data-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0

--- a/shell/swap-cli.bash
+++ b/shell/swap-cli.bash
@@ -45,6 +45,9 @@ _swap-cli() {
             take)
                 cmd+="__take"
                 ;;
+            test)
+                cmd+="__test"
+                ;;
             *)
                 ;;
         esac
@@ -52,7 +55,7 @@ _swap-cli() {
 
     case "${cmd}" in
         swap__cli)
-            opts="-h -V -d -v -T -m -x --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket info peers list-swaps list-offers list-listens make take revoke-offer progress needs-funding help"
+            opts="-h -V -d -v -T -m -x --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket info peers list-swaps list-offers list-listens make take revoke-offer progress test needs-funding help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -546,7 +549,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__progress)
-            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <SWAPID>"
+            opts="-f -h -d -v -T -m -x --follow --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <SWAPID>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -660,6 +663,52 @@ _swap-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --data-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --tor-proxy)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -T)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --msg-socket)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -m)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ctl-socket)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -x)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        swap__cli__test)
+            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <SWAPID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
                 --data-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -12,6 +12,8 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::{
     convert::TryFrom,
     io::{self, Read, Write},
@@ -78,28 +80,28 @@ impl Exec for Command {
 
             Command::Peers => {
                 runtime.request(ServiceId::Farcasterd, Request::ListPeers)?;
-                runtime.report_response()?;
+                runtime.report_response_or_fail()?;
             }
 
             Command::ListSwaps => {
                 runtime.request(ServiceId::Farcasterd, Request::ListSwaps)?;
-                runtime.report_response()?;
+                runtime.report_response_or_fail()?;
             }
 
             // TODO: only list offers matching list of OfferIds
             Command::ListOffers => {
                 runtime.request(ServiceId::Farcasterd, Request::ListOffers)?;
-                runtime.report_response()?;
+                runtime.report_response_or_fail()?;
             }
 
             Command::ListListens => {
                 runtime.request(ServiceId::Farcasterd, Request::ListListens)?;
-                runtime.report_response()?;
+                runtime.report_response_or_fail()?;
             }
 
             // Command::ListOfferIds => {
             //     runtime.request(ServiceId::Farcasterd, Request::ListOfferIds)?;
-            //     runtime.report_response()?;
+            //     runtime.report_response_or_fail()?;
             // }
             Command::Make {
                 network,
@@ -156,7 +158,7 @@ impl Exec for Command {
                 };
                 runtime.request(ServiceId::Farcasterd, Request::MakeOffer(proto_offer))?;
                 // report success or failure of the request to cli
-                runtime.report_response()?;
+                runtime.report_response_or_fail()?;
             }
 
             Command::Take {
@@ -212,23 +214,41 @@ impl Exec for Command {
                         ),
                     )?;
                     // report success of failure of the request to cli
-                    runtime.report_response()?;
+                    runtime.report_response_or_fail()?;
                 }
             }
 
             Command::RevokeOffer { public_offer } => {
                 runtime.request(ServiceId::Farcasterd, Request::RevokeOffer(public_offer))?;
-                runtime.report_response()?;
+                runtime.report_response_or_fail()?;
             }
 
-            Command::Progress { swapid } => {
-                runtime.request(ServiceId::Farcasterd, Request::ReadProgress(swapid))?;
-                runtime.report_response()?;
+            Command::Test { swapid } => {
+                runtime.request(ServiceId::Farcasterd, Request::TestProgress(swapid))?;
+            }
+
+            Command::Progress { swapid, follow } => {
+                if follow {
+                    // subscribe to progress event and loop until Finish event is received or user
+                    // ctrl-c the cli. Expect to recieve a stream of event responses
+                    runtime.request(ServiceId::Farcasterd, Request::SubscribeProgress(swapid))?;
+                    let res = runtime.report_progress();
+                    // if user didn't ctrl-c before that point we can cleanly unsubscribe the
+                    // client from the notification stream and then return the result from report
+                    // progress
+                    runtime.request(ServiceId::Farcasterd, Request::UnsubscribeProgress(swapid))?;
+                    return res;
+                } else {
+                    // request a read progress response. Expect to recieve only one response and
+                    // quit
+                    runtime.request(ServiceId::Farcasterd, Request::ReadProgress(swapid))?;
+                    runtime.report_response_or_fail()?;
+                }
             }
 
             Command::NeedsFunding { coin } => {
                 runtime.request(ServiceId::Farcasterd, Request::NeedsFunding(coin))?;
-                runtime.report_response()?;
+                runtime.report_response_or_fail()?;
             }
         }
 

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -223,10 +223,6 @@ impl Exec for Command {
                 runtime.report_response_or_fail()?;
             }
 
-            Command::Test { swapid } => {
-                runtime.request(ServiceId::Farcasterd, Request::TestProgress(swapid))?;
-            }
-
             Command::Progress { swapid, follow } => {
                 if follow {
                     // subscribe to progress event and loop until Finish event is received or user

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -12,8 +12,6 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 use std::{
     convert::TryFrom,
     io::{self, Read, Write},

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -202,9 +202,6 @@ pub enum Command {
         follow: bool,
     },
 
-    #[display("test<{swapid}>")]
-    Test { swapid: SwapId },
-
     /// Returns addresses and amounts that require funding for coin.
     #[display("needs-funding<{coin}>")]
     NeedsFunding {

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -184,10 +184,10 @@ pub enum Command {
         without_validation: bool,
     },
 
-    /// Revoke offer accepts an offer and revokes it within the runtime
+    /// Revoke offer accepts an offer and revokes it within the runtime.
     #[display("revoke-offer<{public_offer}>")]
     RevokeOffer {
-        /// The offer to be canceled
+        /// The offer to be canceled.
         public_offer: PublicOffer<BtcXmr>,
     },
 
@@ -196,9 +196,21 @@ pub enum Command {
     Progress {
         /// The swap id requested.
         swapid: SwapId,
+
+        /// Subscribe to progress and only return when progress is finished.
+        #[clap(short, long)]
+        follow: bool,
     },
-    /// Returns addresses and amounts that require funding for coin
-    NeedsFunding { coin: Coin },
+
+    #[display("test<{swapid}>")]
+    Test { swapid: SwapId },
+
+    /// Returns addresses and amounts that require funding for coin.
+    #[display("needs-funding<{coin}>")]
+    NeedsFunding {
+        /// The coin funding required needs to be checked against.
+        coin: Coin,
+    },
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display, Error, From)]

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -1186,51 +1186,6 @@ impl Runtime {
                 }
             }
 
-            // Simulate a progress
-            Request::TestProgress(swapid) => {
-                let service = ServiceId::Swap(swapid);
-                use rand::prelude::*;
-                let mut rng = rand::thread_rng();
-                let reqs = if rng.gen::<f64>() >= 0.5 {
-                    if rng.gen::<f64>() >= 0.5 {
-                        vec![Request::Failure(Failure {
-                            code: 1,
-                            info: "Coulod not find to be revoked offer.".to_string(),
-                        })]
-                    } else {
-                        vec![Request::Success(OptionDetails(Some(
-                            "Some success message".to_string(),
-                        )))]
-                    }
-                } else {
-                    vec![
-                        Request::Progress(request::Progress::Message(
-                            "Some progress message".to_string(),
-                        )),
-                        Request::Progress(request::Progress::StateTransition(
-                            "Some progress state -> transition".to_string(),
-                        )),
-                    ]
-                };
-                // Simulate Progress:: match req
-                for req in reqs.iter() {
-                    if !self.progress.contains_key(&service) {
-                        self.progress.insert(service.clone(), none!());
-                    };
-                    let queue = self
-                        .progress
-                        .get_mut(&service)
-                        .expect("checked/added above");
-                    queue.push_back(req.clone());
-
-                    self.notify_subscribed_clients(endpoints, &service, req);
-                }
-
-                println!("Test progress done!");
-                println!("{:#?}", self.progress);
-                println!("{:#?}", self.progress_subscriptions);
-            }
-
             // Remove the request's source from the subscription list of notifications
             Request::UnsubscribeProgress(swapid) => {
                 let service = ServiceId::Swap(swapid);

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -141,6 +141,7 @@ pub fn run(
         syncer_clients: none!(),
         consumed_offers: none!(),
         progress: none!(),
+        progress_subscriptions: none!(),
         stats: none!(),
         funding_xmr: none!(),
         funding_btc: none!(),
@@ -172,6 +173,7 @@ pub struct Runtime {
     syncer_services: HashMap<(Coin, Network), ServiceId>,
     syncer_clients: HashMap<(Coin, Network), HashSet<SwapId>>,
     progress: HashMap<ServiceId, VecDeque<Request>>,
+    progress_subscriptions: HashMap<ServiceId, HashSet<ServiceId>>,
     funding_btc: HashMap<SwapId, (bitcoin::Address, bitcoin::Amount, bool)>,
     funding_xmr: HashMap<SwapId, (monero::Address, monero::Amount, bool)>,
     stats: Stats,
@@ -1083,18 +1085,22 @@ impl Runtime {
                 }
             }
 
+            // Add progress in queues and forward to subscribed clients
             Request::Progress(..) | Request::Success(..) | Request::Failure(..) => {
                 if !self.progress.contains_key(&source) {
                     self.progress.insert(source.clone(), none!());
                 };
                 let queue = self.progress.get_mut(&source).expect("checked/added above");
-                queue.push_back(request);
+                queue.push_back(request.clone());
+                // forward the request to each subscribed clients
+                self.notify_subscribed_clients(endpoints, &source, &request);
             }
 
+            // Returns a unique response that contains the complete progress queue
             Request::ReadProgress(swapid) => {
                 if let Some(queue) = self.progress.get_mut(&ServiceId::Swap(swapid)) {
                     let mut swap_progress = SwapProgress { progress: vec![] };
-                    for (_i, req) in queue.iter().enumerate() {
+                    for req in queue.iter() {
                         match req {
                             Request::Progress(request::Progress::Message(m)) => {
                                 swap_progress
@@ -1119,12 +1125,7 @@ impl Runtime {
                             _ => unreachable!("not handled here"),
                         };
                     }
-                    endpoints.send_to(
-                        ServiceBus::Ctl,
-                        self.identity(),
-                        source,
-                        Request::SwapProgress(swap_progress),
-                    )?;
+                    report_to.push((Some(source.clone()), Request::SwapProgress(swap_progress)));
                 } else {
                     let info = if self.making_swaps.contains_key(&ServiceId::Swap(swapid))
                         || self.taking_swaps.contains_key(&ServiceId::Swap(swapid))
@@ -1133,13 +1134,120 @@ impl Runtime {
                     } else {
                         s!("Unknown swapd")
                     };
-                    endpoints.send_to(
-                        ServiceBus::Ctl,
-                        self.identity(),
-                        source,
+                    report_to.push((
+                        Some(source.clone()),
                         Request::Failure(Failure { code: 1, info }),
-                    )?;
+                    ));
                 }
+            }
+
+            // Add the request's source to the subscription list for later progress notifications
+            // and send all notifications already in the queue
+            Request::SubscribeProgress(swapid) => {
+                let service = ServiceId::Swap(swapid);
+                // if the swap is known either in taking, making or progress, attach the client
+                // otherwise terminate
+                if self.making_swaps.contains_key(&service)
+                    || self.taking_swaps.contains_key(&service)
+                    || self.progress.contains_key(&service)
+                {
+                    if let Some(subscribed) = self.progress_subscriptions.get_mut(&service) {
+                        // ret true if not in the set, false otherwise. Double subscribe is not a
+                        // problem as we manage the list in a set.
+                        let _ = subscribed.insert(source.clone());
+                    } else {
+                        let mut subscribed = HashSet::new();
+                        subscribed.insert(source.clone());
+                        // None is returned, the key was not set as checked before
+                        let _ = self
+                            .progress_subscriptions
+                            .insert(service.clone(), subscribed);
+                    }
+                    trace!(
+                        "{} has been added to {} progress subscription",
+                        source.clone(),
+                        swapid
+                    );
+                    // send all queued notification to the source to catch up
+                    if let Some(queue) = self.progress.get_mut(&service) {
+                        for req in queue.iter() {
+                            report_to.push((Some(source.clone()), req.clone()));
+                        }
+                    }
+                } else {
+                    // no swap service exists, terminate
+                    report_to.push((
+                        Some(source.clone()),
+                        Request::Failure(Failure {
+                            code: 1,
+                            info: "Unknown swapd".to_string(),
+                        }),
+                    ));
+                }
+            }
+
+            // Simulate a progress
+            Request::TestProgress(swapid) => {
+                let service = ServiceId::Swap(swapid);
+                use rand::prelude::*;
+                let mut rng = rand::thread_rng();
+                let reqs = if rng.gen::<f64>() >= 0.5 {
+                    if rng.gen::<f64>() >= 0.5 {
+                        vec![Request::Failure(Failure {
+                            code: 1,
+                            info: "Coulod not find to be revoked offer.".to_string(),
+                        })]
+                    } else {
+                        vec![Request::Success(OptionDetails(Some(
+                            "Some success message".to_string(),
+                        )))]
+                    }
+                } else {
+                    vec![
+                        Request::Progress(request::Progress::Message(
+                            "Some progress message".to_string(),
+                        )),
+                        Request::Progress(request::Progress::StateTransition(
+                            "Some progress state -> transition".to_string(),
+                        )),
+                    ]
+                };
+                // Simulate Progress:: match req
+                for req in reqs.iter() {
+                    if !self.progress.contains_key(&service) {
+                        self.progress.insert(service.clone(), none!());
+                    };
+                    let queue = self
+                        .progress
+                        .get_mut(&service)
+                        .expect("checked/added above");
+                    queue.push_back(req.clone());
+
+                    self.notify_subscribed_clients(endpoints, &service, req);
+                }
+
+                println!("Test progress done!");
+                println!("{:#?}", self.progress);
+                println!("{:#?}", self.progress_subscriptions);
+            }
+
+            // Remove the request's source from the subscription list of notifications
+            Request::UnsubscribeProgress(swapid) => {
+                let service = ServiceId::Swap(swapid);
+                if let Some(subscribed) = self.progress_subscriptions.get_mut(&service) {
+                    // we don't care if the source was not in the set
+                    let _ = subscribed.remove(&source);
+                    trace!(
+                        "{} has been removed from {} progress subscription",
+                        source.clone(),
+                        swapid
+                    );
+                    if subscribed.len() == 0 {
+                        // we drop the empty set located at the swap index
+                        let _ = self.progress_subscriptions.remove(&service);
+                    }
+                }
+                // if no swap service exists no subscription need to be removed
             }
 
             Request::FundingInfo(info) => match info {
@@ -1417,20 +1525,19 @@ impl Runtime {
             }
         }
 
-        let mut len = 0;
-        for (respond_to, resp) in report_to.into_iter() {
+        for (i, (respond_to, resp)) in report_to.clone().into_iter().enumerate() {
             if let Some(respond_to) = respond_to {
-                len += 1;
-                debug!("notifications to cli: {}", len);
                 trace!(
-                    "Respond to {} -> Response {}",
+                    "(#{}) Respond to {}: {}",
+                    i,
                     respond_to.bright_yellow_bold(),
                     resp.bright_blue_bold(),
                 );
                 endpoints.send_to(ServiceBus::Ctl, self.identity(), respond_to, resp)?;
             }
         }
-        debug!("processed all cli notifications");
+        trace!("Processed all cli notifications");
+
         Ok(())
     }
 
@@ -1530,6 +1637,30 @@ impl Runtime {
             Request::GetKeys(wallet_token),
         )?;
         Ok(())
+    }
+
+    /// Notify(forward to) the subscribed clients still online with the given request
+    fn notify_subscribed_clients(
+        &mut self,
+        endpoints: &mut Endpoints,
+        source: &ServiceId,
+        request: &Request,
+    ) {
+        // if subs exists for the source (swapid), forward the request to every subs
+        if let Some(subs) = self.progress_subscriptions.get_mut(source) {
+            // if the sub is no longer reachable, i.e. the process terminated without calling
+            // unsub, remove it from sub list
+            subs.retain(|sub| {
+                endpoints
+                    .send_to(
+                        ServiceBus::Ctl,
+                        ServiceId::Farcasterd,
+                        sub.clone(),
+                        request.clone(),
+                    )
+                    .is_ok()
+            });
+        }
     }
 }
 

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -102,7 +102,7 @@ impl Client {
 
     /// Print the stream of received requests until progress fails or succeed
     pub fn report_progress(&mut self) -> Result<(), Error> {
-        // loop on all requests received until a progress terminaison condition is recieved
+        // loop on all requests received until a progress termination condition is recieved
         // report failure transform Request::Failure in error already, terminate on error or on
         // success
         let res = loop {

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -14,13 +14,14 @@
 
 use crate::service::Endpoints;
 use std::convert::TryInto;
-use std::thread::sleep;
+use std::thread::{self, sleep};
 use std::time::Duration;
 
 use internet2::ZmqType;
 use microservices::esb;
 
 use crate::rpc::request::OptionDetails;
+use crate::rpc::request::SwapProgress;
 use crate::rpc::{Request, ServiceBus};
 use crate::service::ServiceConfig;
 use crate::{Error, LogStyle, ServiceId};
@@ -92,38 +93,33 @@ impl Client {
         }
     }
 
-    pub fn report_response(&mut self) -> Result<(), Error> {
+    pub fn report_response_or_fail(&mut self) -> Result<(), Error> {
         let resp = self.report_failure()?;
         // note: this triggers the yaml formatting when implemented
-        println!("{:#}", resp);
+        println!("{}", resp);
         Ok(())
     }
 
-    pub fn report_progress(&mut self) -> Result<usize, Error> {
-        let mut counter = 0;
-        let mut finished = false;
-        while !finished {
-            finished = true;
-            counter += 1;
-            match self.report_failure()? {
-                // Failure is already covered by `report_response()`
-                Request::Progress(info) => {
-                    println!("{}", info.green_bold());
-                    finished = false;
+    /// Print the stream of received requests until progress fails or succeed
+    pub fn report_progress(&mut self) -> Result<(), Error> {
+        // loop on all requests received until a progress terminaison condition is recieved
+        // report failure transform Request::Failure in error already, terminate on error or on
+        // success
+        let res = loop {
+            match self.report_failure() {
+                Err(e) => {
+                    // terminate on error
+                    break Err(e);
                 }
-                Request::Success(OptionDetails(Some(info))) => {
-                    println!("{}{}", "Success: ".bright_green_bold(), info);
+                Ok(Request::Success(s)) => {
+                    println!("{}", s.bright_green_bold());
+                    // terminate on success
+                    break Ok(());
                 }
-                Request::Success(OptionDetails(None)) => {
-                    println!("{}", "Success".bright_green_bold());
-                }
-                other => {
-                    eprintln!("{}: {}", "Unexpected report".err(), other.err_details());
-                    return Err(Error::Other(s!("Unexpected server response")));
-                }
+                Ok(req) => println!("{}", req),
             }
-        }
-        Ok(counter)
+        };
+        res
     }
 }
 

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -525,23 +525,35 @@ pub enum Request {
     String(String),
 
     #[api(type = 1002)]
-    #[display("progress({0})")]
+    #[display("progress: {0}")]
     Progress(Progress),
 
     #[api(type = 1005)]
-    #[display("swap_progress({0})", alt = "{0:#}")]
+    #[display(inner)]
     SwapProgress(SwapProgress),
 
     #[api(type = 1003)]
     #[display("read_progress({0})")]
     ReadProgress(SwapId),
 
+    #[api(type = 9999)]
+    #[display("test_progress({0})")]
+    TestProgress(SwapId),
+
+    #[api(type = 1006)]
+    #[display("subscribe_progress({0})")]
+    SubscribeProgress(SwapId),
+
+    #[api(type = 1007)]
+    #[display("unsubscribe_progress({0})")]
+    UnsubscribeProgress(SwapId),
+
     #[api(type = 1001)]
-    #[display("success({0})")]
+    #[display(inner)]
     Success(OptionDetails),
 
     #[api(type = 1000)]
-    #[display("failure({0:#})")]
+    #[display(inner)]
     #[from]
     Failure(Failure),
 
@@ -785,7 +797,7 @@ pub struct InitSwap {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
-#[display("progress {}")]
+#[display(inner)]
 pub enum Progress {
     Message(String),
     StateTransition(String),

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -536,10 +536,6 @@ pub enum Request {
     #[display("read_progress({0})")]
     ReadProgress(SwapId),
 
-    #[api(type = 9999)]
-    #[display("test_progress({0})")]
-    TestProgress(SwapId),
-
     #[api(type = 1006)]
     #[display("subscribe_progress({0})")]
     SubscribeProgress(SwapId),


### PR DESCRIPTION
This PR allows `progress` to pass a flag `-f|--follow` to continuously receive progress update until ctrl-c is pressed or termination condition is met: a request success or failure is received.

When the flag is not passed, the behavior is the same as previously, a one shot result in yaml format is returned.

#### How it works
When the client is in follow mode a first request is send to farcasterd to register itself in the progress subscription list, when a client register to a swap farcasterd send the queue back to the client. After registering the client loops on all messages until termination condition is met. When farcasterd receives a message related to some swap progress the message is forwarded to all client subscribed to it. If the forwarding fails the client is removed from the sub list.

```
| client |                | fcd |
    |                        |
   || ---------(sub)-------> || add to list
   ||                        ||
   || <--------------------- || send back queue
   || <--------------------- ||
   || <--------------------- ||
   ||                        |
   ||                        || <----(progress)
   || <--------------------- || call notify_subscribed_clients
   ||                        |
   ||                        || <----(success or failure)
   || <--------------------- || call notify_subscribed_clients
   ||                        |
   || --------(unsub)------> || remove from list
    |                        |
```
If the client has ctrl-c before unsubscribing `call notify_subscribed_clients` will remove it from the list if send fails.

#### This PR does not ensure the progress messages are send in the correct order; this is out of the scope here. Every swap progress sequence should match the following request pattern:
```
 ( Progress::Message | Progress::StateTransition )*
 Success | Failure
```
Subsequent messages will be ignore is some cases (but not when displayed through yaml format).