### PR TITLE
Configuration: Change Monero stagenet node

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ First you need to run a `monero rpc wallet` to manage the moneros, if you have i
 ```
 monero-wallet-rpc --stagenet --rpc-bind-port 38083\
     --disable-rpc-login\
-    --daemon-host stagenet.melo.tools:38081\
+    --daemon-host stagenet.community.rino.io:38081\
     --trusted-daemon\
     --password "soMeDummYPasSwOrd"\
     --wallet-dir ~/.fc_monero_wallets
@@ -55,7 +55,7 @@ or you can use the Docker image
 docker run --rm -p 38083:38083 ghcr.io/farcaster-project/containers/monero-wallet-rpc:latest\
     /usr/bin/monero-wallet-rpc --stagenet\
     --disable-rpc-login --wallet-dir wallets\
-    --daemon-host stagenet.melo.tools:38081\
+    --daemon-host stagenet.community.rino.io:38081\
     --rpc-bind-ip 0.0.0.0 --rpc-bind-port 38083\
     --confirm-external-bind
 ```
@@ -190,7 +190,7 @@ Only blockchain daemons and electrum servers are listed, you should always run y
 | daemon            | value                                                |
 | ----------------- | ---------------------------------------------------- |
 | `electrum server` | `ssl://blockstream.info:700` **(default)**           |
-| `monero daemon`   | `http://node.melo.tools:18081`                       |
+| `monero daemon`   | `http://node.community.rino.io:18081`                       |
 | `monero daemon`   | `http://node.monerooutreach.org:18081` **(default)** |
 
 **Testnet/Stagenet**
@@ -198,7 +198,7 @@ Only blockchain daemons and electrum servers are listed, you should always run y
 | daemon            | value                                            |
 | ----------------- | ------------------------------------------------ |
 | `electrum server` | `ssl://blockstream.info:993` **(default)**       |
-| `monero daemon`   | `http://stagenet.melo.tools:38081` **(default)** |
+| `monero daemon`   | `http://stagenet.community.rino.io:38081` **(default)** |
 
 ### Run a swap locally
 

--- a/compose/farcasterd.toml
+++ b/compose/farcasterd.toml
@@ -1,4 +1,4 @@
 [syncers.testnet]
 electrum_server = "ssl://blockstream.info:993"
-monero_daemon = "http://stagenet.melo.tools:38081"
+monero_daemon = "http://stagenet.community.rino.io:38081"
 monero_rpc_wallet = "http://walletrpc:38083"

--- a/doc/docker-stack.md
+++ b/doc/docker-stack.md
@@ -90,7 +90,7 @@ docker pull ghcr.io/farcaster-project/containers/monero-wallet-rpc:latest
 docker run --rm -p 38083:38083 ghcr.io/farcaster-project/containers/monero-wallet-rpc:latest\
     /usr/bin/monero-wallet-rpc --stagenet\
     --disable-rpc-login --wallet-dir wallets\
-    --daemon-host stagenet.melo.tools:38081\
+    --daemon-host stagenet.community.rino.io:38081\
     --rpc-bind-ip 0.0.0.0 --rpc-bind-port 38083\
     --confirm-external-bind
 ```

--- a/doc/install-guide.md
+++ b/doc/install-guide.md
@@ -92,7 +92,7 @@ services:
   walletrpc:
     image: "ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3"
     container_name: walletrpc
-    command: "/usr/bin/monero-wallet-rpc --stagenet --disable-rpc-login --wallet-dir wallets --daemon-host stagenet.melo.tools:38081 --rpc-bind-ip 0.0.0.0 --rpc-bind-port 38083 --confirm-external-bind"
+    command: "/usr/bin/monero-wallet-rpc --stagenet --disable-rpc-login --wallet-dir wallets --daemon-host stagenet.community.rino.io:38081 --rpc-bind-ip 0.0.0.0 --rpc-bind-port 38083 --confirm-external-bind"
 ```
 
 :mag_right: If you plan to make offer with the Docker stack make sure you understand what ports need to be open and forwarded. You might need to additionally configure your firewall to enable takers to connect.

