### PR TITLE
Swapd: Update peer service id on reconnect if it has not been set yet

### DIFF
--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -571,7 +571,7 @@ impl Runtime {
                                     ServiceBus::Ctl,
                                     self.identity(),
                                     swap_service_id,
-                                    Request::PeerdReconnected,
+                                    Request::PeerdReconnected(source.clone()),
                                 )?;
                             }
                         } else {

--- a/src/rpc/request.rs
+++ b/src/rpc/request.rs
@@ -357,8 +357,8 @@ pub enum Request {
     ReconnectPeer(ReconnectPeer),
 
     #[api(type = 8)]
-    #[display("peerd_reconnected()")]
-    PeerdReconnected,
+    #[display("peerd_reconnected({0})")]
+    PeerdReconnected(ServiceId),
 
     #[api(type = 32)]
     #[display("node_id({0})")]

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -481,7 +481,7 @@ impl Runtime {
         if let Err(error) = endpoints.send_to(
             ServiceBus::Msg,
             self.identity(),
-            self.peer_service.clone(), // = ServiceId::Loopback
+            self.peer_service.clone(), // ServiceId::Loopback if not initiailized
             Request::Protocol(msg.clone()),
         ) {
             error!(
@@ -2356,7 +2356,13 @@ impl Runtime {
                 self.send_ctl(endpoints, source, Request::SwapInfo(info))?;
             }
 
-            Request::PeerdReconnected => {
+            Request::PeerdReconnected(service_id) => {
+                // set the reconnected service id, if it is not set yet. This
+                // can happen if this is a maker launched swap after restoration
+                // and the taker reconnects
+                if self.peer_service == ServiceId::Loopback {
+                    self.peer_service = service_id;
+                }
                 for msg in self.pending_peer_request.clone().iter() {
                     self.send_peer(endpoints, msg.clone())?;
                 }


### PR DESCRIPTION
This can happen if a maker created swap is restored from a checkpoint and the taker attempts a reconnect.

Hopefully fixes https://github.com/farcaster-project/farcaster-node/issues/674