### PR TITLE
Syncer: Remove BtcAddressAddendum script pubkey field

### DIFF
--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -603,9 +603,7 @@ impl Runtime {
                         .expect("address available at CommitB");
                     let txlabel = TxLabel::Funding;
                     if !self.syncer_state.is_watched_addr(&txlabel) {
-                        let task = self
-                            .syncer_state
-                            .watch_addr_btc(addr.script_pubkey(), txlabel);
+                        let task = self.syncer_state.watch_addr_btc(addr, txlabel);
                         self.send_ctl(
                             endpoints,
                             self.syncer_state.bitcoin_syncer(),
@@ -746,9 +744,7 @@ impl Runtime {
                     if let Some(addr) = self.state.b_address().cloned() {
                         let txlabel = TxLabel::Funding;
                         if !self.syncer_state.is_watched_addr(&txlabel) {
-                            let watch_addr_task = self
-                                .syncer_state
-                                .watch_addr_btc(addr.script_pubkey(), txlabel);
+                            let watch_addr_task = self.syncer_state.watch_addr_btc(addr, txlabel);
                             self.send_ctl(
                                 endpoints,
                                 self.syncer_state.bitcoin_syncer(),

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -172,20 +172,19 @@ impl SyncerState {
         self.tasks.tasks.insert(id, task.clone());
         task
     }
-    pub fn watch_addr_btc(&mut self, script_pubkey: Script, tx_label: TxLabel) -> Task {
+    pub fn watch_addr_btc(&mut self, address: bitcoin::Address, tx_label: TxLabel) -> Task {
         let id = self.tasks.new_taskid();
         let from_height = self.from_height(Blockchain::Bitcoin, 6);
         self.tasks.watched_addrs.insert(id, tx_label);
         info!(
-            "{} | Watching {} transaction with scriptPubkey: {}",
+            "{} | Watching address {} for {} transaction",
             self.swap_id.bright_blue_italic(),
+            address.bright_blue_italic(),
             tx_label.bright_white_bold(),
-            script_pubkey.asm().bright_blue_italic()
         );
         let addendum = BtcAddressAddendum {
-            address: None,
             from_height,
-            script_pubkey,
+            address,
         };
         let task = Task::WatchAddress(WatchAddress {
             id,

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -908,9 +908,8 @@ async fn syncer_state_addresses() {
     let mut state = SyncerState::new(event_tx.clone(), Blockchain::Bitcoin);
     let address = bitcoin::Address::from_str("32BkaQeAVcd65Vn7pjEziohf5bCiryNQov").unwrap();
     let addendum = AddressAddendum::Bitcoin(BtcAddressAddendum {
-        address: Some(address.clone()),
         from_height: 0,
-        script_pubkey: address.script_pubkey(),
+        address,
     });
     let address_task = WatchAddress {
         id: TaskId(0),

--- a/src/syncerd/types.rs
+++ b/src/syncerd/types.rs
@@ -20,12 +20,10 @@ pub enum AddressAddendum {
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
 #[display(Debug)]
 pub struct BtcAddressAddendum {
-    /// The address the syncer will watch and query.
-    pub address: Option<bitcoin::Address>,
     /// The blockchain height where to start the query (not inclusive).
     pub from_height: u64,
-    /// The associated script pubkey used by server like Electrum.
-    pub script_pubkey: bitcoin::Script,
+    /// The address to be watched.
+    pub address: bitcoin::Address,
 }
 
 #[derive(Clone, Debug, Display, Eq, PartialEq, Hash, StrictEncode, StrictDecode)]

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -248,14 +248,12 @@ fn bitcoin_syncer_address_test(polling: bool) {
     let address2 = bitcoin_rpc.get_new_address(None, None).unwrap();
 
     let addendum_1 = AddressAddendum::Bitcoin(BtcAddressAddendum {
-        address: Some(address1.clone()),
         from_height: 0,
-        script_pubkey: address1.script_pubkey(),
+        address: address1.clone(),
     });
     let addendum_2 = AddressAddendum::Bitcoin(BtcAddressAddendum {
-        address: Some(address2.clone()),
         from_height: 0,
-        script_pubkey: address2.script_pubkey(),
+        address: address2.clone(),
     });
     let watch_address_task_1 = SyncerdTask {
         task: Task::WatchAddress(WatchAddress {
@@ -362,9 +360,8 @@ fn bitcoin_syncer_address_test(polling: bool) {
 
     let address4 = bitcoin_rpc.get_new_address(None, None).unwrap();
     let addendum_4 = AddressAddendum::Bitcoin(BtcAddressAddendum {
-        address: Some(address4.clone()),
         from_height: 0,
-        script_pubkey: address4.script_pubkey(),
+        address: address4.clone(),
     });
     for i in 0..5 {
         tx.send(SyncerdTask {
@@ -398,9 +395,8 @@ fn bitcoin_syncer_address_test(polling: bool) {
     let blocks = bitcoin_rpc.get_block_count().unwrap();
 
     let addendum_5 = AddressAddendum::Bitcoin(BtcAddressAddendum {
-        address: Some(address5.clone()),
         from_height: blocks,
-        script_pubkey: address5.script_pubkey(),
+        address: address5.clone(),
     });
     tx.send(SyncerdTask {
         task: Task::WatchAddress(WatchAddress {


### PR DESCRIPTION
Un-nests the address in the BtcAddressAddendum from its Option. This reduces the code complexity a bit and allowed us to get rid of another unwrap.