### PR TITLE
Add Support for electrum client Tor proxy

### DIFF
--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -2210,14 +2210,9 @@ pub fn launch(
 
     // Forward tor proxy argument
     let parsed = Opts::parse();
-    match &parsed.shared.tor_proxy {
-        Some(None) => {
-            cmd.args(&["-T"]);
-        }
-        Some(Some(val)) => {
-            cmd.args(&["-T", &format!("{}", val)]);
-        }
-        _ => (),
+    info!("tor opts: {:?}", parsed.shared.tor_proxy);
+    if let Some(t) = &matches.value_of("tor-proxy") {
+        cmd.args(&["-T", &format!("{}", t)]);
     }
 
     // Given specialized args in launch

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -36,7 +36,6 @@ pub const FARCASTER_DATA_DIR: &str = ".";
 pub const FARCASTER_MSG_SOCKET_NAME: &str = "{data_dir}/msg";
 pub const FARCASTER_CTL_SOCKET_NAME: &str = "{data_dir}/ctl";
 
-pub const FARCASTER_TOR_PROXY: &str = "127.0.0.1:9050";
 pub const FARCASTER_KEY_FILE: &str = "{data_dir}/key.dat";
 
 /// Shared options used by different binaries
@@ -58,19 +57,18 @@ pub struct Opts {
 
     /// Use Tor
     ///
-    /// If set, specifies SOCKS5 proxy used for Tor connectivity and directs
-    /// all network traffic through Tor network.
-    /// If the argument is provided in form of flag, without value, uses
-    /// `127.0.0.1:9050` as default Tor proxy address.
+    /// If set, specifies SOCKS5 proxy used for Tor connectivity and directs all
+    /// network traffic through Tor network. On most systems this is
+    /// 127.0.0.1:9050 by default.
     #[clap(
         short = 'T',
         long,
         alias = "tor",
         global = true,
         env = "FARCASTER_TOR_PROXY",
-        value_hint = ValueHint::Hostname
+        value_hint = ValueHint::Hostname,
     )]
-    pub tor_proxy: Option<Option<SocketAddr>>,
+    pub tor_proxy: Option<SocketAddr>,
 
     /// ZMQ socket name/address to forward all incoming protocol messages
     ///


### PR DESCRIPTION
This adds support to route the traffic of the electrum client through a Tor proxy.

To simplify the argument parsing and retain compatibility with positional arugments, the default flag value for the socks proxy was
removed. However, this functionality was never properly implemented in the first place. The socks proxy address always had to be passed in additionally, the default value was never used.