### PR TITLE
Checkpointing: Remove multipart message chunking

### DIFF
--- a/src/databased/mod.rs
+++ b/src/databased/mod.rs
@@ -18,6 +18,5 @@ mod runtime;
 
 #[cfg(feature = "shell")]
 pub use opts::Opts;
-pub use runtime::checkpoint_handle_multipart_receive;
 pub use runtime::checkpoint_send;
 pub use runtime::run;

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -13,7 +13,6 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-use crate::databased::checkpoint_handle_multipart_receive;
 use crate::databased::checkpoint_send;
 use crate::service::Endpoints;
 use crate::syncerd::bitcoin_syncer::p2wpkh_signed_tx_fee;
@@ -88,10 +87,7 @@ use internet2::{
 };
 use microservices::esb::{self, Handler};
 use monero::{cryptonote::hash::keccak_256, PrivateKey, ViewPair};
-use request::{
-    Checkpoint, CheckpointChunk, CheckpointMultipartChunk, CheckpointState, Commit, InitSwap,
-    Params, Reveal, TakeCommit, Tx,
-};
+use request::{Checkpoint, CheckpointState, Commit, InitSwap, Params, Reveal, TakeCommit, Tx};
 use std::net::SocketAddr;
 use strict_encoding::{StrictDecode, StrictEncode};
 
@@ -189,7 +185,6 @@ pub fn run(
         )?),
         pending_requests: none!(),
         pending_peer_request: none!(),
-        pending_checkpoint_chunks: map![],
         txs: none!(),
         public_offer,
     };
@@ -211,7 +206,6 @@ pub struct Runtime {
     temporal_safety: TemporalSafety,
     pending_requests: PendingRequests,
     pending_peer_request: Vec<request::Msg>, // Peer requests that failed and are waiting for reconnection
-    pending_checkpoint_chunks: HashMap<[u8; 20], HashSet<CheckpointChunk>>,
     txs: HashMap<TxLabel, bitcoin::Transaction>,
     #[allow(dead_code)]
     storage: Box<dyn storage::Driver>,
@@ -2365,15 +2359,6 @@ impl Runtime {
                     self.send_peer(endpoints, msg.clone())?;
                 }
                 self.pending_peer_request.clear();
-            }
-
-            Request::CheckpointMultipartChunk(checkpoint_multipart_chunk) => {
-                if let Some(checkpoint_request) = checkpoint_handle_multipart_receive(
-                    checkpoint_multipart_chunk,
-                    &mut self.pending_checkpoint_chunks,
-                )? {
-                    self.handle_rpc_ctl(endpoints, source, checkpoint_request)?;
-                }
             }
 
             Request::Checkpoint(request::Checkpoint { swap_id, state }) => match state {

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -1,10 +1,9 @@
-use crate::databased::checkpoint_handle_multipart_receive;
 use crate::databased::checkpoint_send;
 use crate::service::Endpoints;
 use crate::syncerd::SweepBitcoinAddress;
 use lmdb::{Cursor, Transaction as LMDBTransaction};
 use monero::consensus::{Decodable as MoneroDecodable, Encodable as MoneroEncodable};
-use request::{Checkpoint, CheckpointMultipartChunk};
+use request::Checkpoint;
 use std::path::PathBuf;
 use std::{
     any::Any,
@@ -70,7 +69,7 @@ use farcaster_core::{
 };
 use internet2::{addr::LocalNode, TypedEnum};
 use microservices::esb::{self, Handler};
-use request::{CheckpointChunk, CheckpointState, LaunchSwap, NodeId};
+use request::{CheckpointState, LaunchSwap, NodeId};
 
 pub fn run(
     config: ServiceConfig,
@@ -85,7 +84,6 @@ pub fn run(
         swaps: none!(),
         btc_addrs: none!(),
         xmr_addrs: none!(),
-        pending_checkpoint_chunks: map![],
     };
 
     Service::run(config, runtime, false)
@@ -99,7 +97,6 @@ pub struct Runtime {
     swaps: HashMap<SwapId, Option<Request>>,
     btc_addrs: HashMap<SwapId, bitcoin::Address>,
     xmr_addrs: HashMap<SwapId, monero::Address>,
-    pending_checkpoint_chunks: HashMap<[u8; 20], HashSet<CheckpointChunk>>,
 }
 
 impl Runtime {
@@ -1708,15 +1705,6 @@ impl Runtime {
                     &swap_id.bright_blue_italic(),
                 );
                 self.clean_up_after_swap(&swap_id);
-            }
-
-            Request::CheckpointMultipartChunk(checkpoint_multipart_chunk) => {
-                if let Some(checkpoint_request) = checkpoint_handle_multipart_receive(
-                    checkpoint_multipart_chunk,
-                    &mut self.pending_checkpoint_chunks,
-                )? {
-                    self.handle_rpc_ctl(endpoints, source, checkpoint_request)?;
-                }
             }
 
             Request::Checkpoint(request::Checkpoint { swap_id, state }) => {


### PR DESCRIPTION
We now have unlimited size zmq messages, so remove the checkpoint multipart chunking. :tada: :smile: 