### PR TITLE
Syncers: Add better controls to task receiver loop

### DIFF
--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -654,8 +654,11 @@ async fn run_syncerd_task_receiver(
                                 .expect("terminating, don't care if we panic");
                         }
                     }
+                    continue;
                 }
-                Err(std::sync::mpsc::TryRecvError::Disconnected) => return,
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    panic!("Task receiver is disconnected, will exit synclet runtime")
+                }
                 Err(TryRecvError::Empty) => {
                     // do nothing
                 }

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -462,8 +462,11 @@ async fn run_syncerd_task_receiver(
                             debug!("unimplemented");
                         }
                     }
+                    continue;
                 }
-                Err(std::sync::mpsc::TryRecvError::Disconnected) => return,
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    panic!("Task receiver is disconnected, will exit synclet runtime")
+                }
                 Err(TryRecvError::Empty) => {
                     // do nothing
                 }


### PR DESCRIPTION
Make the loop panic and thus the runtime return if the receiver cannot receive anymore.

Add a continue statement to empty the event queue before sleeping on the loop.