### PR TITLE
ci: filter by paths to reduce actions triggered

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -3,8 +3,16 @@ name: Build binaries
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/**.rs'
+      - 'build.rs'
+      - 'Cargo.*'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**.rs'
+      - 'build.rs'
+      - 'Cargo.*'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,8 +3,18 @@ name: Create packages
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/**.rs'
+      - 'build.rs'
+      - 'Cargo.*'
+      - 'Dockerfile'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**.rs'
+      - 'build.rs'
+      - 'Cargo.*'
+      - 'Dockerfile'
 
 jobs:
   faracsterd_container:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,8 +3,16 @@ name: Static Analysis
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/**.rs'
+      - 'build.rs'
+      - 'Cargo.*'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**.rs'
+      - 'build.rs'
+      - 'Cargo.*'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,24 @@ name: Tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'doc/**'
+      - '.*'
+      - '**.md'
+      - '*.nix'
+      - '*.yml'
+      - '*.json'
+      - 'LICENSE'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'doc/**'
+      - '.*'
+      - '**.md'
+      - '*.nix'
+      - '*.yml'
+      - '*.json'
+      - 'LICENSE'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This tries to reduce the number of actions triggered in PRs and in main.

E.g. do not run the full tests if only markdown files are touched.