### PR TITLE
electrs failures: reattempt `script_get_history(...)`

### DIFF
--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -210,7 +210,7 @@ impl ElectrumRpc {
             // Get the full transaction
             match self.client.transaction_get(&tx_id) {
                 Ok(tx) => {
-                    debug!("Updated tx: {}", &tx_id);
+                    debug!("Updated tx: {}: {:?}", &tx_id, tx);
                     // Look for history of the first output (maybe last is generally less likely
                     // to be used multiple times, so more efficient?!)
                     let history_res;

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -227,16 +227,16 @@ impl ElectrumRpc {
                                         "{:?} should be found in the history if we successfully queried `transaction_get` for it",
                                         &tx_id
                                     );
-                                    let mut state_guard = state.lock().await;
-                                    state_guard
-                                        .change_transaction(
-                                            tx_id.to_vec(),
-                                            None,
-                                            Some(0),
-                                            bitcoin::consensus::serialize(&tx),
-                                        )
-                                        .await;
-                                    drop(state_guard);
+                                    // let mut state_guard = state.lock().await;
+                                    // state_guard
+                                    //     .change_transaction(
+                                    //         tx_id.to_vec(),
+                                    //         None,
+                                    //         Some(0),
+                                    //         bitcoin::consensus::serialize(&tx),
+                                    //     )
+                                    //     .await;
+                                    // drop(state_guard);
                                     continue;
                                 }
                             }},

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -244,7 +244,8 @@ impl ElectrumRpc {
                             }},
                         Err(err) => {
                             trace!(
-                                "error getting script history, treating as not found: {}",
+                                "error getting script history for {}, treating as not found: {}",
+                                &tx_id,
                                 err
                             );
                             let mut state_guard = state.lock().await;

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -211,15 +211,15 @@ impl ElectrumRpc {
             match self.client.transaction_get(&tx_id) {
                 Ok(tx) => {
                     debug!("Updated tx: {}: {:?}", &tx_id, tx);
+                    let history_res;
                     // Look for history of the first output (maybe last is generally less likely
                     // to be used multiple times, so more efficient?!)
-                    let history_res;
                     let entry = match self.client.script_get_history(&tx.output[0].script_pubkey) {
                         Ok(history) => {
                             history_res = history;
                             match history_res
                                 .iter()
-                                .find(|history_res| history_res.tx_hash == tx_id)
+                                .find(|history_entry| history_entry.tx_hash == tx_id)
                             {
                                 Some(entry) => entry,
                                 None => {

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -213,9 +213,31 @@ impl ElectrumRpc {
                     debug!("Updated tx: {}", &tx_id);
                     // Look for history of the first output (maybe last is generally less likely
                     // to be used multiple times, so more efficient?!)
-                    let history = match self.client.script_get_history(&tx.output[0].script_pubkey)
-                    {
-                        Ok(history) => history,
+                    // let mut history_res;
+                    let entry = match self.client.script_get_history(&tx.output[0].script_pubkey) {
+                        Ok(history) => match history
+                            .iter()
+                            .find(|history_res| history_res.tx_hash == tx_id)
+                        {
+                            Some(entry) => entry,
+                            None => {
+                                warn!(
+                                    "{:?} should be found in the history if we successfully queried `transaction_get` for it",
+                                    &tx_id
+                                );
+                                let mut state_guard = state.lock().await;
+                                state_guard
+                                    .change_transaction(
+                                        tx_id.to_vec(),
+                                        None,
+                                        Some(0),
+                                        bitcoin::consensus::serialize(&tx),
+                                    )
+                                    .await;
+                                drop(state_guard);
+                                continue;
+                            }
+                        },
                         Err(err) => {
                             trace!(
                                 "error getting script history, treating as not found: {}",
@@ -234,10 +256,6 @@ impl ElectrumRpc {
                             continue;
                         }
                     };
-
-                    let entry = history.iter().find(|history_res| {
-                        history_res.tx_hash == tx_id
-                    }).expect("Should be found in the history if we successfully queried `transaction_get`");
 
                     let (conf_in_block, blockhash) = match entry.height {
                         // Transaction unconfirmed (0 or -1)

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -221,7 +221,9 @@ impl ElectrumRpc {
                                 .iter()
                                 .find(|history_entry| history_entry.tx_hash == tx_id)
                             {
-                                Some(entry) => entry,
+                                Some(entry) => {
+                                    debug!("Found tx: {}", &tx_id);
+                                    entry},
                                 None => {
                                     warn!(
                                         "{:?} should be found in the history if we successfully queried `transaction_get` for it",

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -222,7 +222,8 @@ impl ElectrumRpc {
                             {
                                 Some(entry) => {
                                     trace!("Found tx: {}", &tx_id);
-                                    entry},
+                                    entry
+                                }
                                 None => {
                                     debug!(
                                         "{:?} should be found in the history if we successfully queried `transaction_get` for it",
@@ -230,7 +231,8 @@ impl ElectrumRpc {
                                     );
                                     continue;
                                 }
-                            }},
+                            }
+                        }
                         Err(err) => {
                             trace!(
                                 "error getting script history for {}, treating as not found: {}",

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -210,6 +210,7 @@ impl ElectrumRpc {
             // Get the full transaction
             match self.client.transaction_get(&tx_id) {
                 Ok(tx) => {
+                    debug!("Updated tx: {}", &tx_id);
                     let history_res;
                     // Look for history of the first output (maybe last is generally less likely
                     // to be used multiple times, so more efficient?!)
@@ -220,13 +221,10 @@ impl ElectrumRpc {
                                 .iter()
                                 .find(|history_entry| history_entry.tx_hash == tx_id)
                             {
-                                Some(entry) => {
-                                    trace!("Found tx: {}", &tx_id);
-                                    entry
-                                }
+                                Some(entry) => entry,
                                 None => {
                                     debug!(
-                                        "{:?} should be found in the history if we successfully queried `transaction_get` for it",
+                                        "{} should be found in the history if we successfully queried `transaction_get` for it",
                                         &tx_id
                                     );
                                     continue;

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -210,7 +210,6 @@ impl ElectrumRpc {
             // Get the full transaction
             match self.client.transaction_get(&tx_id) {
                 Ok(tx) => {
-                    debug!("Updated tx: {}: {:?}", &tx_id, tx);
                     let history_res;
                     // Look for history of the first output (maybe last is generally less likely
                     // to be used multiple times, so more efficient?!)
@@ -222,23 +221,13 @@ impl ElectrumRpc {
                                 .find(|history_entry| history_entry.tx_hash == tx_id)
                             {
                                 Some(entry) => {
-                                    debug!("Found tx: {}", &tx_id);
+                                    trace!("Found tx: {}", &tx_id);
                                     entry},
                                 None => {
-                                    warn!(
+                                    debug!(
                                         "{:?} should be found in the history if we successfully queried `transaction_get` for it",
                                         &tx_id
                                     );
-                                    // let mut state_guard = state.lock().await;
-                                    // state_guard
-                                    //     .change_transaction(
-                                    //         tx_id.to_vec(),
-                                    //         None,
-                                    //         Some(0),
-                                    //         bitcoin::consensus::serialize(&tx),
-                                    //     )
-                                    //     .await;
-                                    // drop(state_guard);
                                     continue;
                                 }
                             }},


### PR DESCRIPTION
Closes #628. Replaces #695, see it for motivation & details, but now reusing existing `unseen_transaction_polling`. Tested extensively on farcaster.dev. Commits are noisy, so squash merge.