### PR TITLE
Use `RUST_LOG` to configure loggers instead of `--verbose` flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2.0.0
         with:
-          key: test-${{ matrix.test }}
+          key: ${{ matrix.test }}
 
       - name: Cargo functional test
         run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features --color always -- --ignored --test-threads=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_LOG_STYLE: always
 
 jobs:
   test:
@@ -135,4 +136,4 @@ jobs:
         uses: Swatinem/rust-cache@v2.0.0
 
       - name: Cargo functional test
-        run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features -- --ignored --test-threads=1
+        run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features --color always -- --ignored --test-threads=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUST_LOG: 'info,farcaster_node=debug,microservices=debug'
+      RUST_BACKTRACE: 1
     container:
       image: rust:slim-bullseye
       volumes:
@@ -136,4 +137,4 @@ jobs:
           key: test-${{ matrix.test }}
 
       - name: Cargo functional test
-        run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1
+        run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features -- --ignored --test-threads=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,8 @@ jobs:
           - test: swap_parallel_execution
             logs: true
     runs-on: ubuntu-latest
+    env:
+      RUST_LOG: 'farcaster_node=debug,microservices=debug'
     container:
       image: rust:slim-bullseye
       volumes:
@@ -137,7 +139,7 @@ jobs:
           key: test-${{ matrix.test }}
 
       - name: Cargo functional test
-        run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features --no-fail-fast -- --ignored --nocapture --test-threads=1
+        run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1
 
       - name: Archive farcasterd logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,8 +133,6 @@ jobs:
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2.0.0
-        with:
-          key: test-${{ matrix.test }}
 
       - name: Cargo functional test
         run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features -- --ignored --test-threads=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,9 +70,6 @@ jobs:
           cli,
           # grpc, TODO: re-enable once ipv6 address support has landed
         ]
-        include:
-          - test: swap_parallel_execution
-            logs: true
     runs-on: ubuntu-latest
     env:
       RUST_LOG: 'info,farcaster_node=debug,microservices=debug'
@@ -140,11 +137,3 @@ jobs:
 
       - name: Cargo functional test
         run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1
