### PR TITLE
Tests: improve how processes are killed

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -11,7 +11,8 @@ mod utils;
 #[tokio::test]
 #[ignore]
 async fn cli_make_offer() {
-    let (farcasterd_maker, data_dir_maker, farcasterd_taker, _) = setup_clients().await;
+    let (_, data_dir_maker, _, _) =
+        launch_farcasterd_instances().await;
 
     // Allow some time for the microservices to start and register each other
     tokio::time::sleep(time::Duration::from_secs(10)).await;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -48,7 +48,4 @@ async fn cli_make_offer() {
 
     let res: MadeOffer = cli(args).unwrap();
     println!("{:?}", res);
-
-    // clean up processes
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }

--- a/tests/grpc.rs
+++ b/tests/grpc.rs
@@ -30,5 +30,4 @@ async fn grpc_server_functional_test() {
     let request = tonic::Request::new(InfoRequest { id: 0 });
     let response = farcaster_client.info(request).await;
     assert_eq!(response.unwrap().into_inner().id, 0);
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }

--- a/tests/grpc.rs
+++ b/tests/grpc.rs
@@ -16,7 +16,7 @@ pub mod farcaster {
 #[tokio::test]
 #[ignore]
 async fn grpc_server_functional_test() {
-    let (farcasterd_maker, _, farcasterd_taker, _) = setup_clients().await;
+    let (_, _, _, _) = launch_farcasterd_instances().await;
 
     // Allow some time for the microservices to start and register each other
     tokio::time::sleep(time::Duration::from_secs(10)).await;

--- a/tests/swap.rs
+++ b/tests/swap.rs
@@ -34,8 +34,7 @@ async fn swap_bob_maker_normal() {
     let bitcoin_rpc = Arc::new(bitcoin_setup());
     let (monero_regtest, monero_wallet) = monero_setup().await;
 
-    let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+    let (_, data_dir_maker, _, data_dir_taker) = launch_farcasterd_instances().await;
 
     let (xmr_dest_wallet_name, bitcoin_address, swap_id) = make_and_take_offer(
         data_dir_maker.clone(),
@@ -71,8 +70,7 @@ async fn swap_bob_funds_incorrect_amount() {
     let bitcoin_rpc = Arc::new(bitcoin_setup());
     let (_monero_regtest, monero_wallet) = monero_setup().await;
 
-    let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+    let (_, data_dir_maker, _, data_dir_taker) = launch_farcasterd_instances().await;
 
     let (_xmr_dest_wallet_name, bitcoin_address, swap_id) = make_and_take_offer(
         data_dir_maker.clone(),
@@ -105,7 +103,7 @@ async fn swap_bob_maker_manual_bitcoin_sweep() {
     let (_, monero_wallet) = monero_setup().await;
 
     let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+        launch_farcasterd_instances().await;
 
     let (_, _, swap_id) = make_and_take_offer(
         data_dir_maker.clone(),
@@ -137,7 +135,7 @@ async fn swap_bob_maker_manual_monero_sweep() {
     let (monero_regtest, monero_wallet) = monero_setup().await;
 
     let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+        launch_farcasterd_instances().await;
 
     let (xmr_dest_wallet_name, bitcoin_address, swap_id) = make_and_take_offer(
         data_dir_maker.clone(),
@@ -173,8 +171,7 @@ async fn swap_bob_maker_user_abort_sweep_btc() {
     let bitcoin_rpc = Arc::new(bitcoin_setup());
     let (_monero_regtest, monero_wallet) = monero_setup().await;
 
-    let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+    let (_, data_dir_maker, _, data_dir_taker) = launch_farcasterd_instances().await;
 
     let (_xmr_dest_wallet_name, bitcoin_address, swap_id) = make_and_take_offer(
         data_dir_maker.clone(),
@@ -211,8 +208,7 @@ async fn swap_bob_maker_kill_peerd_before_funding_should_reconnect_success() {
     let bitcoin_rpc = Arc::new(bitcoin_setup());
     let (monero_regtest, monero_wallet) = monero_setup().await;
 
-    let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+    let (_, data_dir_maker, _, data_dir_taker) = launch_farcasterd_instances().await;
 
     let (xmr_dest_wallet_name, bitcoin_address, swap_id) = make_and_take_offer(
         data_dir_maker.clone(),
@@ -253,8 +249,7 @@ async fn swap_revoke_offer_bob_maker_normal() {
     let bitcoin_rpc = Arc::new(bitcoin_setup());
     let (monero_regtest, monero_wallet) = monero_setup().await;
 
-    let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+    let (_, data_dir_maker, _, data_dir_taker) = launch_farcasterd_instances().await;
 
     // first make and revoke an offer
     make_and_revoke_offer(
@@ -303,8 +298,7 @@ async fn swap_bob_maker_refund_alice_overfunds() {
     let bitcoin_rpc = Arc::new(bitcoin_setup());
     let (monero_regtest, monero_wallet) = monero_setup().await;
 
-    let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+    let (_, data_dir_maker, _, data_dir_taker) = launch_farcasterd_instances().await;
 
     let (xmr_dest_wallet_name, bitcoin_address, swap_id) = make_and_take_offer(
         data_dir_maker.clone(),
@@ -341,8 +335,7 @@ async fn swap_bob_maker_refund_race_cancel() {
     let bitcoin_rpc = Arc::new(bitcoin_setup());
     let (monero_regtest, monero_wallet) = monero_setup().await;
 
-    let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+    let (_, data_dir_maker, _, data_dir_taker) = launch_farcasterd_instances().await;
 
     let (xmr_dest_wallet_name, bitcoin_address, swap_id) = make_and_take_offer(
         data_dir_maker.clone(),
@@ -379,8 +372,7 @@ async fn swap_bob_maker_refund_kill_alice_after_funding() {
     let bitcoin_rpc = Arc::new(bitcoin_setup());
     let (_monero_regtest, monero_wallet) = monero_setup().await;
 
-    let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+    let (_, data_dir_maker, farcasterd_taker, data_dir_taker) = launch_farcasterd_instances().await;
 
     let (_xmr_dest_wallet_name, bitcoin_address, swap_id) = make_and_take_offer(
         data_dir_maker.clone(),
@@ -416,8 +408,7 @@ async fn swap_bob_maker_refund_alice_does_not_fund() {
     let bitcoin_rpc = Arc::new(bitcoin_setup());
     let (_monero_regtest, monero_wallet) = monero_setup().await;
 
-    let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+    let (_, data_dir_maker, _, data_dir_taker) = launch_farcasterd_instances().await;
 
     let (_xmr_dest_wallet_name, bitcoin_address, swap_id) = make_and_take_offer(
         data_dir_maker.clone(),
@@ -451,8 +442,7 @@ async fn swap_bob_maker_punish_kill_bob() {
     let bitcoin_rpc = Arc::new(bitcoin_setup());
     let (monero_regtest, monero_wallet) = monero_setup().await;
 
-    let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+    let (farcasterd_maker, data_dir_maker, _, data_dir_taker) = launch_farcasterd_instances().await;
 
     let (_xmr_dest_wallet_name, bitcoin_address, swap_id) = make_and_take_offer(
         data_dir_maker.clone(),
@@ -490,7 +480,7 @@ async fn swap_bob_maker_restore_checkpoint_bob_pre_buy_alice_pre_lock() {
     let (monero_regtest, monero_wallet) = monero_setup().await;
 
     let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+        launch_farcasterd_instances().await;
 
     let (xmr_dest_wallet_name, bitcoin_address, swap_id) = make_and_take_offer(
         data_dir_maker.clone(),
@@ -528,7 +518,7 @@ async fn swap_bob_maker_restore_checkpoint_bob_pre_buy_alice_pre_buy() {
     let (monero_regtest, monero_wallet) = monero_setup().await;
 
     let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+        launch_farcasterd_instances().await;
 
     let (xmr_dest_wallet_name, bitcoin_address, swap_id) = make_and_take_offer(
         data_dir_maker.clone(),
@@ -565,8 +555,7 @@ async fn swap_alice_maker() {
     let bitcoin_rpc = Arc::new(bitcoin_setup());
     let (monero_regtest, monero_wallet) = monero_setup().await;
 
-    let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+    let (_, data_dir_maker, _, data_dir_taker) = launch_farcasterd_instances().await;
 
     let (xmr_dest_wallet_name, bitcoin_address, swap_id) = make_and_take_offer(
         data_dir_maker.clone(),
@@ -611,8 +600,7 @@ async fn swap_parallel_execution() {
     let bitcoin_rpc = Arc::new(bitcoin_setup());
     let (monero_regtest, monero_wallet) = monero_setup().await;
 
-    let (farcasterd_maker, data_dir_maker, farcasterd_taker, data_dir_taker) =
-        setup_clients().await;
+    let (_, data_dir_maker, _, data_dir_taker) = launch_farcasterd_instances().await;
 
     let previous_offers: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
     let previous_swap_ids: Arc<Mutex<HashSet<SwapId>>> = Arc::new(Mutex::new(HashSet::new()));
@@ -783,7 +771,7 @@ async fn run_restore_checkpoint_bob_pre_buy_alice_pre_buy(
 
     // kill all the daemons,  and start them again
     cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
-    let (farcasterd_maker, _, farcasterd_taker, _) = setup_clients().await;
+    let (_, _, _, _) = launch_farcasterd_instances().await;
 
     // wait a bit for all the daemons to start
     tokio::time::sleep(time::Duration::from_secs(1)).await;
@@ -928,7 +916,7 @@ async fn run_restore_checkpoint_bob_pre_buy_alice_pre_lock(
 
     // kill all the daemons and start them again
     cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
-    let (farcasterd_maker, _, farcasterd_taker, _) = setup_clients().await;
+    let (_, _, _, _) = launch_farcasterd_instances().await;
 
     // wait a bit for all the daemons to start
     tokio::time::sleep(time::Duration::from_secs(1)).await;
@@ -2224,7 +2212,7 @@ async fn run_swap_bob_maker_manual_bitcoin_sweep(
 
     cleanup_processes(vec![farcasterd_maker]);
 
-    let (farcasterd_maker, _, farcasterd_taker, _) = setup_clients().await;
+    let (_, _, _, _) = launch_farcasterd_instances().await;
 
     let before_balance = bitcoin_rpc.get_balance(None, None).unwrap();
     let dest_bitcoin_address = bitcoin_rpc.get_new_address(None, None).unwrap();
@@ -2376,7 +2364,7 @@ async fn run_swap_bob_maker_manual_monero_sweep(
 
     // kill the processes
     cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
-    let (farcasterd_maker, _, farcasterd_taker, _) = setup_clients().await;
+    let (_, _, _, _) = launch_farcasterd_instances().await;
 
     // generate some blocks on monero's side
     monero_regtest

--- a/tests/swap.rs
+++ b/tests/swap.rs
@@ -59,8 +59,6 @@ async fn swap_bob_maker_normal() {
         execution_mutex,
     )
     .await;
-
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }
 
 #[tokio::test]
@@ -91,8 +89,6 @@ async fn swap_bob_funds_incorrect_amount() {
         bitcoin_address,
     )
     .await;
-
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }
 
 #[tokio::test]
@@ -192,8 +188,6 @@ async fn swap_bob_maker_user_abort_sweep_btc() {
         bitcoin_address,
     )
     .await;
-
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }
 
 pub mod farcaster {
@@ -237,8 +231,6 @@ async fn swap_bob_maker_kill_peerd_before_funding_should_reconnect_success() {
         execution_mutex,
     )
     .await;
-
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }
 
 #[tokio::test]
@@ -286,8 +278,6 @@ async fn swap_revoke_offer_bob_maker_normal() {
         execution_mutex,
     )
     .await;
-
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }
 
 #[tokio::test]
@@ -323,8 +313,6 @@ async fn swap_bob_maker_refund_alice_overfunds() {
         execution_mutex,
     )
     .await;
-
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }
 
 #[tokio::test]
@@ -360,8 +348,6 @@ async fn swap_bob_maker_refund_race_cancel() {
         execution_mutex,
     )
     .await;
-
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }
 
 #[tokio::test]
@@ -396,8 +382,6 @@ async fn swap_bob_maker_refund_kill_alice_after_funding() {
         farcasterd_taker,
     )
     .await;
-
-    cleanup_processes(vec![farcasterd_maker]);
 }
 
 #[tokio::test]
@@ -430,8 +414,6 @@ async fn swap_bob_maker_refund_alice_does_not_fund() {
         execution_mutex,
     )
     .await;
-
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }
 
 #[tokio::test]
@@ -467,8 +449,6 @@ async fn swap_bob_maker_punish_kill_bob() {
         farcasterd_maker,
     )
     .await;
-
-    cleanup_processes(vec![farcasterd_taker]);
 }
 
 #[tokio::test]
@@ -580,8 +560,6 @@ async fn swap_alice_maker() {
         execution_mutex,
     )
     .await;
-
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }
 
 #[derive(Debug, Clone)]
@@ -679,7 +657,6 @@ async fn swap_parallel_execution() {
         Arc::clone(&execution_mutex),
     )
     .await;
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -770,7 +747,6 @@ async fn run_restore_checkpoint_bob_pre_buy_alice_pre_buy(
     tokio::time::sleep(time::Duration::from_secs(10)).await;
 
     // kill all the daemons,  and start them again
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
     let (_, _, _, _) = launch_farcasterd_instances().await;
 
     // wait a bit for all the daemons to start
@@ -852,8 +828,6 @@ async fn run_restore_checkpoint_bob_pre_buy_alice_pre_buy(
     drop(lock);
     let delta_balance = after_balance.balance - before_balance.balance;
     assert!(delta_balance > monero::Amount::from_pico(998000000000));
-
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -915,7 +889,6 @@ async fn run_restore_checkpoint_bob_pre_buy_alice_pre_lock(
     tokio::time::sleep(time::Duration::from_secs(1)).await;
 
     // kill all the daemons and start them again
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
     let (_, _, _, _) = launch_farcasterd_instances().await;
 
     // wait a bit for all the daemons to start
@@ -1031,8 +1004,6 @@ async fn run_restore_checkpoint_bob_pre_buy_alice_pre_lock(
     let delta_balance = after_balance.balance - before_balance.balance;
     assert!(delta_balance > monero::Amount::from_pico(998000000000));
     drop(lock);
-
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1433,7 +1404,6 @@ async fn run_refund_swap_kill_alice_after_funding(
     send_monero(Arc::clone(&monero_wallet), monero_address, monero_amount).await;
 
     // kill alice
-    cleanup_processes(vec![alice_farcasterd]);
 
     tokio::time::sleep(time::Duration::from_secs(20)).await;
 
@@ -1657,7 +1627,6 @@ async fn run_punish_swap_kill_bob_before_monero_funding(
     tokio::time::sleep(time::Duration::from_secs(20)).await;
 
     // kill bob
-    cleanup_processes(vec![bob_farcasterd]);
 
     // run until alice has the monero funding address
     let (monero_address, monero_amount) =
@@ -2203,14 +2172,14 @@ async fn run_swap_bob_maker_manual_bitcoin_sweep(
         retry_until_bitcoin_funding_address(swap_id.clone(), cli_bob_needs_funding_args.clone())
             .await;
 
-    cleanup_processes(vec![farcasterd_taker]);
+    drop(farcasterd_taker);
 
     // fund the bitcoin address
     bitcoin_rpc
         .send_to_address(&address, amount, None, None, None, None, None, None)
         .unwrap();
 
-    cleanup_processes(vec![farcasterd_maker]);
+    drop(farcasterd_maker);
 
     let (_, _, _, _) = launch_farcasterd_instances().await;
 
@@ -2231,7 +2200,6 @@ async fn run_swap_bob_maker_manual_bitcoin_sweep(
     let after_balance = bitcoin_rpc.get_balance(None, None).unwrap();
     let delta_balance = after_balance - before_balance;
     assert!(delta_balance > bitcoin::Amount::from_sat(10000000));
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2363,7 +2331,6 @@ async fn run_swap_bob_maker_manual_monero_sweep(
     tokio::time::sleep(time::Duration::from_secs(5)).await;
 
     // kill the processes
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
     let (_, _, _, _) = launch_farcasterd_instances().await;
 
     // generate some blocks on monero's side
@@ -2394,7 +2361,6 @@ async fn run_swap_bob_maker_manual_monero_sweep(
     drop(lock);
     let delta_balance = after_balance.balance - before_balance.balance;
     assert!(delta_balance > monero::Amount::from_pico(998000000000));
-    cleanup_processes(vec![farcasterd_maker, farcasterd_taker]);
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/tests/utils/fc.rs
+++ b/tests/utils/fc.rs
@@ -13,8 +13,12 @@ use sysinfo::{ProcessExt, System, SystemExt};
 
 use super::config;
 
-// TODO: rename this function, this launches fcd, not 'clients'
-pub async fn setup_clients() -> (process::Child, Vec<String>, process::Child, Vec<String>) {
+pub async fn launch_farcasterd_instances() -> (
+    FarcasterdProcess,
+    Vec<String>,
+    FarcasterdProcess,
+    Vec<String>,
+) {
     // data directories
     let data_dir_maker = vec!["-d".to_string(), "tests/fc1".to_string()];
     let data_dir_taker = vec!["-d".to_string(), "tests/fc2".to_string()];


### PR DESCRIPTION
This PR does three things:

- renames `setup_clients` to `launch_farcasterd_instances`
- removes `cleanup_processes` and adds a `struct FarcasterdProcess` with a `impl Drop`; this has the advantage that processes will die even if tests fail, which was not happening before
- improve the logic that cleans up processes; it had some problems that processes spawned by `farcasterd` were not being killed

Run the tests (force them to fail too), and in all cases check if any farcaster-related process is running in your machine.