--- a/doc/local-swap.md
+++ b/doc/local-swap.md
@@ -15,7 +15,7 @@ docker pull ghcr.io/farcaster-project/containers/monero-wallet-rpc:latest
 docker run --rm -p 38083:38083 ghcr.io/farcaster-project/containers/monero-wallet-rpc:latest\
     /usr/bin/monero-wallet-rpc --stagenet\
     --disable-rpc-login --wallet-dir wallets\
-    --daemon-host stagenet.melo.tools:38081\
+    --daemon-host stagenet.community.rino.io:38081\
     --rpc-bind-ip 0.0.0.0 --rpc-bind-port 38083\
     --confirm-external-bind
 ```
@@ -26,7 +26,7 @@ and
 docker run --rm -p 38084:38084 ghcr.io/farcaster-project/containers/monero-wallet-rpc:latest\
     /usr/bin/monero-wallet-rpc --stagenet\
     --disable-rpc-login --wallet-dir wallets\
-    --daemon-host stagenet.melo.tools:38081\
+    --daemon-host stagenet.community.rino.io:38081\
     --rpc-bind-ip 0.0.0.0 --rpc-bind-port 38084\
     --confirm-external-bind
 ```
@@ -40,7 +40,7 @@ We will start two daemons with different data directories (`.node01` and `.node0
 ```toml
 [syncers.testnet]
 electrum_server = "ssl://blockstream.info:993"
-monero_daemon = "http://stagenet.melo.tools:38081"
+monero_daemon = "http://stagenet.community.rino.io:38081"
 monero_rpc_wallet = "http://localhost:{38083|38084}"
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,4 @@ services:
       - "walletrpc"
   walletrpc:
     image: "ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3"
-    command: "/usr/bin/monero-wallet-rpc --stagenet --disable-rpc-login --wallet-dir wallets --daemon-host stagenet.melo.tools:38081 --rpc-bind-ip 0.0.0.0 --rpc-bind-port 38083 --confirm-external-bind"
+    command: "/usr/bin/monero-wallet-rpc --stagenet --disable-rpc-login --wallet-dir wallets --daemon-host stagenet.community.rino.io:38081 --rpc-bind-ip 0.0.0.0 --rpc-bind-port 38083 --confirm-external-bind"

--- a/farcasterd.toml
+++ b/farcasterd.toml
@@ -55,7 +55,7 @@ monero_rpc_wallet = "http://localhost:18083"
 # Electrum Server used by the Bitcoin syncer on testnet
 electrum_server = "ssl://blockstream.info:993"
 # Monero daemon used by the Monero syncer on stagenet
-monero_daemon = "http://stagenet.melo.tools:38081"
+monero_daemon = "http://stagenet.community.rino.io:38081"
 # Monero Wallet RPC used by the Monero syncer on stagenet
 # Point to local running wallet
 monero_rpc_wallet = "http://localhost:38083"

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,7 @@ pub const FARCASTER_MAINNET_MONERO_DAEMON: &str = "http://node.monerooutreach.or
 pub const FARCASTER_MAINNET_MONERO_RPC_WALLET: &str = "http://localhost:18083";
 
 pub const FARCASTER_TESTNET_ELECTRUM_SERVER: &str = "ssl://blockstream.info:993";
-pub const FARCASTER_TESTNET_MONERO_DAEMON: &str = "http://stagenet.melo.tools:38081";
+pub const FARCASTER_TESTNET_MONERO_DAEMON: &str = "http://stagenet.community.rino.io:38081";
 pub const FARCASTER_TESTNET_MONERO_RPC_WALLET: &str = "http://localhost:38083";
 
 #[cfg(feature = "shell")]


### PR DESCRIPTION
Melo.tools is now community.rino.io

Announced in: https://www.reddit.com/r/Monero/comments/w4hhyt/nodemelotools_discontinued_public_remote_node/

Configuration found in: https://community.rino.io/nodes.html