### PR TITLE
Swap: Allow cancel for alice refundsig before arb lock

### DIFF
--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -1498,6 +1498,7 @@ impl Runtime {
                                     && self.state.remote_params().is_some()
                                     && !self.syncer_state.acc_lock_watched() =>
                             {
+                                self.state.a_sup_refundsig_btclocked();
                                 // TODO: implement state management here?
                                 if let (
                                     Some(Params::Alice(alice_params)),
@@ -1575,6 +1576,7 @@ impl Runtime {
                                     && self.state.local_params().is_some() =>
                             {
                                 let xmr_locked = self.state.a_xmr_locked();
+                                let btc_locked = self.state.a_btc_locked();
                                 if let Some((txlabel, buy_tx)) =
                                     self.txs.remove_entry(&TxLabel::Buy)
                                 {
@@ -1582,6 +1584,7 @@ impl Runtime {
                                     self.state = State::Alice(AliceState::RefundSigA {
                                         local_params: self.state.local_params().cloned().unwrap(),
                                         buy_published: true,
+                                        btc_locked,
                                         xmr_locked,
                                         cancel_seen: false,
                                         refund_seen: false,
@@ -2075,6 +2078,7 @@ impl Runtime {
                 trace!("sent peer RefundProcedureSignatures msg");
                 let next_state = State::Alice(AliceState::RefundSigA {
                     local_params: self.state.local_params().cloned().unwrap(),
+                    btc_locked: false,
                     xmr_locked: false,
                     buy_published: false,
                     cancel_seen: false,
@@ -2145,7 +2149,10 @@ impl Runtime {
             }
 
             Request::CancelSwap
-                if self.state.a_start() || self.state.a_commit() || self.state.a_reveal() =>
+                if self.state.a_start()
+                    || self.state.a_commit()
+                    || self.state.a_reveal()
+                    || (self.state.a_refundsig() && !self.state.a_btc_locked()) =>
             {
                 // just cancel the swap, no additional logic required
                 self.state_update(
@@ -2200,10 +2207,6 @@ impl Runtime {
                     Request::Failure(Failure { code: 1, info: msg }),
                 )?;
             }
-            // TODO add rule for canceling alice swap if bob never locks,
-            // but she is already in RefundSigA. This is not that critical,
-            // since Alice won't lock her funds either, but it could leave a
-            // swap running forever
             Request::GetInfo(_) => {
                 fn bmap<T>(remote_peer: &Option<NodeAddr>, v: &T) -> BTreeMap<NodeAddr, T>
                 where

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -33,6 +33,7 @@ pub enum AliceState {
     }, // local, remote, remote
     #[display("RefundSigs(xmr_locked({xmr_locked}), buy_pub({buy_published}), cancel_seen({cancel_seen}), refund_seen({refund_seen}))")]
     RefundSigA {
+        btc_locked: bool,
         xmr_locked: bool,
         buy_published: bool,
         cancel_seen: bool,
@@ -131,6 +132,13 @@ impl State {
                 true
             }
             _ => false,
+        }
+    }
+    pub fn a_btc_locked(&self) -> bool {
+        if let State::Alice(AliceState::RefundSigA { btc_locked, .. }) = self {
+            *btc_locked
+        } else {
+            false
         }
     }
     pub fn a_xmr_locked(&self) -> bool {
@@ -448,6 +456,22 @@ impl State {
         match self {
             State::Bob(BobState::BuySigB { buy_tx_seen }) if !(*buy_tx_seen) => *buy_tx_seen = true,
             _ => unreachable!("checked state"),
+        }
+    }
+    /// Update Alice RefundSig state from BTC unlocked to locked state
+    pub fn a_sup_refundsig_btclocked(&mut self) -> bool {
+        if let State::Alice(AliceState::RefundSigA { btc_locked, .. }) = self {
+            if !*btc_locked {
+                trace!("setting btc_locked");
+                *btc_locked = true;
+                true
+            } else {
+                trace!("btc_locked was already set to true");
+                false
+            }
+        } else {
+            error!("Not on RefundSig state");
+            false
         }
     }
     /// Update Alice RefundSig state from XMR unlocked to locked state


### PR DESCRIPTION
Alice should be able to cancel the swap up until the point where Bob's lock has confirmed.