### PR TITLE
electrs failures: reattempt `script_get_history(...)`

### DIFF
--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -229,7 +229,7 @@ impl ElectrumRpc {
                                     break;
                                 }
                                 warn!("{:?} should be found in the history if we successfully queried `transaction_get` - reattempting {:?}", &tx_id, attempts);
-                                std::thread::sleep(Duration::from_secs_f32(0.5 * attempts));
+                                std::thread::sleep(Duration::from_secs_f32(0.5 * attempts as f32));
                             }
                             Err(err) => {
                                 trace!(

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -235,6 +235,9 @@ impl ElectrumRpc {
                         }
                     };
 
+                    debug!("tx.outputs: {:?} {:?}", &tx.output.len(), &tx.output);
+                    debug!("history for transaction {:?}: {:?}", &tx_id, history);
+
                     let entry = history.iter().find(|history_res| {
                         history_res.tx_hash == tx_id
                     }).expect("Should be found in the history if we successfully queried `transaction_get`");

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -228,7 +228,7 @@ impl ElectrumRpc {
                                 if entry_option.is_some() {
                                     break;
                                 }
-                                debug!("{:?} should be found in the history if we successfully queried `transaction_get` - reattempting {:?}", &tx_id, attempts);
+                                warn!("{:?} should be found in the history if we successfully queried `transaction_get` - reattempting {:?}", &tx_id, attempts);
                                 std::thread::sleep(Duration::from_secs_f32(0.5 * attempts));
                             }
                             Err(err) => {

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -215,7 +215,7 @@ impl ElectrumRpc {
                     // to be used multiple times, so more efficient?!)
                     let mut entry_option = None;
                     let mut history: Vec<electrum_client::GetHistoryRes> = vec![];
-                    for attempts in 0..30 {
+                    for attempts in 0..200 {
                         match self.client.script_get_history(&tx.output[0].script_pubkey) {
                             Ok(history_res) => {
                                 debug!("tx.outputs: {:?} {:?}", &tx.output.len(), &tx.output);
@@ -228,8 +228,8 @@ impl ElectrumRpc {
                                 if entry_option.is_some() {
                                     break;
                                 }
-                                debug!("Should be found in the history if we successfully queried `transaction_get` - reattempting {:?}", attempts);
-                                std::thread::sleep(Duration::from_secs_f32(30.0));
+                                debug!("{:?} should be found in the history if we successfully queried `transaction_get` - reattempting {:?}", &tx_id, attempts);
+                                std::thread::sleep(Duration::from_secs_f32(0.5 * attempts));
                             }
                             Err(err) => {
                                 trace!(

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -222,11 +222,15 @@ impl ElectrumRpc {
                                 debug!("history for transaction {:?}: {:?}", &tx_id, history_res);
 
                                 history = history_res;
-                                entry_option = history.iter().find(|history_entry| {history_entry.tx_hash == tx_id});
-                                if entry_option.is_some() {break}
-                                debug!("Should be found in the history if we successfully queried `transaction_get` - reattempting");
+                                entry_option = history
+                                    .iter()
+                                    .find(|history_entry| history_entry.tx_hash == tx_id);
+                                if entry_option.is_some() {
+                                    break;
+                                }
+                                debug!("Should be found in the history if we successfully queried `transaction_get` - reattempting {:?}", attempts);
                                 std::thread::sleep(Duration::from_secs_f32(30.0));
-                            },
+                            }
                             Err(err) => {
                                 trace!(
                                     "error getting script history, treating as not found: {}",


### PR DESCRIPTION
Closes #628. The failures reported in #628 stem from the `client.transaction_get(&tx_id)` call successfully returning the `tx`, but said `tx_id` not showing up in the script history retrieved via `script_get_history(&tx.output[0].script_pubkey)` yet, which would panic the syncer. This issue's gotten worse with electrs v0.9.x.

Since this would crash the syncer, an error in one swap would break Bitcoin liveness for all running swaps, which should not be happening at all, in particular since liveness on the Bitcoin chain is safety critical.

A mitigation is to reattempt the call after some time delay - this has worked for me without failure, but I'm still tweaking to find the appropriate delay. Can also handle this the same as `script_get_history` returning an error, which would then only reattempt upon a block height change.