### PR TITLE
Swap: Add public offer to GetInfo

### DIFF
--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -1177,19 +1177,11 @@ pub struct SwapInfo {
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub swap_id: Option<SwapId>,
     // pub state: crate::swapd::State,
-    // #[serde_as(as = "BTreeMap<DisplayFromStr, Same>")]
-    // pub funding_outpoint: OutPoint,
     #[serde_as(as = "Vec<DisplayFromStr>")]
     pub maker_peer: Vec<NodeAddr>,
     #[serde_as(as = "DurationSeconds")]
     pub uptime: Duration,
     pub since: u64,
-    //// FIXME serde::Serialize/Deserialize missing
-    // #[serde_as(as = "Option<DisplayFromStr)>")]
-    // pub params: Option<Params>,
-    pub local_keys: lnp::channel::bolt::LocalKeyset,
-    #[serde_as(as = "BTreeMap<DisplayFromStr, Same>")]
-    pub remote_keys: BTreeMap<NodeAddr, lnp::channel::bolt::RemoteKeyset>,
     pub public_offer: PublicOffer<BtcXmr>,
 }
 

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -1190,6 +1190,7 @@ pub struct SwapInfo {
     pub local_keys: lnp::channel::bolt::LocalKeyset,
     #[serde_as(as = "BTreeMap<DisplayFromStr, Same>")]
     pub remote_keys: BTreeMap<NodeAddr, lnp::channel::bolt::RemoteKeyset>,
+    pub public_offer: PublicOffer<BtcXmr>,
 }
 
 #[cfg(feature = "serde")]

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -2211,16 +2211,6 @@ impl Runtime {
                 )?;
             }
             Request::GetInfo(_) => {
-                fn bmap<T>(remote_peer: &Option<NodeAddr>, v: &T) -> BTreeMap<NodeAddr, T>
-                where
-                    T: Clone,
-                {
-                    remote_peer
-                        .as_ref()
-                        .map(|p| bmap! { p.clone() => v.clone() })
-                        .unwrap_or_default()
-                }
-
                 let swap_id = if self.swap_id() == zero!() {
                     None
                 } else {
@@ -2238,10 +2228,6 @@ impl Runtime {
                         .duration_since(SystemTime::UNIX_EPOCH)
                         .unwrap_or_else(|_| Duration::from_secs(0))
                         .as_secs(),
-                    // params: self.params, // FIXME
-                    // serde::Serialize/Deserialize missing
-                    local_keys: dumb!(),
-                    remote_keys: bmap(&self.maker_peer, &dumb!()),
                     public_offer: self.public_offer.clone(),
                 };
                 self.send_ctl(endpoints, source, Request::SwapInfo(info))?;

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -11,10 +11,7 @@ use crate::rpc::request::{Commit, Outcome, Params};
 pub enum AliceState {
     // #[display("Start: {0:#?} {1:#?}")]
     #[display("Start")]
-    StartA {
-        local_trade_role: TradeRole,
-        public_offer: PublicOffer<BtcXmr>,
-    }, // local, both
+    StartA { local_trade_role: TradeRole }, // local, both
     // #[display("Commit: {0}")]
     #[display("Commit")]
     CommitA {
@@ -52,10 +49,7 @@ pub enum AliceState {
 pub enum BobState {
     // #[display("Start {0:#?} {1:#?}")]
     #[display("Start")]
-    StartB {
-        local_trade_role: TradeRole,
-        public_offer: PublicOffer<BtcXmr>,
-    }, // local, both
+    StartB { local_trade_role: TradeRole }, // local, both
     // #[display("Commit {0} {1}")]
     #[display("Commit")]
     CommitB {
@@ -268,13 +262,6 @@ impl State {
             | State::Alice(AliceState::RefundSigA { local_params, .. })
             | State::Bob(BobState::RevealB { local_params, .. })
             | State::Bob(BobState::CorearbB { local_params, .. }) => Some(local_params),
-            _ => None,
-        }
-    }
-    pub fn public_offer(&self) -> Option<&PublicOffer<BtcXmr>> {
-        match self {
-            State::Alice(AliceState::StartA { public_offer, .. })
-            | State::Bob(BobState::StartB { public_offer, .. }) => Some(public_offer),
             _ => None,
         }
     }

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -11,7 +11,7 @@ use crate::rpc::request::{Commit, Outcome, Params};
 pub enum AliceState {
     // #[display("Start: {0:#?} {1:#?}")]
     #[display("Start")]
-    StartA { local_trade_role: TradeRole }, // local, both
+    StartA { local_trade_role: TradeRole }, // local
     // #[display("Commit: {0}")]
     #[display("Commit")]
     CommitA {
@@ -49,7 +49,7 @@ pub enum AliceState {
 pub enum BobState {
     // #[display("Start {0:#?} {1:#?}")]
     #[display("Start")]
-    StartB { local_trade_role: TradeRole }, // local, both
+    StartB { local_trade_role: TradeRole }, // local
     // #[display("Commit {0} {1}")]
     #[display("Commit")]
     CommitB {


### PR DESCRIPTION
Adds a public_offer to each swap state. Not sure if the swap state is the correct place to put it, as opposed to the Runtime, would be great to get your comment on this @zkao.

Also cleans up the swap GetInfo struct a bit.

Closes #458 