### PR TITLE
fix: pin lws version to match 0.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
           MONERO_DAEMON_ADDRESS: monerod:18081
           WALLET_RPC_PORT: 18083
       monero-lws:
-        image: ghcr.io/farcaster-project/containers/monero-lws:latest
+        image: ghcr.io/farcaster-project/containers/monero-lws:monerod-0.17.3.2
         env:
           NETWORK: main
           MONERO_DAEMON_ADDRESS: monerod:18082


### PR DESCRIPTION
As mentioned on IRC lws `latest` tag points to 0.18 which does not work yet, this should fix the CI so we can still validate other PRs until latest versions are stabilized.