-
-      - name: Archive farcasterd logs
-        uses: actions/upload-artifact@v3
-        if: ${{ matrix.logs }}
-        with:
-          name: faracsterd-logs
-          path: |
-            tests/*.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,6 +134,8 @@ jobs:
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2.0.0
+        with:
+          key: test-${{ matrix.test }}
 
       - name: Cargo functional test
         run: cargo test ${{ matrix.test }} --workspace --all-targets --all-features --color always -- --ignored --test-threads=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
             logs: true
     runs-on: ubuntu-latest
     env:
-      RUST_LOG: 'farcaster_node=debug,microservices=debug'
+      RUST_LOG: 'info,farcaster_node=debug,microservices=debug'
     container:
       image: rust:slim-bullseye
       volumes:

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ docker run --rm -p 38083:38083 ghcr.io/farcaster-project/containers/monero-walle
 
 #### Launching `farcasterd`
 
-Now that you have a working Monero RPC wallet to connect you can launch the node in verbose mode (`-vv`), and follow the logs to see what's appening.
+Now that you have a working Monero RPC wallet to connect you can launch the node, and follow the logs to see what's appening.
 
 ```
-farcasterd -vv
+farcasterd
 ```
 
 :mag_right: You can find more details below about the [configuration](#configuration) if you need to customize some values.
@@ -146,7 +146,7 @@ So maker must make sure her router allows external connections to that port to h
 
 The make command will output an encoded **public offer** that can be shared with potential takers. As a maker, your `farcasterd` registers this public offer, and waits for someone to connect through `peerd` and take the offer. A taker in her turn takes the offer and initiates a swap with the maker.
 
-Follow your `farcasterd` log (**with a log level set at `-vv`**) and fund the swap with the bitcoins or moneros when the log asks for this. At the end coins are swapped successfully, or - less ideally - refunded. We currently offer no manual cancel functionality. We offer progress through `swap-cli progress {swapid}`. To list the the swapids of the running swaps, use `swap-cli ls`.
+Follow your `farcasterd` logs (**you can fine tune your log with `RUST_LOG` environment variable, e.g. `RUST_LOG="farcaster_node=debug,microservices=debug"`**) and fund the swap with the bitcoins or moneros when the log asks for this. At the end coins are swapped successfully, or - less ideally - refunded. We currently offer no manual cancel functionality. We offer progress through `swap-cli progress {swapid}`. To list the the swapids of the running swaps, use `swap-cli ls`.
 
 ### :moneybag: Take the offer
 
@@ -160,7 +160,7 @@ swap-cli take --btc-addr tb1qmcku4ht3tq53tvdl5hj03rajpdkdatd4w4mswx\
 
 The cli will ask you to validate the offer's specifics (amounts, assets, etc.). You can use the flag of interest `--without-validation` or `-w` for externally validated automated setups.
 
-Then follow your `farcasterd` log (**with a log level set at `-vv`**) and fund the swap with the bitcoins or moneroj when it asks so. At the end of the swap, you should receive the counterparty's assets.
+Then follow your `farcasterd` logs and fund the swap with the bitcoins or moneroj when it asks so. At the end of the swap, you should receive the counterparty's assets.
 
 ### Configuration
 

--- a/doc/docker-stack.md
+++ b/doc/docker-stack.md
@@ -57,7 +57,7 @@ docker run --rm --init -t -p 9735:9735 -p 9981:9981\
     --mount type=bind,source=<config folder>,destination=/etc/farcaster\
     --name farcaster_node\
     ghcr.io/farcaster-project/farcaster-node/farcasterd:latest\
-    -vvv -c /etc/farcaster/farcasterd.toml
+    -c /etc/farcaster/farcasterd.toml
 ```
 
 If you don't use the default values for syncers daemons don't forget to mount your config inside the container (here at `/etc/farcaster`) and pass the config file with `-c /etc/farcaster/farcasterd.toml`.
@@ -125,7 +125,7 @@ The daemon is controlled though ZMQ _ctl_ socket, an internal interface for cont
 To launch `farcasterd` with network binded _control_ (`-x`) bus and _message_ bus (`-m`) instead of `ctl.rpc` and `msg.rpc` files:
 
 ```
-farcasterd -vv -x "lnpz://127.0.0.1:9981/?api=esb" -m "lnpz://127.0.0.1:9982/?api=esb"
+farcasterd -x "lnpz://127.0.0.1:9981/?api=esb" -m "lnpz://127.0.0.1:9982/?api=esb"
 ```
 
 **Client**

--- a/doc/install-guide.md
+++ b/doc/install-guide.md
@@ -86,7 +86,7 @@ services:
     ports:
       - "9735:9735"
       - "9981:9981"
-    command: "-vv -c /var/lib/farcaster/farcasterd.toml"
+    command: "-c /var/lib/farcaster/farcasterd.toml"
     depends_on:
       - "walletrpc"
   walletrpc:

--- a/doc/local-swap.md
+++ b/doc/local-swap.md
@@ -47,7 +47,7 @@ monero_rpc_wallet = "http://localhost:{38083|38084}"
 Then launch two `farcasterd` services:
 
 ```
-farcasterd -vv --data-dir {.node01|.node02}
+farcasterd --data-dir {.node01|.node02}
 ```
 
 You can use other public daemons for syncers, see [:bulb: Use public infrastructure](../README.md#bulb-use-public-infrastructure) for more details.
@@ -122,7 +122,7 @@ monero-wallet-rpc --stagenet --rpc-bind-port 38083\
 Then start the node with:
 
 ```
-farcasterd -vv -c farcasterd.toml
+farcasterd -c farcasterd.toml
 ```
 
 with `farcasterd.toml` configuration file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,9 @@ services:
     ports:
       - "9735:9735"
       - "9981:9981"
-    command: "-vvv -c /var/lib/farcaster/farcasterd.toml"
+    environment:
+      - RUST_LOG: "info"
+    command: "-c /var/lib/farcaster/farcasterd.toml"
     depends_on:
       - "walletrpc"
   walletrpc:

--- a/shell/_farcasterd
+++ b/shell/_farcasterd
@@ -29,8 +29,6 @@ _farcasterd() {
 '--help[Print help information]' \
 '-V[Print version information]' \
 '--version[Print version information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 && ret=0
 }
 

--- a/shell/_farcasterd.ps1
+++ b/shell/_farcasterd.ps1
@@ -35,8 +35,6 @@ Register-ArgumentCompleter -Native -CommandName 'farcasterd' -ScriptBlock {
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
     })

--- a/shell/_peerd
+++ b/shell/_peerd
@@ -37,8 +37,6 @@ _peerd() {
 '--help[Print help information]' \
 '-V[Print version information]' \
 '--version[Print version information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 && ret=0
 }
 

--- a/shell/_peerd.ps1
+++ b/shell/_peerd.ps1
@@ -43,8 +43,6 @@ Register-ArgumentCompleter -Native -CommandName 'peerd' -ScriptBlock {
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
     })

--- a/shell/_swap-cli
+++ b/shell/_swap-cli
@@ -27,8 +27,6 @@ _swap-cli() {
 '--help[Print help information]' \
 '-V[Print version information]' \
 '--version[Print version information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 ":: :_swap-cli_commands" \
 "*::: :->swap-cli" \
 && ret=0
@@ -50,8 +48,6 @@ _arguments "${_arguments_options[@]}" \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 '::subject -- Remote peer address or temporary/permanent/short channel id. If absent, returns information about the node itself:' \
 && ret=0
 ;;
@@ -67,8 +63,6 @@ _arguments "${_arguments_options[@]}" \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 && ret=0
 ;;
 (list-swaps)
@@ -83,8 +77,6 @@ _arguments "${_arguments_options[@]}" \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 && ret=0
 ;;
 (list-offers)
@@ -101,8 +93,6 @@ _arguments "${_arguments_options[@]}" \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 && ret=0
 ;;
 (offer-info)
@@ -117,8 +107,6 @@ _arguments "${_arguments_options[@]}" \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 ':public-offer -- The offer to be canceled:' \
 && ret=0
 ;;
@@ -134,8 +122,6 @@ _arguments "${_arguments_options[@]}" \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 && ret=0
 ;;
 (list-checkpoints)
@@ -150,8 +136,6 @@ _arguments "${_arguments_options[@]}" \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 && ret=0
 ;;
 (restore-checkpoint)
@@ -166,8 +150,6 @@ _arguments "${_arguments_options[@]}" \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 ':swap-id:' \
 && ret=0
 ;;
@@ -203,8 +185,6 @@ _arguments "${_arguments_options[@]}" \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 && ret=0
 ;;
 (take)
@@ -225,8 +205,6 @@ _arguments "${_arguments_options[@]}" \
 '--without-validation[Accept the public offer without validation]' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 && ret=0
 ;;
 (revoke-offer)
@@ -241,8 +219,6 @@ _arguments "${_arguments_options[@]}" \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 ':public-offer -- The offer to be canceled:' \
 && ret=0
 ;;
@@ -258,8 +234,6 @@ _arguments "${_arguments_options[@]}" \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 ':swap-id -- The swap to be aborted:' \
 && ret=0
 ;;
@@ -277,8 +251,6 @@ _arguments "${_arguments_options[@]}" \
 '--follow[Subscribe to progress and only return when progress is finished]' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 ':swapid -- The swap id requested:' \
 && ret=0
 ;;
@@ -294,8 +266,6 @@ _arguments "${_arguments_options[@]}" \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 ':coin -- The coin funding required needs to be checked against:' \
 && ret=0
 ;;
@@ -311,8 +281,6 @@ _arguments "${_arguments_options[@]}" \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 ':source-address -- The source address to be swept:' \
 ':destination-address -- The destination address receiving the coins:' \
 && ret=0
@@ -329,8 +297,6 @@ _arguments "${_arguments_options[@]}" \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '-h[Print help information]' \
 '--help[Print help information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 ':source-address -- The source address to be swept:' \
 ':destination-address -- The destination address receiving the coins:' \
 && ret=0
@@ -345,8 +311,6 @@ _arguments "${_arguments_options[@]}" \
 '--msg-socket=[ZMQ socket name/address to forward all incoming protocol messages]:MSG_SOCKET:_files' \
 '-x+[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
 '--ctl-socket=[ZMQ socket name/address for daemon control interface]:CTL_SOCKET:_files' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 '*::subcommand -- The subcommand whose help message to display:' \
 && ret=0
 ;;

--- a/shell/_swap-cli.ps1
+++ b/shell/_swap-cli.ps1
@@ -33,8 +33,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             [CompletionResult]::new('info', 'info', [CompletionResultType]::ParameterValue, 'General information about the running node')
             [CompletionResult]::new('peers', 'peers', [CompletionResultType]::ParameterValue, 'Lists existing peer connections')
             [CompletionResult]::new('list-swaps', 'list-swaps', [CompletionResultType]::ParameterValue, 'Lists running swaps')
@@ -65,8 +63,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;peers' {
@@ -80,8 +76,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;list-swaps' {
@@ -95,8 +89,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;list-offers' {
@@ -112,8 +104,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;offer-info' {
@@ -127,8 +117,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;list-listens' {
@@ -142,8 +130,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;list-checkpoints' {
@@ -157,8 +143,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;restore-checkpoint' {
@@ -172,8 +156,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;make' {
@@ -207,8 +189,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;take' {
@@ -228,8 +208,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--without-validation', 'without-validation', [CompletionResultType]::ParameterName, 'Accept the public offer without validation')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;revoke-offer' {
@@ -243,8 +221,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;abort-swap' {
@@ -258,8 +234,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;progress' {
@@ -275,8 +249,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--follow', 'follow', [CompletionResultType]::ParameterName, 'Subscribe to progress and only return when progress is finished')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;needs-funding' {
@@ -290,8 +262,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;sweep-bitcoin-address' {
@@ -305,8 +275,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;sweep-monero-address' {
@@ -320,8 +288,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
         'swap-cli;help' {
@@ -333,8 +299,6 @@ Register-ArgumentCompleter -Native -CommandName 'swap-cli' -ScriptBlock {
             [CompletionResult]::new('--msg-socket', 'msg-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address to forward all incoming protocol messages')
             [CompletionResult]::new('-x', 'x', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
             [CompletionResult]::new('--ctl-socket', 'ctl-socket', [CompletionResultType]::ParameterName, 'ZMQ socket name/address for daemon control interface')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
     })

--- a/shell/_swapd
+++ b/shell/_swapd
@@ -27,8 +27,6 @@ _swapd() {
 '--help[Print help information]' \
 '-V[Print version information]' \
 '--version[Print version information]' \
-'*-v[Set verbosity level]' \
-'*--verbose[Set verbosity level]' \
 ':swap-id -- Swap id:' \
 ':public-offer -- Public offer to initiate swapd runtime:' \
 ':trade-role -- Trade role of participant (Maker or Taker):' \

--- a/shell/_swapd.ps1
+++ b/shell/_swapd.ps1
@@ -33,8 +33,6 @@ Register-ArgumentCompleter -Native -CommandName 'swapd' -ScriptBlock {
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
-            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')
-            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'Set verbosity level')
             break
         }
     })

--- a/shell/farcasterd.bash
+++ b/shell/farcasterd.bash
@@ -19,7 +19,7 @@ _farcasterd() {
 
     case "${cmd}" in
         farcasterd)
-            opts="-h -V -d -v -T -m -x -c --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket --config"
+            opts="-h -V -d -T -m -x -c --help --version --data-dir --tor-proxy --msg-socket --ctl-socket --config"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/shell/peerd.bash
+++ b/shell/peerd.bash
@@ -19,7 +19,7 @@ _peerd() {
 
     case "${cmd}" in
         peerd)
-            opts="-h -V -L -C -p -o -d -v -T -m -x --help --version --listen --connect --port --overlay --peer-secret-key --token --data-dir --verbose --tor-proxy --msg-socket --ctl-socket"
+            opts="-h -V -L -C -p -o -d -T -m -x --help --version --listen --connect --port --overlay --peer-secret-key --token --data-dir --tor-proxy --msg-socket --ctl-socket"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/shell/swap-cli.bash
+++ b/shell/swap-cli.bash
@@ -70,7 +70,7 @@ _swap-cli() {
 
     case "${cmd}" in
         swap__cli)
-            opts="-h -V -d -v -T -m -x --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket info peers list-swaps list-offers offer-info list-listens list-checkpoints restore-checkpoint make take revoke-offer abort-swap progress needs-funding sweep-bitcoin-address sweep-monero-address help"
+            opts="-h -V -d -T -m -x --help --version --data-dir --tor-proxy --msg-socket --ctl-socket info peers list-swaps list-offers offer-info list-listens list-checkpoints restore-checkpoint make take revoke-offer abort-swap progress needs-funding sweep-bitcoin-address sweep-monero-address help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -116,7 +116,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__abort__swap)
-            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <SWAP_ID>"
+            opts="-h -d -T -m -x --help --data-dir --tor-proxy --msg-socket --ctl-socket <SWAP_ID>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -162,7 +162,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__help)
-            opts="-d -v -T -m -x --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <SUBCOMMAND>..."
+            opts="-d -T -m -x --data-dir --tor-proxy --msg-socket --ctl-socket <SUBCOMMAND>..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -208,7 +208,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__info)
-            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <SUBJECT>"
+            opts="-h -d -T -m -x --help --data-dir --tor-proxy --msg-socket --ctl-socket <SUBJECT>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -254,7 +254,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__list__checkpoints)
-            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket"
+            opts="-h -d -T -m -x --help --data-dir --tor-proxy --msg-socket --ctl-socket"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -300,7 +300,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__list__listens)
-            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket"
+            opts="-h -d -T -m -x --help --data-dir --tor-proxy --msg-socket --ctl-socket"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -346,7 +346,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__list__offers)
-            opts="-s -h -d -v -T -m -x --select --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket"
+            opts="-s -h -d -T -m -x --select --help --data-dir --tor-proxy --msg-socket --ctl-socket"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -400,7 +400,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__list__swaps)
-            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket"
+            opts="-h -d -T -m -x --help --data-dir --tor-proxy --msg-socket --ctl-socket"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -446,7 +446,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__make)
-            opts="-n -r -I -b -p -h -d -v -T -m -x --btc-addr --xmr-addr --network --arb-blockchain --acc-blockchain --btc-amount --xmr-amount --maker-role --cancel-timelock --punish-timelock --fee-strategy --public-ip-addr --bind-ip-addr --port --overlay --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket"
+            opts="-n -r -I -b -p -h -d -T -m -x --btc-addr --xmr-addr --network --arb-blockchain --acc-blockchain --btc-amount --xmr-amount --maker-role --cancel-timelock --punish-timelock --fee-strategy --public-ip-addr --bind-ip-addr --port --overlay --help --data-dir --tor-proxy --msg-socket --ctl-socket"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -572,7 +572,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__needs__funding)
-            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <COIN>"
+            opts="-h -d -T -m -x --help --data-dir --tor-proxy --msg-socket --ctl-socket <COIN>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -618,7 +618,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__offer__info)
-            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <PUBLIC_OFFER>"
+            opts="-h -d -T -m -x --help --data-dir --tor-proxy --msg-socket --ctl-socket <PUBLIC_OFFER>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -664,7 +664,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__peers)
-            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket"
+            opts="-h -d -T -m -x --help --data-dir --tor-proxy --msg-socket --ctl-socket"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -710,7 +710,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__progress)
-            opts="-f -h -d -v -T -m -x --follow --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <SWAPID>"
+            opts="-f -h -d -T -m -x --follow --help --data-dir --tor-proxy --msg-socket --ctl-socket <SWAPID>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -756,7 +756,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__restore__checkpoint)
-            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <SWAP_ID>"
+            opts="-h -d -T -m -x --help --data-dir --tor-proxy --msg-socket --ctl-socket <SWAP_ID>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -802,7 +802,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__revoke__offer)
-            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <PUBLIC_OFFER>"
+            opts="-h -d -T -m -x --help --data-dir --tor-proxy --msg-socket --ctl-socket <PUBLIC_OFFER>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -848,7 +848,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__sweep__bitcoin__address)
-            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <SOURCE_ADDRESS> <DESTINATION_ADDRESS>"
+            opts="-h -d -T -m -x --help --data-dir --tor-proxy --msg-socket --ctl-socket <SOURCE_ADDRESS> <DESTINATION_ADDRESS>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -894,7 +894,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__sweep__monero__address)
-            opts="-h -d -v -T -m -x --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <SOURCE_ADDRESS> <DESTINATION_ADDRESS>"
+            opts="-h -d -T -m -x --help --data-dir --tor-proxy --msg-socket --ctl-socket <SOURCE_ADDRESS> <DESTINATION_ADDRESS>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -940,7 +940,7 @@ _swap-cli() {
             return 0
             ;;
         swap__cli__take)
-            opts="-o -w -h -d -v -T -m -x --btc-addr --xmr-addr --offer --without-validation --help --data-dir --verbose --tor-proxy --msg-socket --ctl-socket"
+            opts="-o -w -h -d -T -m -x --btc-addr --xmr-addr --offer --without-validation --help --data-dir --tor-proxy --msg-socket --ctl-socket"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/shell/swapd.bash
+++ b/shell/swapd.bash
@@ -19,7 +19,7 @@ _swapd() {
 
     case "${cmd}" in
         swapd)
-            opts="-h -V -d -v -T -m -x --help --version --data-dir --verbose --tor-proxy --msg-socket --ctl-socket <SWAP_ID> <PUBLIC_OFFER> <TRADE_ROLE>"
+            opts="-h -V -d -T -m -x --help --version --data-dir --tor-proxy --msg-socket --ctl-socket <SWAP_ID> <PUBLIC_OFFER> <TRADE_ROLE>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -2191,15 +2191,6 @@ pub fn launch(
     // Cannot use value_of directly because of default values
     let matches = app.get_matches();
 
-    // Set verbosity to same level
-    let verbose = matches.occurrences_of("verbose");
-    if verbose > 0 {
-        cmd.args(&[&format!(
-            "-{}",
-            (0..verbose).map(|_| "v").collect::<String>()
-        )]);
-    }
-
     if let Some(d) = &matches.value_of("data-dir") {
         cmd.args(&["-d", d]);
     }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -122,13 +122,7 @@ impl FromStr for TokenString {
 impl Opts {
     pub fn process(&mut self) {
         let env = env_logger::Env::new().default_filter_or("farcaster_node=info");
-        // standard environment variable set to "true" when running in CI environments
-        let is_test = match std::env::var("CI") {
-            Ok(v) if v == "true" => true,
-            _ => false,
-        };
         env_logger::from_env(env)
-            .is_test(is_test)
             .try_init()
             .expect("Failed to initialize loggger!");
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -127,7 +127,10 @@ impl Opts {
             Ok(v) if v == "true" => true,
             _ => false,
         };
-        env_logger::from_env(env).is_test(is_test).try_init().expect("Failed to initialize loggger!");
+        env_logger::from_env(env)
+            .is_test(is_test)
+            .try_init()
+            .expect("Failed to initialize loggger!");
 
         let mut me = self.clone();
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -122,7 +122,13 @@ impl FromStr for TokenString {
 impl Opts {
     pub fn process(&mut self) {
         let env = env_logger::Env::new().default_filter_or("farcaster_node=info");
+        // standard environment variable set to "true" when running in CI environments
+        let is_test = match std::env::var("CI") {
+            Ok(v) if v == "true" => true,
+            _ => false,
+        };
         env_logger::from_env(env)
+            .is_test(is_test)
             .try_init()
             .expect("Failed to initialize loggger!");
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -19,7 +19,6 @@ use std::str::FromStr;
 use std::{fs, io};
 
 use internet2::PartialNodeAddr;
-use microservices::shell::LogLevel;
 
 #[cfg(any(target_os = "linux"))]
 pub const FARCASTER_DATA_DIR: &str = "~/.farcaster";
@@ -56,12 +55,6 @@ pub struct Opts {
         value_hint = ValueHint::DirPath
     )]
     pub data_dir: PathBuf,
-
-    /// Set verbosity level
-    ///
-    /// Can be used multiple times to increase verbosity.
-    #[clap(short, long, global = true, parse(from_occurrences))]
-    pub verbose: u8,
 
     /// Use Tor
     ///
@@ -128,7 +121,14 @@ impl FromStr for TokenString {
 
 impl Opts {
     pub fn process(&mut self) {
-        LogLevel::from_verbosity_flag_count(self.verbose).apply();
+        let env = env_logger::Env::new().default_filter_or("farcaster_node=info");
+        // standard environment variable set to "true" when running in CI environments
+        let is_test = match std::env::var("CI") {
+            Ok(v) if v == "true" => true,
+            _ => false,
+        };
+        env_logger::from_env(env).is_test(is_test).try_init().expect("Failed to initialize loggger!");
+
         let mut me = self.clone();
 
         me.data_dir = PathBuf::from(shellexpand::tilde(&me.data_dir.to_string_lossy()).to_string());

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,7 +10,7 @@ docker-compose up -d
 Place your specific test name after `cargo test`, the following command runs all tests:
 
 ```
-RUST_LOG="farcaster_node=debug,microservices=debug" cargo test --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1
+RUST_BACKTRACE=1 RUST_LOG="farcaster_node=debug,microservices=debug" cargo test --workspace --all-targets --all-features -- --ignored --test-threads=1
 ```
 
 Stop the tests and remove the volume:

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,7 +10,7 @@ docker-compose up -d
 Place your specific test name after `cargo test`, the following command runs all tests:
 
 ```
-cargo test --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1
+RUST_LOG="farcaster_node=debug,microservices=debug" cargo test --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1
 ```
 
 Stop the tests and remove the volume:
@@ -21,7 +21,7 @@ docker-compose down -v
 
 ## Steps
 
-By default the functional tests are not run when executing `cargo test`. To run them, run `cargo test --workspace --all-targets --all-features --no-fail-fast -- --ignored --test-threads=1`.
+By default the functional tests are not run when executing `cargo test` because of the `#[ignore]` directive. To run them, see the above cargo test command with `-- --ignored`.
 
 Before running the functional tests, start the docker containers first with `docker-compose up -d`.
 

--- a/tests/utils/fc.rs
+++ b/tests/utils/fc.rs
@@ -21,12 +21,12 @@ pub async fn setup_clients() -> (process::Child, Vec<String>, process::Child, Ve
     let farcasterd_maker_args = farcasterd_args(
         data_dir_maker.clone(),
         vec!["--config", &format!("tests/cfg/fc1{}", ext)],
-        vec!["2>&1", "|", "tee", "-a", "tests/fc1.log"],
+        vec![],
     );
     let farcasterd_taker_args = farcasterd_args(
         data_dir_taker.clone(),
         vec!["--config", &format!("tests/cfg/fc2{}", ext)],
-        vec!["2>&1", "|", "tee", "-a", "tests/fc2.log"],
+        vec![],
     );
 
     let farcasterd_maker = launch("../farcasterd", farcasterd_maker_args).unwrap();

--- a/tests/utils/fc.rs
+++ b/tests/utils/fc.rs
@@ -20,12 +20,12 @@ pub async fn setup_clients() -> (process::Child, Vec<String>, process::Child, Ve
 
     let farcasterd_maker_args = farcasterd_args(
         data_dir_maker.clone(),
-        vec!["-vvv", "--config", &format!("tests/cfg/fc1{}", ext)],
+        vec!["--config", &format!("tests/cfg/fc1{}", ext)],
         vec!["2>&1", "|", "tee", "-a", "tests/fc1.log"],
     );
     let farcasterd_taker_args = farcasterd_args(
         data_dir_taker.clone(),
-        vec!["-vvv", "--config", &format!("tests/cfg/fc2{}", ext)],
+        vec!["--config", &format!("tests/cfg/fc2{}", ext)],
         vec!["2>&1", "|", "tee", "-a", "tests/fc2.log"],
     );
 

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -10,5 +10,5 @@ pub mod misc;
 pub fn setup_logging() {
     // !!! Configure RUST_LOG in CI to change this value !!!
     let env = env_logger::Env::new().default_filter_or("farcaster_node=debug");
-    let _ = env_logger::from_env(env).is_test(true).try_init();
+    env_logger::from_env(env).is_test(true).try_init().expect("Failed to initialize loggger!");
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -9,9 +9,10 @@ pub mod misc;
 
 pub fn setup_logging() {
     // !!! Configure RUST_LOG in CI to change this value !!!
-    let env = env_logger::Env::new().default_filter_or("farcaster_node=debug");
-    env_logger::from_env(env)
-        .is_test(true)
-        .try_init()
-        .expect("Failed to initialize loggger!");
+    // set default level to info, debug for node
+    // info level is for bitcoin and monero that correspond to `tests/{bitcoin.rs,monero.rs}`
+    let env = env_logger::Env::new().default_filter_or("info,farcaster_node=debug");
+    // try init the logger, this fails if logger has been already initialized
+    // and it happens when multiple tests are called as the (test)binary is not restarted
+    let _ = env_logger::from_env(env).is_test(true).try_init();
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -14,5 +14,5 @@ pub fn setup_logging() {
     let env = env_logger::Env::new().default_filter_or("info,farcaster_node=debug");
     // try init the logger, this fails if logger has been already initialized
     // and it happens when multiple tests are called as the (test)binary is not restarted
-    let _ = env_logger::from_env(env).is_test(true).try_init();
+    let _ = env_logger::from_env(env).try_init();
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -14,5 +14,5 @@ pub fn setup_logging() {
     let env = env_logger::Env::new().default_filter_or("info,farcaster_node=debug");
     // try init the logger, this fails if logger has been already initialized
     // and it happens when multiple tests are called as the (test)binary is not restarted
-    let _ = env_logger::from_env(env).try_init();
+    let _ = env_logger::from_env(env).is_test(true).try_init();
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -10,5 +10,8 @@ pub mod misc;
 pub fn setup_logging() {
     // !!! Configure RUST_LOG in CI to change this value !!!
     let env = env_logger::Env::new().default_filter_or("farcaster_node=debug");
-    env_logger::from_env(env).is_test(true).try_init().expect("Failed to initialize loggger!");
+    env_logger::from_env(env)
+        .is_test(true)
+        .try_init()
+        .expect("Failed to initialize loggger!");
 }


### PR DESCRIPTION
To allow more granular settings in logger this PR switch from using one flag `--verbose` and instead make use of the `RUST_LOG` environment variable.

By default, if the env var is not set, the default is `farcaster_node=info`. This will display all info logs ONLY coming from farcaster node. In test the var is set to `farcaster_node=debug,microservices=debug`.