### PR TITLE
Cli: Add endpoint to print information about a passed-in offer

### DIFF
--- a/shell/_swap-cli
+++ b/shell/_swap-cli
@@ -103,6 +103,23 @@ _arguments "${_arguments_options[@]}" \
 '*--verbose[Set verbosity level]' \
 && ret=0
 ;;
+(offer-info)
+_arguments "${_arguments_options[@]}" \
+'-d+[Data directory path]:DATA_DIR:_files -/' \
+'--data-dir=[Data directory path]:DATA_DIR:_files -/' \
+'-T+[Use Tor]:TOR_PROXY:_hosts' \
+'--tor-proxy=[Use Tor]:TOR_PROXY:_hosts' \
+'-m+[ZMQ socket name/address to forward all incoming protocol messages]:MSG_SOCKET:_files' \
+'--msg-socket=[ZMQ socket name/address to forward all incoming protocol messages]:MSG_SOCKET:_files' \
+'-x+[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
+'--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'*-v[Set verbosity level]' \
+'*--verbose[Set verbosity level]' \
+':public-offer -- The offer to be canceled:' \
+&& ret=0
+;;
 (list-listens)
 _arguments "${_arguments_options[@]}" \
 '-d+[Data directory path]:DATA_DIR:_files -/' \
@@ -257,6 +274,7 @@ _swap-cli_commands() {
 'peers:Lists existing peer connections' \
 'list-swaps:Lists running swaps' \
 'list-offers:Lists public offers created by daemon' \
+'offer-info:Gives information on an open offer' \
 'list-listens:Lists listeners created by daemon' \
 'make:Maker creates offer and start listening for incoming connections. Command used to to print the resulting public offer that shall be shared with Taker. Additionally it spins up the listener awaiting for connection related to this offer' \
 'take:Taker accepts offer and connects to maker'\''s daemon to start the trade' \
@@ -301,6 +319,11 @@ _swap-cli__make_commands() {
 _swap-cli__needs-funding_commands() {
     local commands; commands=()
     _describe -t commands 'swap-cli needs-funding commands' commands "$@"
+}
+(( $+functions[_swap-cli__offer-info_commands] )) ||
+_swap-cli__offer-info_commands() {
+    local commands; commands=()
+    _describe -t commands 'swap-cli offer-info commands' commands "$@"
 }
 (( $+functions[_swap-cli__peers_commands] )) ||
 _swap-cli__peers_commands() {

--- a/shell/_swap-cli.ps1
+++ b/shell/_swap-cli.ps1
@@ -39,6 +39,7 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('peers', 'peers', [CompletionResultType]::ParameterValue, 'Lists existing peer connections')
             [CompletionResult]::new('list-swaps', 'list-swaps', [CompletionResultType]::ParameterValue, 'Lists running swaps')
             [CompletionResult]::new('list-offers', 'list-offers', [CompletionResultType]::ParameterValue, 'Lists public offers created by daemon')
+            [CompletionResult]::new('offer-info', 'offer-info', [CompletionResultType]::ParameterValue, 'Gives information on an open offer')
             [CompletionResult]::new('list-listens', 'list-listens', [CompletionResultType]::ParameterValue, 'Lists listeners created by daemon')
             [CompletionResult]::new('make', 'make', [CompletionResultType]::ParameterValue, 'Maker creates offer and start listening for incoming connections. Command used to to print the resulting public offer that shall be shared with Taker. Additionally it spins up the listener awaiting for connection related to this offer')
             [CompletionResult]::new('take', 'take', [CompletionResultType]::ParameterValue, 'Taker accepts offer and connects to maker''s daemon to start the trade')
@@ -94,6 +95,21 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             break
         }
         'swap-cli;list-offers' {
+            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
+            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
+            [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')
+            [CompletionResult]::new('--tor-proxy', 'tor-proxy', [CompletionResultType]::ParameterName, 'Use Tor')
+            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
+            [CompletionResult]::new('--msg-socket', 'msg-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
+            [CompletionResult]::new('-x', 'x', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
+            [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
+            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
+            break
+        }
+        'swap-cli;offer-info' {
             [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')

--- a/shell/swap-cli.bash
+++ b/shell/swap-cli.bash
@@ -33,6 +33,9 @@ _swap-cli() {
             needs-funding)
                 cmd+="__needs__funding"
                 ;;
+            offer-info)
+                cmd+="__offer__info"
+                ;;
             peers)
                 cmd+="__peers"
                 ;;
@@ -52,7 +55,7 @@ _swap-cli() {
 
     case "${cmd}" in
         swap__cli)
-            opts="-h -V -d -v -T -m -x --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket info peers list-swaps list-offers list-listens make take revoke-offer progress needs-funding help"
+            opts="-h -V -d -v -T -m -x --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket info peers list-swaps list-offers offer-info list-listens make take revoke-offer progress needs-funding help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -455,6 +458,52 @@ _swap-cli() {
             ;;
         swap__cli__needs__funding)
             opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <COIN>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --data-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --tor-proxy)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -T)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --msg-socket)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -m)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ctl-socket)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -x)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        swap__cli__offer__info)
+            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <PUBLIC_OFFER>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -73,6 +73,14 @@ pub enum Command {
     #[clap(aliases = &["lo"])]
     ListOffers,
 
+    /// Gives information on an open offer
+    #[clap(aliases = &["oi"])]
+    #[display("offer-info<{public_offer}>")]
+    OfferInfo {
+        /// The offer to be canceled.
+        public_offer: PublicOffer<BtcXmr>,
+    },
+
     // /// Lists IDs of public offers created by daemon
     // ListOfferIds,
     /// Lists listeners created by daemon


### PR DESCRIPTION
This completes #457 by adding an endpoint to display information about an offer. It is similar to the `take` command but does not interact with any of the other microservices.