### PR TITLE
fix sweep failures on intermittent daemon irresponsiveness

### DIFF
--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -2091,7 +2091,7 @@ impl Runtime {
                     )?;
                 }
                 SweepAddressAddendum::Monero(sweep_xmr) => {
-                    let task = self.syncer_state.sweep_xmr(sweep_xmr.clone(), false);
+                    let task = self.syncer_state.sweep_xmr(sweep_xmr.clone(), true);
                     let acc_confs_needs = self.temporal_safety.sweep_monero_thr
                         - self.temporal_safety.xmr_finality_thr;
                     let sweep_block =

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -668,7 +668,7 @@ fn sweep_polling(
                     )
                     .await
                     .unwrap_or_else(|err| {
-                        warn!("error polling sweep address {:?}, retrying", err);
+                        warn!("error polling sweep address {:?}, retrying: {}", err, sweep_address_task.retry);
                         vec![]
                     });
                     let mut state_guard = state.lock().await;


### PR DESCRIPTION
as reported on irc, all sustained maker/taker relationships would eventually halt. this was primarily down to monero sweep sometimes failing: if the daemon would intermittently not respond, the sweep would fail and not be reattempted (this lack of retry was introduced by a code refactor). Thus the swap would never finish for Bob, only Alice.

now sweeps are again always reattempted when this occurs.