### PR TITLE
Cancel swap

### DIFF
--- a/shell/_swap-cli
+++ b/shell/_swap-cli
@@ -244,6 +244,23 @@ _arguments "${_arguments_options[@]}" \
 ':public-offer -- The offer to be canceled:' \
 && ret=0
 ;;
+(cancel-swap)
+_arguments "${_arguments_options[@]}" \
+'-d+[Data directory path]:DATA_DIR:_files -/' \
+'--data-dir=[Data directory path]:DATA_DIR:_files -/' \
+'-T+[Use Tor]:TOR_PROXY:_hosts' \
+'--tor-proxy=[Use Tor]:TOR_PROXY:_hosts' \
+'-m+[ZMQ socket name/address to forward all incoming protocol messages]:MSG_SOCKET:_files' \
+'--msg-socket=[ZMQ socket name/address to forward all incoming protocol messages]:MSG_SOCKET:_files' \
+'-x+[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
+'--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'*-v[Set verbosity level]' \
+'*--verbose[Set verbosity level]' \
+':swap-id -- The swap to be canceled:' \
+&& ret=0
+;;
 (progress)
 _arguments "${_arguments_options[@]}" \
 '-d+[Data directory path]:DATA_DIR:_files -/' \
@@ -314,11 +331,17 @@ _swap-cli_commands() {
 'make:Maker creates offer and start listening for incoming connections. Command used to to print the resulting public offer that shall be shared with Taker. Additionally it spins up the listener awaiting for connection related to this offer' \
 'take:Taker accepts offer and connects to maker'\''s daemon to start the trade' \
 'revoke-offer:Revoke offer accepts an offer and revokes it within the runtime' \
+'cancel-swap:Cancel a swap if it has not locked yet' \
 'progress:Request swap progress report' \
 'needs-funding:Returns addresses and amounts that require funding for coin' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'swap-cli commands' commands "$@"
+}
+(( $+functions[_swap-cli__cancel-swap_commands] )) ||
+_swap-cli__cancel-swap_commands() {
+    local commands; commands=()
+    _describe -t commands 'swap-cli cancel-swap commands' commands "$@"
 }
 (( $+functions[_swap-cli__help_commands] )) ||
 _swap-cli__help_commands() {

--- a/shell/_swap-cli.ps1
+++ b/shell/_swap-cli.ps1
@@ -46,6 +46,7 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('make', 'make', [CompletionResultType]::ParameterValue, 'Maker creates offer and start listening for incoming connections. Command used to to print the resulting public offer that shall be shared with Taker. Additionally it spins up the listener awaiting for connection related to this offer')
             [CompletionResult]::new('take', 'take', [CompletionResultType]::ParameterValue, 'Taker accepts offer and connects to maker''s daemon to start the trade')
             [CompletionResult]::new('revoke-offer', 'revoke-offer', [CompletionResultType]::ParameterValue, 'Revoke offer accepts an offer and revokes it within the runtime')
+            [CompletionResult]::new('cancel-swap', 'cancel-swap', [CompletionResultType]::ParameterValue, 'Cancel a swap if it has not locked yet')
             [CompletionResult]::new('progress', 'progress', [CompletionResultType]::ParameterValue, 'Request swap progress report')
             [CompletionResult]::new('needs-funding', 'needs-funding', [CompletionResultType]::ParameterValue, 'Returns addresses and amounts that require funding for coin')
             [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
@@ -228,6 +229,21 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             break
         }
         'swap-cli;revoke-offer' {
+            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
+            [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
+            [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')
+            [CompletionResult]::new('--tor-proxy', 'tor-proxy', [CompletionResultType]::ParameterName, 'Use Tor')
+            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
+            [CompletionResult]::new('--msg-socket', 'msg-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
+            [CompletionResult]::new('-x', 'x', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
+            [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
+            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
+            break
+        }
+        'swap-cli;cancel-swap' {
             [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')

--- a/shell/swap-cli.bash
+++ b/shell/swap-cli.bash
@@ -12,6 +12,9 @@ _swap-cli() {
             "$1")
                 cmd="swap__cli"
                 ;;
+            cancel-swap)
+                cmd+="__cancel__swap"
+                ;;
             help)
                 cmd+="__help"
                 ;;
@@ -61,8 +64,54 @@ _swap-cli() {
 
     case "${cmd}" in
         swap__cli)
-            opts="-h -V -d -v -T -m -x --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket info peers list-swaps list-offers offer-info list-listens list-checkpoints restore-checkpoint make take revoke-offer progress needs-funding help"
+            opts="-h -V -d -v -T -m -x --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket info peers list-swaps list-offers offer-info list-listens list-checkpoints restore-checkpoint make take revoke-offer cancel-swap progress needs-funding help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --data-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --tor-proxy)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -T)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --msg-socket)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -m)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ctl-socket)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -x)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        swap__cli__cancel__swap)
+            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <SWAP_ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -224,6 +224,11 @@ impl Exec for Command {
                 runtime.report_response_or_fail()?;
             }
 
+            Command::CancelSwap { swap_id } => {
+                runtime.request(ServiceId::Swap(swap_id), Request::CancelSwap)?;
+                runtime.report_response_or_fail()?;
+            }
+
             Command::Progress { swapid, follow } => {
                 if follow {
                     // subscribe to progress event and loop until Finish event is received or user

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -210,6 +210,13 @@ pub enum Command {
         public_offer: PublicOffer<BtcXmr>,
     },
 
+    /// Cancel a swap if it has not locked yet.
+    #[display("cancel-swap<{swap_id}>")]
+    CancelSwap {
+        /// The swap to be canceled
+        swap_id: SwapId,
+    },
+
     /// Request swap progress report.
     #[display("progress<{swapid}>")]
     Progress {

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -1519,30 +1519,28 @@ impl Runtime {
 
             Request::FundingCanceled(coin) => {
                 let swapid = get_swap_id(&source)?;
-                if match coin {
+                match coin {
                     Coin::Bitcoin => {
                         if self.funding_btc.remove(&get_swap_id(&source)?).is_some() {
                             self.stats.incr_funding_bitcoin_canceled();
-                            true
-                        } else {
-                            false
+                            info!(
+                                "{} | Your {} funding was canceled",
+                                swapid.bright_blue_italic(),
+                                coin.bright_green_bold()
+                            );
                         }
                     }
                     Coin::Monero => {
                         if self.funding_xmr.remove(&get_swap_id(&source)?).is_some() {
                             self.stats.incr_funding_monero_canceled();
-                            true
-                        } else {
-                            false
+                            info!(
+                                "{} | Your {} funding was canceled",
+                                swapid.bright_blue_italic(),
+                                coin.bright_green_bold()
+                            );
                         }
                     }
-                } {
-                    info!(
-                        "{} | Your {} funding was canceled",
-                        swapid.bright_blue_italic(),
-                        coin.bright_green_bold()
-                    );
-                }
+                };
             }
 
             Request::NeedsFunding(Coin::Monero) => {

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -314,7 +314,6 @@ impl Runtime {
         &mut self,
         swapid: &SwapId,
         endpoints: &mut Endpoints,
-        success: &Outcome,
     ) -> Result<(), Error> {
         if self.running_swaps.remove(swapid) {
             endpoints.send_to(
@@ -373,11 +372,6 @@ impl Runtime {
                     }
                 }
             }
-        }
-
-        // do not kill the syncers if the swap was canceled by the user
-        if let Outcome::Cancel = success {
-            return Ok(());
         }
 
         self.syncer_clients = self
@@ -729,7 +723,7 @@ impl Runtime {
 
             Request::SwapOutcome(success) => {
                 let swapid = get_swap_id(&source)?;
-                self.clean_up_after_swap(&swapid, endpoints, &success)?;
+                self.clean_up_after_swap(&swapid, endpoints)?;
                 self.stats.incr_outcome(&success);
                 match success {
                     Outcome::Buy => {

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -15,6 +15,7 @@
 #![allow(clippy::clone_on_copy)]
 
 use crate::swapd::CheckpointSwapd;
+use crate::syncerd::SweepBitcoinAddress;
 use crate::walletd::{
     runtime::{AliceState, CheckpointWallet},
     NodeSecrets,
@@ -413,6 +414,14 @@ pub enum Request {
     #[display("get_keys({0})")]
     GetKeys(GetKeys),
 
+    #[api(type = 36)]
+    #[display("get_sweep_bitcoin_address")]
+    GetSweepBitcoinAddress(bitcoin::Address),
+
+    #[api(type = 37)]
+    #[display("funding_key")]
+    FundingKey(FundingKey),
+
     #[api(type = 29)]
     #[display("launch_swap({0})")]
     LaunchSwap(LaunchSwap),
@@ -520,6 +529,10 @@ pub enum Request {
     #[api(type = 193)]
     #[display("revoke_offer({0})")]
     RevokeOffer(PublicOffer<BtcXmr>),
+
+    #[api(type = 192)]
+    #[display("cancel_swap")]
+    CancelSwap,
 
     #[api(type = 205)]
     #[display("fund_swap({0})")]
@@ -688,6 +701,11 @@ pub enum Request {
     #[api(type = 1309)]
     #[display("restore_checkpoint({0})", alt = "{0:#}")]
     RestoreCheckpoint(SwapId),
+
+    #[api(type = 1310)]
+    #[display("task({0})", alt = "{0:#}")]
+    #[from]
+    SweepBitcoinAddress(SweepBitcoinAddress),
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
@@ -698,6 +716,8 @@ pub enum Outcome {
     Refund,
     #[display("Failure(Punished)")]
     Punish,
+    #[display("Failure(Canceled)")]
+    Cancel,
 }
 #[derive(Clone, Debug, Display, StrictDecode, StrictEncode)]
 #[display("funding_info")]
@@ -724,6 +744,13 @@ pub struct CheckpointEntry {
 pub struct CheckpointChunk {
     pub msg_index: usize,
     pub serialized_state_chunk: Vec<u8>,
+}
+
+#[derive(Clone, Debug, StrictEncode, StrictDecode, Display)]
+#[display("funding key")]
+pub struct FundingKey {
+    pub funding_key: [u8; 32],
+    pub destination_address: bitcoin::Address,
 }
 
 #[derive(Clone, Debug, Display, StrictDecode, StrictEncode)]

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -641,7 +641,7 @@ pub enum Request {
     FundingCompleted(Coin),
 
     #[api(type = 1112)]
-    #[display("funding_canceld")]
+    #[display("funding_canceled")]
     FundingCanceled(Coin),
 
     // #[api(type = 1203)]

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -418,10 +418,6 @@ pub enum Request {
     #[display("get_sweep_bitcoin_address")]
     GetSweepBitcoinAddress(bitcoin::Address),
 
-    #[api(type = 37)]
-    #[display("funding_key")]
-    FundingKey(FundingKey),
-
     #[api(type = 29)]
     #[display("launch_swap({0})")]
     LaunchSwap(LaunchSwap),
@@ -645,7 +641,7 @@ pub enum Request {
     FundingCompleted(Coin),
 
     #[api(type = 1112)]
-    #[display("read_funding")]
+    #[display("funding_canceld")]
     FundingCanceled(Coin),
 
     // #[api(type = 1203)]
@@ -744,13 +740,6 @@ pub struct CheckpointEntry {
 pub struct CheckpointChunk {
     pub msg_index: usize,
     pub serialized_state_chunk: Vec<u8>,
-}
-
-#[derive(Clone, Debug, StrictEncode, StrictDecode, Display)]
-#[display("funding key")]
-pub struct FundingKey {
-    pub funding_key: [u8; 32],
-    pub destination_address: bitcoin::Address,
 }
 
 #[derive(Clone, Debug, Display, StrictDecode, StrictEncode)]

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -220,6 +220,9 @@ impl State {
     pub fn b_buy_sig(&self) -> bool {
         matches!(self, State::Bob(BobState::BuySigB { .. }))
     }
+    pub fn b_outcome_cancel(&self) -> bool {
+        matches!(self, State::Bob(BobState::FinishB(Outcome::Cancel)))
+    }
     pub fn remote_commit(&self) -> Option<&Commit> {
         match self {
             State::Alice(AliceState::CommitA { remote_commit, .. })

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -75,9 +75,11 @@ pub enum BobState {
     // #[display("CoreArb: {0:#?}")]
     #[display("CoreArb")]
     CorearbB {
+        received_refund_procedure_signatures: bool,
         cancel_seen: bool,
         remote_params: Params,
         local_params: Params,
+        b_address: bitcoin::Address,
     }, // lock (not signed), cancel_seen, remote
     #[display("BuySig")]
     BuySigB { buy_tx_seen: bool },
@@ -171,6 +173,47 @@ impl State {
             _ => false,
         }
     }
+    pub fn sup_received_refund_procedure_signatures(&mut self) -> bool {
+        match self {
+            State::Bob(BobState::CorearbB {
+                received_refund_procedure_signatures,
+                ..
+            }) => {
+                *received_refund_procedure_signatures = true;
+                true
+            }
+            _ => false,
+        }
+    }
+    pub fn b_received_refund_procedure_signatures(&self) -> bool {
+        if let State::Bob(BobState::CorearbB {
+            received_refund_procedure_signatures,
+            ..
+        }) = self
+        {
+            *received_refund_procedure_signatures
+        } else {
+            false
+        }
+    }
+    pub fn a_start(&self) -> bool {
+        matches!(self, State::Alice(AliceState::StartA { .. }))
+    }
+    pub fn a_commit(&self) -> bool {
+        matches!(self, State::Alice(AliceState::CommitA { .. }))
+    }
+    pub fn a_reveal(&self) -> bool {
+        matches!(self, State::Alice(AliceState::RevealA { .. }))
+    }
+    pub fn b_start(&self) -> bool {
+        matches!(self, State::Bob(BobState::StartB { .. }))
+    }
+    pub fn b_commit(&self) -> bool {
+        matches!(self, State::Bob(BobState::CommitB { .. }))
+    }
+    pub fn b_reveal(&self) -> bool {
+        matches!(self, State::Bob(BobState::RevealB { .. }))
+    }
     pub fn b_core_arb(&self) -> bool {
         matches!(self, State::Bob(BobState::CorearbB { .. }))
     }
@@ -207,7 +250,8 @@ impl State {
     pub fn b_address(&self) -> Option<&bitcoin::Address> {
         match self {
             State::Bob(BobState::CommitB { b_address, .. })
-            | State::Bob(BobState::RevealB { b_address, .. }) => Some(b_address),
+            | State::Bob(BobState::RevealB { b_address, .. })
+            | State::Bob(BobState::CorearbB { b_address, .. }) => Some(b_address),
             _ => None,
         }
     }

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -270,6 +270,7 @@ impl SyncerState {
     }
     pub fn sweep_btc(&mut self, sweep_bitcoin_address: SweepBitcoinAddress) -> Task {
         let id = self.tasks.new_taskid();
+        self.tasks.sweeping_addr = Some(id);
         let lifetime = self.task_lifetime(Coin::Bitcoin);
         let addendum = SweepAddressAddendum::Bitcoin(sweep_bitcoin_address);
         let sweep_task = SweepAddress {
@@ -278,7 +279,9 @@ impl SyncerState {
             addendum,
             from_height: None,
         };
-        Task::SweepAddress(sweep_task)
+        let task = Task::SweepAddress(sweep_task);
+        self.tasks.tasks.insert(id, task.clone());
+        task
     }
 
     pub fn acc_lock_watched(&self) -> bool {

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -1,3 +1,4 @@
+use crate::syncerd::SweepBitcoinAddress;
 use crate::{
     service::LogStyle,
     syncerd::{
@@ -266,6 +267,18 @@ impl SyncerState {
         });
         self.tasks.tasks.insert(id, task.clone());
         task
+    }
+    pub fn sweep_btc(&mut self, sweep_bitcoin_address: SweepBitcoinAddress) -> Task {
+        let id = self.tasks.new_taskid();
+        let lifetime = self.task_lifetime(Coin::Bitcoin);
+        let addendum = SweepAddressAddendum::Bitcoin(sweep_bitcoin_address);
+        let sweep_task = SweepAddress {
+            id,
+            lifetime,
+            addendum,
+            from_height: None,
+        };
+        Task::SweepAddress(sweep_task)
     }
 
     pub fn acc_lock_watched(&self) -> bool {

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -965,7 +965,6 @@ fn sweep_polling(
                     }
                 }
             }
-
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
         }
     })

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -930,37 +930,37 @@ fn sweep_polling(
             let state_guard = state.lock().await;
             let sweep_addresses = state_guard.sweep_addresses.clone();
             drop(state_guard);
-            match Client::new(&electrum_server) {
-                Err(err) => {
-                    error!(
-                        "Failed to create btc sweep electrum client: {}, retrying",
-                        err
-                    );
-                }
-                Ok(client) => {
-                    for (id, sweep_address_task) in sweep_addresses.iter() {
-                        if let SweepAddressAddendum::Bitcoin(addendum) =
-                            sweep_address_task.addendum.clone()
-                        {
-                            let sweep_address_txs = sweep_address(
-                                addendum.source_private_key,
-                                addendum.source_address,
-                                addendum.destination_address,
-                                &client,
-                                network,
-                            )
-                            .unwrap_or_else(|err| {
-                                warn!("error polling sweep address {:?}, retrying", err);
-                                vec![]
-                            });
-                            debug!("sweep address transaction: {:?}", sweep_address_txs);
-                            if !sweep_address_txs.is_empty() {
+            if !sweep_addresses.is_empty() {
+                match Client::new(&electrum_server) {
+                    Err(err) => {
+                        error!(
+                            "Failed to create btc sweep electrum client: {}, retrying",
+                            err
+                        );
+                    }
+                    Ok(client) => {
+                        for (id, sweep_address_task) in sweep_addresses.iter() {
+                            if let SweepAddressAddendum::Bitcoin(addendum) =
+                                sweep_address_task.addendum.clone()
+                            {
+                                let sweep_address_txs = sweep_address(
+                                    addendum.source_private_key,
+                                    addendum.source_address,
+                                    addendum.destination_address,
+                                    &client,
+                                    network,
+                                )
+                                .unwrap_or_else(|err| {
+                                    warn!("error polling sweep address {:?}, retrying", err);
+                                    vec![]
+                                });
+                                debug!("sweep address transaction: {:?}", sweep_address_txs);
                                 let mut state_guard = state.lock().await;
                                 state_guard.success_sweep(id, sweep_address_txs).await;
                                 drop(state_guard);
+                            } else {
+                                error!("Not sweeping address - is not using a bitcoin sweep address addendum");
                             }
-                        } else {
-                            error!("Not sweeping address - is not using a bitcoin sweep address addendum");
                         }
                     }
                 }

--- a/tests/functional-swap.rs
+++ b/tests/functional-swap.rs
@@ -1864,9 +1864,6 @@ async fn run_user_cancel_swap(
     // cancel the swap on Alice's side
     cancel_swap(swap_id, data_dir_alice);
 
-    // wait a bit for sweep to happen
-    tokio::time::sleep(time::Duration::from_secs(10)).await;
-
     // fund the bitcoin address
     bitcoin_rpc
         .send_to_address(&address, amount, None, None, None, None, None, None)
@@ -1876,8 +1873,7 @@ async fn run_user_cancel_swap(
     println!("waiting for the bitcoin funding info to clear");
     retry_until_funding_info_cleared(swap_id.clone(), cli_bob_needs_funding_args.clone()).await;
 
-    println!("\n\n Cancelling Bob\n\n");
-    // cance lthe swap on Bob's side
+    // cancel the swap on Bob's side
     cancel_swap(swap_id, data_dir_bob);
 
     // wait a bit for sweep to happen

--- a/tests/functional-swap.rs
+++ b/tests/functional-swap.rs
@@ -69,6 +69,39 @@ async fn swap_bob_maker_normal() {
     cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }
 
+#[tokio::test]
+#[timeout(600000)]
+#[ignore]
+async fn swap_bob_maker_user_cancel_sweep_btc() {
+    let bitcoin_rpc = Arc::new(bitcoin_setup());
+    let (_monero_regtest, monero_wallet) = monero_setup().await;
+
+    let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
+        setup_farcaster_clients().await;
+
+    let (_xmr_dest_wallet_name, bitcoin_address, swap_id) = make_and_take_offer(
+        data_dir_maker.clone(),
+        data_dir_taker.clone(),
+        "Bob".to_string(),
+        Arc::clone(&bitcoin_rpc),
+        Arc::clone(&monero_wallet),
+        bitcoin::Amount::from_str("1 BTC").unwrap(),
+        monero::Amount::from_str_with_denomination("1 XMR").unwrap(),
+    )
+    .await;
+
+    run_user_cancel_swap(
+        swap_id,
+        data_dir_taker,
+        data_dir_maker,
+        Arc::clone(&bitcoin_rpc),
+        bitcoin_address,
+    )
+    .await;
+
+    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
+}
+
 pub mod farcaster {
     tonic::include_proto!("farcaster");
 }
@@ -1809,6 +1842,59 @@ async fn run_swaps_parallel(
 }
 
 #[allow(clippy::too_many_arguments)]
+async fn run_user_cancel_swap(
+    swap_id: SwapId,
+    data_dir_alice: Vec<String>,
+    data_dir_bob: Vec<String>,
+    bitcoin_rpc: Arc<bitcoincore_rpc::Client>,
+    destination_btc_address: bitcoin::Address,
+) {
+    let cli_bob_needs_funding_args: Vec<String> =
+        needs_funding_args(data_dir_bob.clone(), "bitcoin".to_string());
+
+    bitcoin_rpc
+        .generate_to_address(1, &reusable_btc_address())
+        .unwrap();
+
+    // run until bob has the btc funding address
+    let (address, amount) =
+        retry_until_bitcoin_funding_address(swap_id.clone(), cli_bob_needs_funding_args.clone())
+            .await;
+
+    // cancel the swap on Alice's side
+    cancel_swap(swap_id, data_dir_alice);
+
+    // wait a bit for sweep to happen
+    tokio::time::sleep(time::Duration::from_secs(10)).await;
+
+    // fund the bitcoin address
+    bitcoin_rpc
+        .send_to_address(&address, amount, None, None, None, None, None, None)
+        .unwrap();
+
+    // run until the funding infos are cleared again
+    println!("waiting for the bitcoin funding info to clear");
+    retry_until_funding_info_cleared(swap_id.clone(), cli_bob_needs_funding_args.clone()).await;
+
+    println!("\n\n Cancelling Bob\n\n");
+    // cance lthe swap on Bob's side
+    cancel_swap(swap_id, data_dir_bob);
+
+    // wait a bit for sweep to happen
+    tokio::time::sleep(time::Duration::from_secs(10)).await;
+    bitcoin_rpc
+        .generate_to_address(1, &reusable_btc_address())
+        .unwrap();
+
+    // check that btc was received in the destination address
+    let balance = bitcoin_rpc
+        .get_received_by_address(&destination_btc_address, None)
+        .unwrap();
+    println!("received balance: {}", balance);
+    assert!(balance.as_sat() > 90000000);
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn run_swap(
     swap_id: SwapId,
     data_dir_alice: Vec<String>,
@@ -2180,6 +2266,13 @@ fn revoke_offer_args(data_dir: Vec<String>, offer: String) -> Vec<String> {
         .collect()
 }
 
+fn cancel_swap_args(data_dir: Vec<String>, swap_id: SwapId) -> Vec<String> {
+    data_dir
+        .into_iter()
+        .chain(vec!["cancel-swap".to_string(), format!("{:#?}", swap_id)])
+        .collect()
+}
+
 fn cli_output_to_node_info(stdout: Vec<String>) -> NodeInfo {
     serde_yaml::from_str(
         &stdout
@@ -2209,6 +2302,11 @@ async fn retry_until_offer(args: Vec<String>) -> Vec<String> {
 fn get_info(args: Vec<String>) -> NodeInfo {
     let (stdout, _stderr) = run("../swap-cli", args.clone()).unwrap();
     cli_output_to_node_info(stdout)
+}
+
+fn cancel_swap(swap_id: SwapId, data_dir: Vec<String>) {
+    let res = run("../swap-cli", cancel_swap_args(data_dir, swap_id)).unwrap();
+    println!("res: {:?}", res);
 }
 
 fn revoke_offer(offer: String, data_dir: Vec<String>) {


### PR DESCRIPTION
Based on #499 and #485 .

A swap should be cancelable by the user if its side has not locked any coins yet.
    
For Alice, this means a swap can be canceled without additional handling up until she reaches state RefundSigA. Once she reaches RefundSigA, the XMR funding address is displayed and may thus contain locked coins. At the point, the swap should just follow the rest of  the protocol. 
    
For Bob, this means a swap can be canceled without additional handling as long as it still is in its original start state. If it is in commit, reveal, or corearb state and has not yet received the refund procedure signatures from Alice, it additionally attempts to sweep any coins that were sent to the funding address.

~Because of the sweeping, the syncers need to keep on running after the user has canceled and the swap is already being cleaned up.~