### PR TITLE
Fix Checkpoint race condition

### DIFF
--- a/tests/functional-swap.rs
+++ b/tests/functional-swap.rs
@@ -844,8 +844,6 @@ async fn run_restore_checkpoint_bob_pre_buy_alice_pre_lock(
     println!("waiting for the bitcoin funding info to clear");
     retry_until_funding_info_cleared(swap_id.clone(), cli_bob_needs_funding_args.clone()).await;
 
-    tokio::time::sleep(time::Duration::from_secs(5)).await;
-
     // kill all the daemons and start them again
     cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
     let (farcasterd_maker, _, farcasterd_taker, _) = setup_farcaster_clients().await;


### PR DESCRIPTION
Solves the race condition described in #515. The syncer state (syncer client) now keeps track of transactions that are pending broadcast. Once their broadcast has been confirmed by the syncer, they are removed again.