### PR TITLE
Database: Expand to full path for lmdb file location

### DIFF
--- a/src/bin/databased.rs
+++ b/src/bin/databased.rs
@@ -46,7 +46,8 @@ fn main() {
     debug!("CTL RPC socket {}", &service_config.ctl_endpoint);
 
     debug!("Starting runtime ...");
-    databased::run(service_config, opts.shared.data_dir).expect("Error running databased runtime");
+    databased::run(service_config, opts.absolute_data_dir_path())
+        .expect("Error running databased runtime");
 
     unreachable!()
 }

--- a/src/databased/opts.rs
+++ b/src/databased/opts.rs
@@ -38,4 +38,8 @@ impl Opts {
     pub fn process(&mut self) {
         self.shared.process();
     }
+
+    pub fn absolute_data_dir_path(&self) -> PathBuf {
+        PathBuf::from(shellexpand::tilde(&self.shared.data_dir.to_string_lossy()).to_string())
+    }
 }


### PR DESCRIPTION
The rust LMDB crate expects a full path for the location of the database directory.

This fixes an error where if the data_dir has a non-expanded (tilde) path, for example when running the farcaster node after a cargo install, LMDB will not be able to create a database.

Fixes #576 