### PR TITLE
Farcasterd: Improve report

### DIFF
--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -1889,6 +1889,10 @@ impl Runtime {
 
         for (i, (respond_to, resp)) in report_to.clone().into_iter().enumerate() {
             if let Some(respond_to) = respond_to {
+                // do not respond to self
+                if respond_to == self.identity() {
+                    continue;
+                }
                 trace!(
                     "(#{}) Respond to {}: {}",
                     i,

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -665,13 +665,6 @@ impl Runtime {
                              Requesting swapd to be the maker of this swap",
                         source
                     );
-                    report_to.push((
-                        swap_params.report_to.clone(), // walletd
-                        Request::Progress(request::Progress::Message(format!(
-                            "Swap daemon {} operational",
-                            source
-                        ))),
-                    ));
                     // notify this swapd about its syncers that are up and
                     // running. if syncer not ready, then swapd will be notified
                     // on the ServiceId::Syncer(blockchain, network) Hello pattern. in
@@ -708,13 +701,6 @@ impl Runtime {
                              Requesting swapd to be the taker of this swap",
                         source
                     );
-                    report_to.push((
-                        swap_params.report_to.clone(), // walletd
-                        Request::Progress(request::Progress::Message(format!(
-                            "Swap daemon {} operational",
-                            source
-                        ))),
-                    ));
                     let init_swap_req = Request::TakeSwap(swap_params.clone());
                     if self.syncers.pair_ready(
                         (Blockchain::Bitcoin, *network),
@@ -744,10 +730,6 @@ impl Runtime {
                          connection by a request from {}",
                         source, enquirer
                     );
-                    report_to.push((
-                        Some(enquirer.clone()),
-                        Request::Success(OptionDetails::with(format!("Connected to {}", source))),
-                    ));
                     self.spawning_services.remove(&source);
                 }
             }


### PR DESCRIPTION
Removes reports that were never read by the client. This removes a spurious esb error message for the taker.

Never report to self, which removes esb error reporting farcasterd sending to itself.