### PR TITLE
Farcasterd: Check if peerd listen launched successfully

### DIFF
--- a/src/bin/peerd.rs
+++ b/src/bin/peerd.rs
@@ -200,16 +200,20 @@ fn main() {
 
                     // TODO: Support multithread mode
                     debug!("Forking child process");
-                    if let ForkResult::Child = unsafe { fork().expect("Unable to fork child process") }
+                    if let ForkResult::Child =
+                        unsafe { fork().expect("Unable to fork child process") }
                     {
                         stream
                             .set_read_timeout(Some(Duration::from_secs(30)))
                             .expect("Unable to set up timeout for TCP connection");
 
                         debug!("Establishing session with the remote");
-                        let session =
-                            session::Raw::with_brontide(stream, local_node.private_key(), inet_addr)
-                                .expect("Unable to establish session with the remote peer");
+                        let session = session::Raw::with_brontide(
+                            stream,
+                            local_node.private_key(),
+                            inet_addr,
+                        )
+                        .expect("Unable to establish session with the remote peer");
 
                         debug!(
                             "Session successfully established with {}",

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -1453,7 +1453,18 @@ impl Runtime {
                     "--token",
                     &self.wallet_token.clone().to_string(),
                 ],
-            )?;
+            );
+
+            // in case it can't connect wait for it to crash
+            std::thread::sleep(Duration::from_secs_f32(0.5));
+
+            // status is Some if peerd returns because it crashed
+            let (child, status) = child.and_then(|mut c| c.try_wait().map(|s| (c, s)))?;
+
+            if status.is_some() {
+                return Err(Error::Peer(internet2::presentation::Error::InvalidEndpoint));
+            }
+
             debug!("New instance of peerd launched with PID {}", child.id());
             Ok(())
         } else {

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -909,14 +909,16 @@ impl Runtime {
                         return self.get_secret(endpoints, source, request);
                     }
                     (None, Some(sk), Some(pk)) => {
-                        self.listens.insert(offer.id(), bind_addr);
-                        self.node_ids.insert(offer.id(), pk);
                         info!(
                             "{} for incoming peer connections on {}",
                             "Starting listener".bright_blue_bold(),
                             bind_addr.bright_blue_bold()
                         );
-                        self.listen(&bind_addr, sk)
+                        self.listen(&bind_addr, sk).and_then(|_| {
+                            self.listens.insert(offer.id(), bind_addr);
+                            self.node_ids.insert(offer.id(), pk);
+                            Ok(())
+                        })
                     }
                     (Some(&addr), _, Some(pk)) => {
                         // no need for the keys, because peerd already knows them

--- a/src/service.rs
+++ b/src/service.rs
@@ -406,6 +406,10 @@ pub trait LogStyle: ToString {
         self.to_string().bold().green()
     }
 
+    fn red_bold(&self) -> colored::ColoredString {
+        self.to_string().bold().red()
+    }
+
     fn bright_green_bold(&self) -> colored::ColoredString {
         self.to_string().bold().bright_green()
     }


### PR DESCRIPTION
Uses the same heuristic as the `connect_peer` method.