### PR TITLE
fix(nix): fix git revision and format file according to statix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,21 +1,19 @@
 let
-  pkgs = import (builtins.fetchGit {
-    # Descriptive name to make the store path easier to identify
-    name = "nixos-release-22.05";
-    url = "https://github.com/nixos/nixpkgs/";
-    # Commit hash for nixos-unstable as of 2018-09-12
-    # `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
-    ref = "refs/heads/release-22.05";
-    rev = "cbaacfb8dfa2ddadfb152fa8ef163b40db9041af";
-  })
-  # pkgs = import (<nixos>) # or comment pkgs above and uncomment this
+  pkgs = import
+    (builtins.fetchGit {
+      name = "nixos-release-22.05";
+      url = "https://github.com/nixos/nixpkgs/";
+      ref = "refs/heads/release-22.05";
+      rev = "6ddd2d34e3701339eb01bbf1259b258adcc6156c";
+    })
     {
       overlays = [
         (import (builtins.fetchTarball
           "https://github.com/oxalica/rust-overlay/archive/master.tar.gz"))
       ];
     };
-in pkgs.mkShell {
+in
+pkgs.mkShell {
   buildInputs = with pkgs; [
     cargo
     cargo-watch


### PR DESCRIPTION
Also, removed some unnecessary comments.

Note 1: statix url is https://github.com/nerdypepper/statix

Note 2: `cargo-watch` is not building in Mac; this is a known issue (see https://github.com/NixOS/nixpkgs/issues/146349 and https://github.com/h4llow3En/mac-notification-sys/issues/28)


