### PR TITLE
Offer history

### DIFF
--- a/shell/_swap-cli
+++ b/shell/_swap-cli
@@ -89,6 +89,8 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (list-offers)
 _arguments "${_arguments_options[@]}" \
+'-s+[]:SELECT:(open Open inprogress in_progress ended Ended all All)' \
+'--select=[]:SELECT:(open Open inprogress in_progress ended Ended all All)' \
 '-d+[Data directory path]:DATA_DIR:_files -/' \
 '--data-dir=[Data directory path]:DATA_DIR:_files -/' \
 '-T+[Use Tor]:TOR_PROXY:_hosts' \

--- a/shell/_swap-cli.ps1
+++ b/shell/_swap-cli.ps1
@@ -98,6 +98,8 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             break
         }
         'swap-cli;list-offers' {
+            [CompletionResult]::new('-s', 's', [CompletionResultType]::ParameterName, 's')
+            [CompletionResult]::new('--select', 'select', [CompletionResultType]::ParameterName, 'select')
             [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('--data-dir', 'data-dir', [CompletionResultType]::ParameterName, 'Data directory path')
             [CompletionResult]::new('-T', 'T', [CompletionResultType]::ParameterName, 'Use Tor')

--- a/shell/swap-cli.bash
+++ b/shell/swap-cli.bash
@@ -340,12 +340,20 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__list__offers)
-            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket"
+            opts="-s -h -d -v -T -m -x --select --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --select)
+                    COMPREPLY=($(compgen -W "open Open inprogress in_progress ended Ended all All" -- "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -W "open Open inprogress in_progress ended Ended all All" -- "${cur}"))
+                    return 0
+                    ;;
                 --data-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -89,8 +89,8 @@ impl Exec for Command {
             }
 
             // TODO: only list offers matching list of OfferIds
-            Command::ListOffers => {
-                runtime.request(ServiceId::Farcasterd, Request::ListOffers)?;
+            Command::ListOffers { select } => {
+                runtime.request(ServiceId::Farcasterd, Request::ListOffers(select.into()))?;
                 runtime.report_response_or_fail()?;
             }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,4 +15,4 @@
 mod command;
 mod opts;
 
-pub use opts::{Command, Opts};
+pub use opts::{Command, OfferSelector, Opts};

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -68,10 +68,17 @@ pub enum Command {
     #[clap(aliases = &["ls"])]
     ListSwaps,
 
-    // TODO: only list offers matching list of OfferIds
     /// Lists public offers created by daemon
     #[clap(aliases = &["lo"])]
-    ListOffers,
+    ListOffers {
+        #[clap(
+            short,
+            long,
+            default_value = "open",
+            possible_values = &["open", "Open", "inprogress", "in_progress", "ended", "Ended", "all", "All"],
+        )]
+        select: OfferSelector,
+    },
 
     /// Gives information on an open offer
     #[clap(aliases = &["oi"])]
@@ -234,6 +241,38 @@ pub enum Command {
         /// The coin funding required needs to be checked against.
         coin: Coin,
     },
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display, From)]
+pub enum OfferSelector {
+    #[display("Open")]
+    Open,
+    #[display("In Progress")]
+    InProgress,
+    #[display("Ended")]
+    Ended,
+    #[display("All")]
+    All,
+}
+
+impl FromStr for OfferSelector {
+    type Err = OfferSelectorParseError;
+    fn from_str(input: &str) -> Result<OfferSelector, Self::Err> {
+        match input {
+            "open" | "Open" => Ok(OfferSelector::Open),
+            "in_progress" | "inprogress" => Ok(OfferSelector::InProgress),
+            "ended" | "Ended" => Ok(OfferSelector::Ended),
+            "all" | "All" => Ok(OfferSelector::All),
+            _ => Err(OfferSelectorParseError::Invalid),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display, Error, From)]
+#[display(doc_comments)]
+pub enum OfferSelectorParseError {
+    /// The provided value can't be parsed as an offer selector
+    Invalid,
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display, Error, From)]

--- a/src/databased/runtime.rs
+++ b/src/databased/runtime.rs
@@ -314,7 +314,7 @@ impl Runtime {
                 self.database.set_offer_status(&offer, &status)?;
             }
 
-            Request::RetrieveOffers(selector) => {
+            Request::ListOffers(selector) => {
                 let offer_status_pairs = self.database.get_offers(selector)?;
                 endpoints.send_to(
                     ServiceBus::Ctl,

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -20,6 +20,8 @@ pub mod request;
 use crate::ServiceId;
 pub use client::Client;
 pub use reply::Reply;
+#[cfg(feature = "shell")]
+pub use request::OfferStatusSelector;
 pub use request::Request;
 
 use microservices::esb::BusId;

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -14,6 +14,7 @@
 
 #![allow(clippy::clone_on_copy)]
 
+use crate::cli::OfferSelector;
 use crate::swapd::CheckpointSwapd;
 use crate::syncerd::SweepBitcoinAddress;
 use crate::walletd::{
@@ -453,10 +454,9 @@ pub enum Request {
     #[display("list_tasks()")]
     ListTasks,
 
-    // TODO: only list offers matching list of OfferIds
     #[api(type = 104)]
     #[display("list_offers()")]
-    ListOffers,
+    ListOffers(OfferStatusSelector),
 
     // #[api(type = 105)]
     // #[display("list_offer_ids()")]
@@ -755,6 +755,29 @@ pub enum OfferStatusSelector {
     Ended,
     #[display("All")]
     All,
+}
+
+impl From<OfferSelector> for OfferStatusSelector {
+    fn from(offer_selector: OfferSelector) -> OfferStatusSelector {
+        match offer_selector {
+            OfferSelector::Open => OfferStatusSelector::Open,
+            OfferSelector::InProgress => OfferStatusSelector::InProgress,
+            OfferSelector::Ended => OfferStatusSelector::Ended,
+            OfferSelector::All => OfferStatusSelector::All,
+        }
+    }
+}
+
+impl FromStr for OfferStatusSelector {
+    type Err = ();
+    fn from_str(input: &str) -> Result<OfferStatusSelector, Self::Err> {
+        match input {
+            "open" | "Open" => Ok(OfferStatusSelector::Open),
+            "in_progress" | "inprogress" => Ok(OfferStatusSelector::Open),
+            "ended" | "Ended" => Ok(OfferStatusSelector::Ended),
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Display, StrictEncode, StrictDecode)]


### PR DESCRIPTION
Persist open, in progress and ended offers. Adds an option to `list-offers` to select offers by their status. This allows the user to query trade history.