### PR TITLE
reattempt connect if failed during init connect

### DIFF
--- a/src/bin/peerd.rs
+++ b/src/bin/peerd.rs
@@ -225,8 +225,18 @@ fn main() {
             remote_node_addr = Some(remote_node);
 
             debug!("Connecting to {}", &remote_node.addr());
-            PeerConnection::connect_brontozaur(local_node, remote_node)
-                .expect("Unable to connect to the remote peer")
+
+            let mut connection = PeerConnection::connect_brontozaur(local_node, remote_node);
+            let mut attempt = 0;
+
+            while let Err(err) = connection {
+                trace!("failed to establish tcp connection: {}", err);
+                attempt += 1;
+                warn!("connect failed attempting again in {} seconds", attempt);
+                std::thread::sleep(std::time::Duration::from_secs(attempt));
+                connection = PeerConnection::connect_brontozaur(local_node, remote_node);
+            }
+            connection.expect("Already filtered for connection errors")
         }
     };
 

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -668,7 +668,10 @@ fn sweep_polling(
                     )
                     .await
                     .unwrap_or_else(|err| {
-                        warn!("error polling sweep address {:?}, retrying: {}", err, sweep_address_task.retry);
+                        warn!(
+                            "error polling sweep address {:?}, retrying: {}",
+                            err, sweep_address_task.retry
+                        );
                         vec![]
                     });
                     let mut state_guard = state.lock().await;


### PR DESCRIPTION
resolves #728 - reuses logic in https://github.com/farcaster-project/farcaster-node/blob/main/src/peerd/runtime.rs#L432-L449