### PR TITLE
Style: improve logs and colors

### DIFF
--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -629,12 +629,7 @@ impl Runtime {
                 if respond_to == self.identity() {
                     continue;
                 }
-                trace!(
-                    "(#{}) Respond to {}: {}",
-                    i,
-                    respond_to.bright_yellow_bold(),
-                    resp.bright_blue_bold(),
-                );
+                trace!("(#{}) Respond to {}: {}", i, respond_to, resp,);
                 endpoints.send_to(
                     ServiceBus::Rpc,
                     self.identity(),
@@ -995,11 +990,7 @@ impl Runtime {
             return Ok(existing_peer.clone());
         }
 
-        debug!(
-            "{} to remote peer {}",
-            "Connecting".bright_blue_bold(),
-            node_addr.bright_blue_italic()
-        );
+        debug!("{} to remote peer {}", "Connecting", node_addr);
 
         // Start peerd
         let child = launch(

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -200,7 +200,7 @@ impl Runtime {
                 // Ignoring; this is used to set remote identity at ZMQ level
                 info!(
                     "Service {} is now {}",
-                    source.bright_white_bold(),
+                    source.label(),
                     "connected".bright_green_bold()
                 );
 

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -81,7 +81,11 @@ pub fn run(
     let _databased = launch("databased", empty)?;
 
     if config.is_auto_funding_enable() {
-        info!("farcasterd will attempt to fund automatically");
+        info!(
+            "{} will attempt to {}",
+            "farcasterd".label(),
+            "fund automatically".label()
+        );
     }
 
     let runtime = Runtime {
@@ -311,7 +315,7 @@ impl Runtime {
                         // is not completed, and thus present in consumed_offers
                         let peerd_id = ServiceId::Peer(addr);
                         if self.connection_has_swap_client(&peerd_id) {
-                            info!("a swap is still running over the terminated peer {}, the counterparty will attempt to reconnect.", addr);
+                            info!("A swap is still running over the terminated peer {}, the counterparty will attempt to reconnect.", addr.bright_blue_italic());
                         }
                     }
                 }
@@ -1071,7 +1075,7 @@ pub fn syncer_up(
             network.to_string(),
         ];
         args.append(&mut syncer_servers_args(config, blockchain, network)?);
-        info!("launching syncer with: {:?}", args);
+        debug!("launching syncer with: {:?}", args);
         launch("syncerd", args)?;
         spawning_services.insert(syncer_service.clone());
     }
@@ -1189,7 +1193,7 @@ pub fn launch(
 
     // Forward tor proxy argument
     let parsed = Opts::parse();
-    info!("tor opts: {:?}", parsed.shared.tor_proxy);
+    debug!("tor opts: {:?}", parsed.shared.tor_proxy);
     if let Some(t) = &matches.value_of("tor-proxy") {
         cmd.args(&["-T", *t]);
     }

--- a/src/farcasterd/stats.rs
+++ b/src/farcasterd/stats.rs
@@ -49,8 +49,8 @@ impl Stats {
         if !newly_inserted {
             warn!(
                 "{} | This swap was already in awaiting {} funding",
-                swapid.bright_blue_italic(),
-                blockchain.bright_white_bold()
+                swapid.swap_id(),
+                blockchain.label()
             );
         }
     }
@@ -69,8 +69,8 @@ impl Stats {
         if !present_in_set {
             warn!(
                 "{} | This swap wasn't awaiting {} funding",
-                swapid.bright_blue_italic(),
-                "Bitcoin".bright_white_bold()
+                swapid.swap_id(),
+                blockchain.label()
             );
         }
     }
@@ -91,8 +91,8 @@ impl Stats {
         if !present_in_set {
             warn!(
                 "{} | This swap wasn't awaiting {} funding",
-                swapid.bright_blue_italic(),
-                "Bitcoin".bright_white_bold()
+                swapid.swap_id(),
+                blockchain.label()
             );
         }
     }
@@ -115,17 +115,17 @@ impl Stats {
         let rate = *success as f64 / (total as f64);
         info!(
             "Swapped({}) | Refunded({}) / Punished({}) | Aborted({}) | Initialized({}) / AwaitingFundingXMR({}) / AwaitingFundingBTC({}) / FundedXMR({}) / FundedBTC({}) / FundingCanceledXMR({}) / FundingCanceledBTC({})",
-            success.bright_white_bold(),
-            refund.bright_white_bold(),
-            punish.bright_white_bold(),
-            abort.bright_white_bold(),
-            initialized,
-            awaiting_funding_xmr.len().bright_white_bold(),
-            awaiting_funding_btc.len().bright_white_bold(),
-            funded_xmr.bright_white_bold(),
-            funded_btc.bright_white_bold(),
-            funding_canceled_xmr.bright_white_bold(),
-            funding_canceled_btc.bright_white_bold(),
+            success.label(),
+            refund.label(),
+            punish.label(),
+            abort.label(),
+            initialized.label(),
+            awaiting_funding_xmr.len().label(),
+            awaiting_funding_btc.len().label(),
+            funded_xmr.label(),
+            funded_btc.label(),
+            funding_canceled_xmr.label(),
+            funding_canceled_btc.label(),
         );
         info!(
             "{} = {:>4.3}%",

--- a/src/peerd/runtime.rs
+++ b/src/peerd/runtime.rs
@@ -374,8 +374,8 @@ impl Runtime {
             let swap_id = message.swap_id();
             info!(
                 "{} | Sent the {} protocol message",
-                swap_id.bright_blue_italic(),
-                message.bright_white_bold()
+                swap_id.swap_id(),
+                message.label()
             );
         }
 
@@ -390,7 +390,7 @@ impl Runtime {
     ) -> Result<(), Error> {
         match request {
             Ctl::Terminate if source == ServiceId::Farcasterd => {
-                info!("Terminating {}", self.identity().bright_white_bold());
+                info!("Terminating {}", self.identity().label());
                 std::process::exit(0);
             }
 
@@ -553,8 +553,8 @@ impl Runtime {
                 let swap_id = msg.swap_id();
                 info!(
                     "{} | Received the {} protocol message",
-                    swap_id.bright_blue_italic(),
-                    msg.bright_white_bold()
+                    swap_id.swap_id(),
+                    msg.label()
                 );
                 endpoints.send_to(
                     ServiceBus::Msg,

--- a/src/service.rs
+++ b/src/service.rs
@@ -517,8 +517,24 @@ pub trait LogStyle: ToString {
         self.to_string().bold().bright_white()
     }
 
+    // Typed log styles
+    // This is used to standardize color and fonts across the codebase
+    // ----------------
+
+    fn swap_id(&self) -> colored::ColoredString {
+        self.to_string().italic().bright_blue()
+    }
+
+    fn label(&self) -> colored::ColoredString {
+        self.to_string().bold().bright_white()
+    }
+
     fn addr(&self) -> colored::ColoredString {
         self.to_string().bold().bright_yellow()
+    }
+
+    fn tx_hash(&self) -> colored::ColoredString {
+        self.to_string().italic().bright_yellow()
     }
 
     fn err(&self) -> colored::ColoredString {

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -88,11 +88,11 @@ pub fn run(
     info!(
         "{}: {}",
         "Starting swap".to_string().bright_green_bold(),
-        format!("{:#x}", swap_id).addr()
+        format!("{:#x}", swap_id).swap_id()
     );
     info!(
         "{} | Initial state: {}",
-        swap_id.bright_blue_italic(),
+        swap_id.swap_id(),
         init_state.bright_white_bold()
     );
 
@@ -504,7 +504,7 @@ impl Runtime {
     fn state_update(&mut self, endpoints: &mut Endpoints, next_state: State) -> Result<(), Error> {
         info!(
             "{} | State transition: {} -> {}",
-            self.swap_id.bright_blue_italic(),
+            self.swap_id.swap_id(),
             self.state.bright_white_bold(),
             next_state.bright_white_bold(),
         );
@@ -522,9 +522,9 @@ impl Runtime {
     ) -> Result<(), Error> {
         info!(
             "{} | Broadcasting {} tx ({})",
-            self.swap_id.bright_blue_italic(),
-            tx_label.bright_white_bold(),
-            tx.txid().bright_yellow_italic()
+            self.swap_id.swap_id(),
+            tx_label.label(),
+            tx.txid().tx_hash()
         );
         let task = self.syncer_state.broadcast(tx);
         Ok(endpoints.send_to(
@@ -847,7 +847,7 @@ impl Runtime {
             (BusMsg::Ctl(Ctl::Hello), _) => {
                 info!(
                     "{} | Service {} daemon is now {}",
-                    self.swap_id.bright_blue_italic(),
+                    self.swap_id.swap_id(),
                     source.bright_green_bold(),
                     "connected"
                 );
@@ -871,7 +871,7 @@ impl Runtime {
             BusMsg::Ctl(Ctl::Terminate) if source == ServiceId::Farcasterd => {
                 info!(
                     "{} | {}",
-                    self.swap_id.bright_blue_italic(),
+                    self.swap_id.swap_id(),
                     format!("Terminating {}", self.identity()).bright_white_bold()
                 );
                 std::process::exit(0);
@@ -1176,7 +1176,9 @@ impl Runtime {
                 SweepAddressAddendum::Bitcoin(sweep_btc) => {
                     info!(
                         "{} | Sweeping source (funding) address: {} to destination address: {}",
-                        self.swap_id, sweep_btc.source_address, sweep_btc.destination_address
+                        self.swap_id.swap_id(),
+                        sweep_btc.source_address.addr(),
+                        sweep_btc.destination_address.addr()
                     );
                     let task = self.syncer_state.sweep_btc(sweep_btc.clone(), false);
                     endpoints.send_to(
@@ -1194,17 +1196,17 @@ impl Runtime {
                         self.syncer_state.height(Blockchain::Monero) + acc_confs_needs as u64;
                     info!(
                         "{} | Tx {} needs {}, and has {} {}",
-                        self.swap_id.bright_blue_italic(),
-                        TxLabel::AccLock.bright_white_bold(),
+                        self.swap_id.swap_id(),
+                        TxLabel::AccLock.label(),
                         "10 confirmations".bright_green_bold(),
                         (10 - acc_confs_needs).bright_green_bold(),
                         "confirmations".bright_green_bold(),
                     );
                     info!(
                         "{} | {} reaches your address {} around block {}",
-                        self.swap_id.bright_blue_italic(),
-                        Blockchain::Monero.bright_white_bold(),
-                        sweep_xmr.destination_address.bright_yellow_bold(),
+                        self.swap_id.swap_id(),
+                        Blockchain::Monero.label(),
+                        sweep_xmr.destination_address.addr(),
                         sweep_block.bright_blue_bold(),
                     );
                     warn!(
@@ -1420,7 +1422,7 @@ impl Runtime {
                     pending_broadcasts,
                     xmr_addr_addendum,
                 }) => {
-                    info!("{} | Restoring swap", swap_id);
+                    info!("{} | Restoring swap", swap_id.swap_id());
                     self.state = state;
                     self.enquirer = enquirer;
                     self.temporal_safety = temporal_safety;
@@ -1708,7 +1710,7 @@ impl Runtime {
 
                             info!(
                                 "{} | Monero are spendable now (height {}), sweeping ephemeral wallet",
-                                self.swap_id.bright_blue_italic(),
+                                self.swap_id.swap_id(),
                                 self.syncer_state.monero_height.bright_white_bold()
                             );
                             endpoints.send_to(bus_id, self.identity(), dest, request)?;
@@ -1885,7 +1887,7 @@ impl Runtime {
                         let tx = bitcoin::Transaction::deserialize(tx)?;
                         info!(
                             "Received AddressTransaction, processing tx {}",
-                            &tx.txid().addr()
+                            &tx.txid().tx_hash()
                         );
                         let txlabel = self.syncer_state.tasks.watched_addrs.get(id).unwrap();
                         match txlabel {
@@ -2072,7 +2074,7 @@ impl Runtime {
                                     let amount = self.syncer_state.monero_amount;
                                     info!(
                                         "{} | Send {} to {}",
-                                        swap_id.bright_blue_italic(),
+                                        swap_id.swap_id(),
                                         amount.bright_green_bold(),
                                         address.addr(),
                                     );
@@ -2486,7 +2488,7 @@ impl Runtime {
                         id: _,
                     }) => {
                         // FIXME handle low priority as well
-                        info!("fee: {} sat/kvB", high_priority_sats_per_kvbyte);
+                        info!("Fee: {} sat/kvB", high_priority_sats_per_kvbyte);
                         self.syncer_state.btc_fee_estimate_sat_per_kvb =
                             Some(*high_priority_sats_per_kvbyte);
 
@@ -2547,10 +2549,10 @@ impl Runtime {
         let amount = self.syncer_state.bitcoin_amount + total_fees;
         info!(
             "{} | Send {} to {}, this includes {} for the Lock transaction network fees",
-            swap_id.bright_blue_italic(),
+            swap_id.swap_id(),
             amount.bright_green_bold(),
             address.addr(),
-            total_fees
+            total_fees.bright_white_bold(),
         );
         self.state.b_sup_required_funding_amount(amount);
         let req = BusMsg::Ctl(Ctl::FundingInfo(FundingInfo::Bitcoin(BitcoinFundingInfo {
@@ -2572,7 +2574,7 @@ impl Runtime {
     ) -> Result<Commit, Error> {
         info!(
             "{} | {} to Maker remote peer",
-            self.swap_id().bright_blue_italic(),
+            self.swap_id().swap_id(),
             "Proposing to take swap".bright_white_bold(),
         );
 
@@ -2607,7 +2609,7 @@ impl Runtime {
     ) -> Result<Commit, Error> {
         info!(
             "{} | {} as Maker from Taker through peerd {}",
-            swap_id.bright_blue_italic(),
+            swap_id.swap_id(),
             "Accepting swap".bright_white_bold(),
             peerd.bright_blue_italic()
         );
@@ -2638,7 +2640,7 @@ impl Runtime {
         let swap_success_req = BusMsg::Ctl(Ctl::SwapOutcome(Outcome::Abort));
         self.send_ctl(endpoints, ServiceId::Wallet, swap_success_req.clone())?;
         self.send_ctl(endpoints, ServiceId::Farcasterd, swap_success_req)?;
-        info!("{} | Aborted swap.", self.swap_id);
+        info!("{} | Aborted swap.", self.swap_id.swap_id());
         Ok(())
     }
 }

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -93,7 +93,7 @@ pub fn run(
     info!(
         "{} | Initial state: {}",
         swap_id.swap_id(),
-        init_state.bright_white_bold()
+        init_state.label()
     );
 
     let temporal_safety = TemporalSafety {
@@ -505,8 +505,8 @@ impl Runtime {
         info!(
             "{} | State transition: {} -> {}",
             self.swap_id.swap_id(),
-            self.state.bright_white_bold(),
-            next_state.bright_white_bold(),
+            self.state.label(),
+            next_state.label(),
         );
         let msg = format!("{} -> {}", self.state, next_state,);
         self.state = next_state;
@@ -872,7 +872,7 @@ impl Runtime {
                 info!(
                     "{} | {}",
                     self.swap_id.swap_id(),
-                    format!("Terminating {}", self.identity()).bright_white_bold()
+                    format!("Terminating {}", self.identity()).label()
                 );
                 std::process::exit(0);
             }
@@ -1711,7 +1711,7 @@ impl Runtime {
                             info!(
                                 "{} | Monero are spendable now (height {}), sweeping ephemeral wallet",
                                 self.swap_id.swap_id(),
-                                self.syncer_state.monero_height.bright_white_bold()
+                                self.syncer_state.monero_height.label()
                             );
                             endpoints.send_to(bus_id, self.identity(), dest, request)?;
                         } else {
@@ -2425,8 +2425,8 @@ impl Runtime {
                             tx_label => trace!(
                                 "{} | Tx {} with {} confirmations evokes no response in state {}",
                                 self.swap_id.swap_id(),
-                                tx_label.bright_white_bold(),
-                                confirmations,
+                                tx_label.label(),
+                                confirmations.label(),
                                 &self.state
                             ),
                         }
@@ -2552,7 +2552,7 @@ impl Runtime {
             swap_id.swap_id(),
             amount.bright_green_bold(),
             address.addr(),
-            total_fees.bright_white_bold(),
+            total_fees.label(),
         );
         self.state.b_sup_required_funding_amount(amount);
         let req = BusMsg::Ctl(Ctl::FundingInfo(FundingInfo::Bitcoin(BitcoinFundingInfo {

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -799,7 +799,7 @@ impl Runtime {
                 // checkpoint swap alice pre buy
                 debug!(
                     "{} | checkpointing alice pre buy swapd state",
-                    self.swap_id.bright_blue_italic()
+                    self.swap_id.swap_id()
                 );
                 if self.state.a_sup_checkpoint_pre_buy() {
                     checkpoint_send(
@@ -1384,7 +1384,7 @@ impl Runtime {
             }
             BusMsg::Ctl(Ctl::AbortSwap) => {
                 let msg = "Swap is already locked-in, cannot manually abort anymore.".to_string();
-                warn!("{} | {}", self.swap_id, msg);
+                warn!("{} | {}", self.swap_id.swap_id(), msg);
 
                 if let ServiceId::Client(_) = source {
                     self.send_ctl(
@@ -2176,7 +2176,7 @@ impl Runtime {
                             {
                                 warn!(
                                     "{} | Alice, the swap may be cancelled soon. Do not fund anymore",
-                                    self.swap_id.bright_blue_italic()
+                                    self.swap_id.swap_id()
                                 );
                                 self.syncer_state.awaiting_funding = false;
                                 endpoints.send_to(
@@ -2229,7 +2229,7 @@ impl Runtime {
                             {
                                 warn!(
                                     "{} | Alice, this swap was canceled. Do not fund anymore.",
-                                    self.swap_id.bright_blue_italic()
+                                    self.swap_id.swap_id()
                                 );
                                 if self.syncer_state.awaiting_funding {
                                     endpoints.send_to(
@@ -2424,7 +2424,7 @@ impl Runtime {
                             }
                             tx_label => trace!(
                                 "{} | Tx {} with {} confirmations evokes no response in state {}",
-                                self.swap_id.bright_blue_italic(),
+                                self.swap_id.swap_id(),
                                 tx_label.bright_white_bold(),
                                 confirmations,
                                 &self.state

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -461,11 +461,7 @@ impl esb::Handler<ServiceBus> for Runtime {
 
 impl Runtime {
     fn send_peer(&mut self, endpoints: &mut Endpoints, msg: Msg) -> Result<(), Error> {
-        trace!(
-            "sending peer message {} to {}",
-            msg.bright_yellow_bold(),
-            self.peer_service
-        );
+        trace!("sending peer message {} to {}", msg, self.peer_service);
         if let Err(error) = endpoints.send_to(
             ServiceBus::Msg,
             self.identity(),
@@ -797,10 +793,7 @@ impl Runtime {
                 }
 
                 // checkpoint swap alice pre buy
-                debug!(
-                    "{} | checkpointing alice pre buy swapd state",
-                    self.swap_id.swap_id()
-                );
+                debug!("{} | checkpointing alice pre buy swapd state", self.swap_id);
                 if self.state.a_sup_checkpoint_pre_buy() {
                     checkpoint_send(
                         endpoints,
@@ -1047,10 +1040,7 @@ impl Runtime {
                     && self.state.local_params().is_some() =>
             {
                 // checkpoint swap pre lock bob
-                debug!(
-                    "{} | checkpointing bob pre lock swapd state",
-                    self.swap_id.bright_blue_italic()
-                );
+                debug!("{} | checkpointing bob pre lock swapd state", self.swap_id);
                 if self.state.b_sup_checkpoint_pre_lock() {
                     checkpoint_send(
                         endpoints,
@@ -1233,7 +1223,7 @@ impl Runtime {
                 // checkpoint alice pre lock bob
                 debug!(
                     "{} | checkpointing alice pre lock swapd state",
-                    self.swap_id.bright_blue_italic()
+                    self.swap_id
                 );
                 if self.state.a_sup_checkpoint_pre_lock() {
                     checkpoint_send(
@@ -1277,10 +1267,7 @@ impl Runtime {
                     && !self.syncer_state.tasks.txids.contains_key(&TxLabel::Buy) =>
             {
                 // checkpoint bob pre buy
-                debug!(
-                    "{} | checkpointing bob pre buy swapd state",
-                    self.swap_id.bright_blue_italic()
-                );
+                debug!("{} | checkpointing bob pre buy swapd state", self.swap_id);
                 if self.state.b_sup_checkpoint_pre_buy() {
                     checkpoint_send(
                         endpoints,
@@ -2424,9 +2411,9 @@ impl Runtime {
                             }
                             tx_label => trace!(
                                 "{} | Tx {} with {} confirmations evokes no response in state {}",
-                                self.swap_id.swap_id(),
-                                tx_label.label(),
-                                confirmations.label(),
+                                self.swap_id,
+                                tx_label,
+                                confirmations,
                                 &self.state
                             ),
                         }

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -125,9 +125,9 @@ impl SyncerState {
         self.tasks.txids.insert(tx_label, txid);
         info!(
             "{} | Watching {} transaction ({})",
-            self.swap_id.bright_blue_italic(),
-            tx_label.bright_white_bold(),
-            txid.bright_yellow_italic()
+            self.swap_id.swap_id(),
+            tx_label.label(),
+            txid.tx_hash()
         );
         let task = Task::WatchTransaction(WatchTransaction {
             id,
@@ -146,9 +146,9 @@ impl SyncerState {
         self.tasks.watched_txs.insert(id, tx_label);
         info!(
             "{} | Watching {} transaction ({})",
-            self.swap_id.bright_blue_italic(),
-            tx_label.bright_white_bold(),
-            hex::encode(&hash).bright_yellow_italic(),
+            self.swap_id.swap_id(),
+            tx_label.label(),
+            hex::encode(&hash).tx_hash(),
         );
         debug!("Watching transaction {} with {}", hex::encode(&hash), id);
         let task = Task::WatchTransaction(WatchTransaction {
@@ -178,9 +178,9 @@ impl SyncerState {
         self.tasks.watched_addrs.insert(id, tx_label);
         info!(
             "{} | Watching address {} for {} transaction",
-            self.swap_id.bright_blue_italic(),
-            address.bright_blue_italic(),
-            tx_label.bright_white_bold(),
+            self.swap_id.swap_id(),
+            address.addr(),
+            tx_label.label(),
         );
         let addendum = BtcAddressAddendum {
             from_height,
@@ -240,9 +240,9 @@ impl SyncerState {
 
         info!(
             "{} | Watching {} on address {}",
-            self.swap_id.bright_blue_italic(),
-            tx_label.bright_white_bold(),
-            address
+            self.swap_id.swap_id(),
+            tx_label.label(),
+            address.addr(),
         );
 
         let watch_addr = WatchAddress {
@@ -352,8 +352,8 @@ impl SyncerState {
             {
                 info!(
                     "{} | Tx {} {} with {} {}",
-                    self.swap_id.bright_blue_italic(),
-                    txlabel.bright_white_bold(),
+                    self.swap_id.swap_id(),
+                    txlabel.label(),
                     "final".bright_green_bold(),
                     confirmations.unwrap().bright_green_bold(),
                     "confirmations".bright_green_bold()
@@ -362,8 +362,8 @@ impl SyncerState {
             } else if self.tasks.final_txs.contains_key(txlabel) {
                 debug!(
                     "{} | Tx {} {} with {} {}",
-                    self.swap_id.bright_blue_italic(),
-                    txlabel.bright_white_bold(),
+                    self.swap_id.swap_id(),
+                    txlabel.label(),
                     "final".bright_green_bold(),
                     confirmations.unwrap().bright_green_bold(),
                     "confirmations".bright_green_bold()
@@ -373,15 +373,15 @@ impl SyncerState {
                     Some(0) => {
                         info!(
                             "{} | Tx {} on mempool but hasn't been mined",
-                            swapid.bright_blue_italic(),
-                            txlabel.bright_white_bold()
+                            swapid.swap_id(),
+                            txlabel.label()
                         );
                     }
                     Some(confs) => {
                         info!(
                             "{} | Tx {} mined with {} {}",
-                            swapid.bright_blue_italic(),
-                            txlabel.bright_white_bold(),
+                            swapid.swap_id(),
+                            txlabel.label(),
                             confs.bright_green_bold(),
                             "confirmations".bright_green_bold(),
                         )
@@ -389,8 +389,8 @@ impl SyncerState {
                     None => {
                         info!(
                             "{} | Tx {} not on the mempool",
-                            swapid.bright_blue_italic(),
-                            txlabel.bright_white_bold()
+                            swapid.swap_id(),
+                            txlabel.label()
                         );
                     }
                 }
@@ -433,17 +433,17 @@ impl SyncerState {
 pub fn log_tx_seen(swap_id: SwapId, txlabel: &TxLabel, txid: &Txid) {
     info!(
         "{} | {} transaction ({}) in mempool or blockchain, forward to walletd",
-        swap_id.bright_blue_italic(),
-        txlabel.bright_white_bold(),
-        txid.bright_yellow_italic(),
+        swap_id.swap_id(),
+        txlabel.label(),
+        txid.tx_hash(),
     );
 }
 
 pub fn log_tx_received(swap_id: SwapId, txlabel: TxLabel) {
     info!(
         "{} | {} transaction received from {}",
-        swap_id.bright_blue_italic(),
-        txlabel.bright_white_bold(),
-        ServiceId::Wallet
+        swap_id.swap_id(),
+        txlabel.label(),
+        ServiceId::Wallet.label(),
     );
 }

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -313,10 +313,7 @@ async fn sweep_address(
             .iter()
             .filter_map(|hash| {
                 let hash_str = hash.to_string();
-                info!(
-                    "Sweep transaction hash: {}",
-                    hash_str.bright_yellow_italic()
-                );
+                info!("Sweep transaction hash: {}", hash_str.tx_hash());
                 hex::decode(hash_str).ok()
             })
             .collect();
@@ -355,7 +352,7 @@ async fn sweep_address(
                 warn!("No associated wallet data cleaned up after sweep. The path used for the wallet directory is probably malformed");
             }
         } else {
-            info!("{}", format!("Completed operations on Monero wallets with address {} . These wallets can now be safely deleted", source_address));
+            info!("Completed operations on Monero wallets with address {}. These wallets can now be safely deleted", source_address.addr());
         }
         Ok(tx_ids)
     } else {
@@ -784,7 +781,7 @@ impl Synclet for MoneroSyncer {
                     monero_rpc_wallet: rpc_wallet.clone(),
                     monero_lws: opts.monero_lws.clone(),
                 };
-                info!("monero syncer servers: {:?}", syncer_servers);
+                debug!("monero syncer servers: {:?}", syncer_servers);
                 let wallet_dir = opts.monero_wallet_dir_path.clone().map(PathBuf::from);
 
                 let _handle = std::thread::spawn(move || {

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -403,21 +403,27 @@ impl SyncerState {
                 self.block_height = h;
                 self.block_hash = block;
                 info!(
-                    "{} incremented height {}",
-                    self.blockchain.bright_white_bold(),
+                    "{} | Incremented height {}",
+                    self.blockchain.label(),
                     &h.bright_blue_bold()
                 );
             }
             (h, b) if h == self.block_height && b != &self.block_hash => {
+                info!(
+                    "{} | New chain tip at {} ({} -> {})",
+                    self.blockchain.label(),
+                    &h.bright_blue_bold(),
+                    format!("{:x?}", &self.block_hash).tx_hash(),
+                    format!("{:x?}", &b).tx_hash(),
+                );
                 self.block_hash = block;
-                info!("{} new chain tip", self.blockchain.bright_white_bold());
             }
             (h, b) if h < self.block_height && b != &self.block_hash => {
                 self.block_height = h;
                 self.block_hash = block;
                 warn!(
-                    "{} height decreased {}, new chain tip",
-                    self.blockchain.bright_white_bold(),
+                    "{} | Height decreased {}, new chain tip",
+                    self.blockchain.label(),
                     &h.bright_blue_bold()
                 );
             }

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -15,7 +15,6 @@ use crate::LogStyle;
 use crate::{CtlServer, Error, Service, ServiceConfig, ServiceId};
 
 use bitcoin::secp256k1::ecdsa::Signature;
-use colored::Colorize;
 use farcaster_core::{
     bitcoin::{
         segwitv0::LockTx,
@@ -340,7 +339,11 @@ impl Runtime {
 
             // errors
             BusMsg::Msg(msg) if req_swap_id.is_some() && Some(msg.swap_id()) != req_swap_id => {
-                error!("Msg and source don't have same swap_id, ignoring...");
+                error!(
+                    "Msg and source don't have same swap id ({} | {}), ignoring...",
+                    msg.swap_id(),
+                    req_swap_id.expect("checked above is some").swap_id()
+                );
                 return Ok(());
             }
             _ => {
@@ -363,7 +366,10 @@ impl Runtime {
             // false`
             BusMsg::Ctl(Ctl::BitcoinAddress(BitcoinAddress(swapid, btc_addr))) => {
                 if self.btc_addrs.insert(swapid, btc_addr).is_some() {
-                    error!("btc_addrs rm accidentally")
+                    error!(
+                        "{} | Bitcoin address replaced accidentally",
+                        swapid.swap_id()
+                    )
                 };
             }
 
@@ -374,7 +380,10 @@ impl Runtime {
             // false`
             BusMsg::Ctl(Ctl::MoneroAddress(MoneroAddress(swapid, xmr_addr))) => {
                 if self.xmr_addrs.insert(swapid, xmr_addr).is_some() {
-                    error!("xmr_addrs rm accidentally")
+                    error!(
+                        "{} | Monero address replaced accidentally",
+                        swapid.swap_id()
+                    )
                 };
             }
             // 1st protocol message received through peer connection, and last
@@ -418,11 +427,7 @@ impl Runtime {
                                         .get_or_derive_bitcoin_key(ArbitratingKeyId::Lock)?,
                                 })),
                             )?;
-                            debug!(
-                                "{} | Loading {}",
-                                swap_id.bright_blue_italic(),
-                                "Wallet::Bob".bright_yellow()
-                            );
+                            info!("{} | Loading {}", swap_id.swap_id(), "Wallet::Bob".label());
                             let local_trade_role = TradeRole::Maker;
                             if let Commit::AliceParameters(remote_commit) = remote_commit.clone() {
                                 let bob_wallet = BobState::new(
@@ -436,7 +441,7 @@ impl Runtime {
                                 );
                                 self.wallets.insert(swap_id, Wallet::Bob(bob_wallet));
                             } else {
-                                error!("{} | Not Commit::Alice", swap_id.bright_blue_italic());
+                                error!("{} | Not Commit::Alice", swap_id.swap_id());
                                 return Ok(());
                             }
                             let launch_swap = LaunchSwap {
@@ -454,7 +459,7 @@ impl Runtime {
                                 BusMsg::Ctl(Ctl::LaunchSwap(launch_swap)),
                             )?;
                         } else {
-                            error!("{} | Wallet already existed", swap_id.bright_blue_italic());
+                            error!("{} | Wallet already existed", swap_id.swap_id());
                         }
                     }
                     SwapRole::Alice => {
@@ -470,10 +475,10 @@ impl Runtime {
                         let local_params =
                             alice.generate_parameters(&mut key_manager, &public_offer)?;
                         if self.wallets.get(&swap_id).is_none() {
-                            debug!(
+                            info!(
                                 "{} | Loading {}",
-                                swap_id.bright_blue_italic(),
-                                "Wallet::Alice".bright_yellow()
+                                swap_id.swap_id(),
+                                "Wallet::Alice".label()
                             );
                             if let Commit::BobParameters(bob_commit) = remote_commit.clone() {
                                 let local_trade_role = TradeRole::Maker;
@@ -502,10 +507,10 @@ impl Runtime {
                                     BusMsg::Ctl(Ctl::LaunchSwap(launch_swap)),
                                 )?;
                             } else {
-                                error!("{} | Not Commit::Bob", swap_id.bright_blue_italic());
+                                error!("{} | Not Commit::Bob", swap_id.swap_id());
                             }
                         } else {
-                            error!("{} | Wallet already existed", swap_id.bright_blue_italic());
+                            error!("{} | Wallet already existed", swap_id.swap_id());
                         }
                     }
                 }
@@ -520,10 +525,7 @@ impl Runtime {
                         })) = self.wallets.get_mut(&swap_id)
                         {
                             if remote_commit.is_some() {
-                                error!(
-                                    "{} | Bob commit (remote) already set",
-                                    swap_id.bright_blue_italic(),
-                                );
+                                error!("{} | Bob commit (remote) already set", swap_id.swap_id(),);
                             } else if let Commit::BobParameters(commit) = commit {
                                 trace!("Setting bob commit");
                                 *remote_commit = Some(commit);
@@ -531,7 +533,7 @@ impl Runtime {
                         } else {
                             error!(
                                 "{} | Wallet not found or not on correct state",
-                                swap_id.bright_blue_italic(),
+                                swap_id.swap_id(),
                             );
                             return Ok(());
                         }
@@ -543,10 +545,7 @@ impl Runtime {
                         })) = self.wallets.get_mut(&swap_id)
                         {
                             if remote_commit_params.is_some() {
-                                error!(
-                                    "{} | Alice commit (remote) already set",
-                                    swap_id.bright_blue_italic(),
-                                );
+                                error!("{} | Alice commit (remote) already set", swap_id.swap_id(),);
                             } else if let Commit::AliceParameters(commit) = commit {
                                 trace!("Setting alice commit");
                                 *remote_commit_params = Some(commit);
@@ -554,7 +553,7 @@ impl Runtime {
                         } else {
                             error!(
                                 "{} | Wallet not found or not on correct state",
-                                swap_id.bright_blue_italic(),
+                                swap_id.swap_id(),
                             );
                             return Ok(());
                         }
@@ -594,7 +593,7 @@ impl Runtime {
                     })) => *remote_proof = Some(proof.proof),
                     None => error!(
                         "{} | wallet for specified swap does not exist",
-                        swap_id.bright_blue_italic(),
+                        swap_id.swap_id(),
                     ),
                 }
             }
@@ -615,8 +614,8 @@ impl Runtime {
                         {
                             if let Some(remote_params) = remote_params {
                                 error!(
-                                    "{} | bob_params were previously set to: {:#?}",
-                                    swap_id.bright_blue_italic(),
+                                    "{} | bob_params were previously set to: {:?}",
+                                    swap_id.swap_id(),
                                     remote_params
                                 );
                             } else {
@@ -631,7 +630,7 @@ impl Runtime {
                                 );
 
                                 if proof_verification.is_err() {
-                                    error!("{} | DLEQ proof invalid", swap_id.bright_blue_italic());
+                                    error!("{} | DLEQ proof invalid", swap_id.swap_id());
                                     return Ok(());
                                 }
                                 *remote_params = Some(remote_params_candidate);
@@ -654,10 +653,7 @@ impl Runtime {
                                 // CoreArbitratingSetup to proceed
                             }
                         } else {
-                            error!(
-                                "{} | only Some(Wallet::Alice)",
-                                swap_id.bright_blue_italic(),
-                            );
+                            error!("{} | only Some(Wallet::Alice)", swap_id.swap_id(),);
                         }
                         return Ok(());
                     }
@@ -680,10 +676,7 @@ impl Runtime {
                         {
                             // set wallet params
                             if remote_params.is_some() {
-                                error!(
-                                    "{} | Alice params already set",
-                                    swap_id.bright_blue_italic(),
-                                );
+                                error!("{} | Alice params already set", swap_id.swap_id(),);
                                 return Ok(());
                             }
 
@@ -696,7 +689,7 @@ impl Runtime {
                             );
 
                             if proof_verification.is_err() {
-                                error!("{} | DLEQ proof invalid", swap_id.bright_blue_italic());
+                                error!("{} | DLEQ proof invalid", swap_id.swap_id());
                                 return Ok(());
                             }
                             *remote_params = Some(remote_params_candidate);
@@ -750,14 +743,11 @@ impl Runtime {
 
                             // set wallet core_arb_txs
                             if core_arb_setup.is_some() {
-                                error!(
-                                    "{} | Core Arb Txs already set",
-                                    swap_id.bright_blue_italic(),
-                                );
+                                error!("{} | Core Arb Txs already set", swap_id.swap_id(),);
                                 return Ok(());
                             }
                             if !funding_tx.was_seen() {
-                                error!("{} | Funding not yet seen", swap_id.bright_blue_italic());
+                                error!("{} | Funding not yet seen", swap_id.swap_id());
                                 return Ok(());
                             }
                             // FIXME should be set before
@@ -778,7 +768,7 @@ impl Runtime {
 
                             self.send_ctl(endpoints, source, BusMsg::Msg(core_arb_setup_msg))?;
                         } else {
-                            error!("{} | only Some(Wallet::Bob)", swap_id.bright_blue_italic());
+                            error!("{} | only Some(Wallet::Bob)", swap_id.swap_id());
                         }
                     }
                     Reveal::Proof(reveal) => {
@@ -809,28 +799,22 @@ impl Runtime {
                                         if verification_result.is_ok() {
                                             *remote_proof = Some(reveal.proof);
                                         } else {
-                                            error!(
-                                                "{} | DLEQ proof invalid",
-                                                swap_id.bright_blue_italic(),
-                                            )
+                                            error!("{} | DLEQ proof invalid", swap_id.swap_id(),)
                                         }
                                     }
                                     (None, Some(_)) => {
-                                        error!(
-                                            "{} | already set DLEQ proof",
-                                            swap_id.bright_blue_italic(),
-                                        )
+                                        error!("{} | Already set DLEQ proof", swap_id.swap_id(),)
                                     }
                                     (Some(_), Some(_)) => {
                                         error!(
-                                            "{} | already set DLEQ proof and parameters",
-                                            swap_id.bright_blue_italic(),
+                                            "{} | Already set DLEQ proof and parameters",
+                                            swap_id.swap_id(),
                                         )
                                     }
                                 };
                             }
                             None => {
-                                error!("{} | only Some(Wallet::_)", swap_id.bright_blue_italic());
+                                error!("{} | only Some(Wallet::_)", swap_id.swap_id());
                             }
                         }
                     }
@@ -869,7 +853,7 @@ impl Runtime {
                     )?;
 
                     if adaptor_buy.is_some() {
-                        error!("{} | adaptor_buy already set", swap_id.bright_blue_italic());
+                        error!("{} | adaptor_buy already set", swap_id.swap_id());
                         return Ok(());
                     }
                     *adaptor_buy = Some(bob.sign_adaptor_buy(
@@ -977,11 +961,7 @@ impl Runtime {
                         )?;
                     }
                 } else {
-                    error!(
-                        "{:#} | Unknown wallet and swap_id {:#}",
-                        swap_id.bright_blue_italic(),
-                        swap_id.bright_white_bold(),
-                    );
+                    error!("{} | Unknown wallet and swap_id", swap_id.swap_id(),);
                 }
             }
             BusMsg::Msg(Msg::CoreArbitratingSetup(core_arbitrating_setup)) => {
@@ -1003,16 +983,13 @@ impl Runtime {
                 })) = self.wallets.get_mut(&swap_id)
                 {
                     if core_arb_setup.is_some() {
-                        error!(
-                            "{} | core_arb_txs already set for alice",
-                            swap_id.bright_blue_italic(),
-                        );
+                        error!("{} | core_arb_txs already set for alice", swap_id.swap_id(),);
                         return Ok(());
                     }
                     if alice_cancel_signature.is_some() {
                         error!(
                             "{} | alice_cancel_sig already set for alice",
-                            swap_id.bright_blue_italic(),
+                            swap_id.swap_id(),
                         );
                         return Ok(());
                     }
@@ -1125,10 +1102,7 @@ impl Runtime {
                         BusMsg::Msg(refund_proc_signatures),
                     )?
                 } else {
-                    error!(
-                        "{} | only Some(Wallet::Alice)",
-                        swap_id.bright_blue_italic(),
-                    );
+                    error!("{} | only Some(Wallet::Alice)", swap_id.swap_id(),);
                 }
             }
             BusMsg::Msg(Msg::BuyProcedureSignature(buy_proc_sig)) => {
@@ -1151,11 +1125,7 @@ impl Runtime {
                         }),
                     )?;
                 } else {
-                    error!(
-                        "{:#} | Unknown wallet and swap_id {:#}",
-                        swap_id.bright_blue_italic(),
-                        swap_id.bright_white_bold(),
-                    );
+                    error!("{} | Unknown wallet and swap_id", swap_id.swap_id(),);
                 };
 
                 if let Some(Wallet::Alice(AliceState {
@@ -1219,15 +1189,12 @@ impl Runtime {
 
                     // buy_adaptor_sig
                 } else {
-                    error!(
-                        "{} | could not get alice's wallet",
-                        swap_id.bright_blue_italic(),
-                    )
+                    error!("{} | could not get alice's wallet", swap_id.swap_id(),)
                 }
             }
             req => {
                 error!(
-                    "MSG RPC can only be used for forwarding farcaster protocol messages, found {:?}, {:#?}",
+                    "MSG RPC can only be used for forwarding farcaster protocol messages, found {:?}, {:?}",
                     req.to_string(), req
                 )
             }
@@ -1294,11 +1261,7 @@ impl Runtime {
                                     .get_or_derive_bitcoin_key(ArbitratingKeyId::Lock)?,
                             })),
                         )?;
-                        debug!(
-                            "{} | Loading {}",
-                            swap_id.bright_blue_italic(),
-                            "Wallet::Bob".bright_yellow()
-                        );
+                        info!("{} | Loading {}", swap_id.swap_id(), "Wallet::Bob".label());
                         let local_trade_role = TradeRole::Taker;
                         if self.wallets.get(&swap_id).is_none() {
                             let local_wallet = BobState::new(
@@ -1312,7 +1275,7 @@ impl Runtime {
                             );
                             self.wallets.insert(swap_id, Wallet::Bob(local_wallet));
                         } else {
-                            error!("{} | Wallet already exists", swap_id.bright_blue_italic());
+                            error!("{} | Wallet already exists", swap_id.swap_id());
                             return Ok(());
                         }
                         let launch_swap = LaunchSwap {
@@ -1346,10 +1309,7 @@ impl Runtime {
                         if self.wallets.get(&swap_id).is_none() {
                             // TODO instead of storing in state, start building
                             // requests and store the state in there directly
-                            debug!(
-                                "{} | Loading Alice Taker's Wallet",
-                                swap_id.bright_blue_italic()
-                            );
+                            info!("{} | Loading Alice Taker's Wallet", swap_id.swap_id());
                             let wallet = AliceState::new(
                                 alice,
                                 local_trade_role,
@@ -1360,7 +1320,7 @@ impl Runtime {
                             );
                             self.wallets.insert(swap_id, Wallet::Alice(wallet));
                         } else {
-                            error!("{} | Wallet already exists", swap_id.bright_blue_italic());
+                            error!("{} | Wallet already exists", swap_id.swap_id());
                         }
                         let launch_swap = LaunchSwap {
                             local_trade_role,
@@ -1389,15 +1349,15 @@ impl Runtime {
                 {
                     if funding.was_seen() {
                         warn!(
-                            "{} | funding was previously updated, ignoring",
-                            swap_id.bright_blue_italic(),
+                            "{} | Funding was previously updated, ignoring",
+                            swap_id.swap_id(),
                         );
                         return Ok(());
                     }
                     funding_update(funding, tx)?;
                     debug!(
                         "{} | bob's wallet informs swapd that funding was successfully updated",
-                        swap_id.bright_blue_italic(),
+                        swap_id,
                     );
                     endpoints.send_to(
                         ServiceBus::Ctl,
@@ -1433,7 +1393,7 @@ impl Runtime {
                     info!(
                         "{} | Extracted monero key from Buy tx: {}",
                         swap_id.swap_id(),
-                        sk_a.bright_white_bold()
+                        sk_a.label()
                     );
                     let sk_b = key_manager.get_or_derive_monero_spend_key()?;
                     let spend = sk_a + sk_b;
@@ -1527,7 +1487,7 @@ impl Runtime {
                     info!(
                         "{} | Extracted monero key from Refund tx: {}",
                         swap_id.swap_id(),
-                        sk_b.bright_white_bold()
+                        sk_b.label()
                     );
 
                     let sk_a = key_manager.get_or_derive_monero_spend_key()?;
@@ -1661,22 +1621,24 @@ impl Runtime {
                 self.clean_up_after_swap(&swap_id);
             }
 
-            BusMsg::Ctl(Ctl::Checkpoint(Checkpoint { swap_id, state })) => {
-                match state {
-                    CheckpointState::CheckpointWallet(CheckpointWallet { wallet, xmr_addr }) => {
-                        info!("{} | Restoring wallet for swap", swap_id.swap_id());
-                        if !self.wallets.contains_key(&swap_id) {
-                            self.wallets.insert(swap_id, wallet);
-                        } else {
-                            warn!("Did not restore full wallet, a wallet with this key already exists.");
-                        }
-                        self.xmr_addrs.insert(swap_id, xmr_addr);
+            BusMsg::Ctl(Ctl::Checkpoint(Checkpoint { swap_id, state })) => match state {
+                CheckpointState::CheckpointWallet(CheckpointWallet { wallet, xmr_addr }) => {
+                    info!("{} | Restoring wallet for swap", swap_id.swap_id());
+                    if !self.wallets.contains_key(&swap_id) {
+                        self.wallets.insert(swap_id, wallet);
+                    } else {
+                        warn!("{} | Did not restore full wallet, a wallet with this key already exists.", swap_id.swap_id());
                     }
-                    s => {
-                        error!("Checkpoint {} not supported in walletd", s);
-                    }
+                    self.xmr_addrs.insert(swap_id, xmr_addr);
                 }
-            }
+                s => {
+                    error!(
+                        "{} | Checkpoint {} not supported in walletd",
+                        swap_id.swap_id(),
+                        s
+                    );
+                }
+            },
 
             _ => {
                 error!("BusMsg {:?} is not supported by the CTL interface", request);

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -1432,14 +1432,14 @@ impl Runtime {
                         .expect("Valid Monero Private Key");
                     info!(
                         "{} | Extracted monero key from Buy tx: {}",
-                        swap_id.bright_blue_italic(),
-                        sk_a.bright_white_italic()
+                        swap_id.swap_id(),
+                        sk_a.bright_white_bold()
                     );
                     let sk_b = key_manager.get_or_derive_monero_spend_key()?;
                     let spend = sk_a + sk_b;
                     info!(
                         "{} | Full secret monero spending key: {}",
-                        swap_id.bright_blue_italic(),
+                        swap_id.swap_id(),
                         spend.bright_green_bold()
                     );
                     let view_key_alice = *alice_params
@@ -1460,7 +1460,7 @@ impl Runtime {
                     let view = view_key_alice + view_key_bob;
                     info!(
                         "{} | Full secret monero view key: {}",
-                        swap_id.bright_blue_italic(),
+                        swap_id.swap_id(),
                         view.bright_green_bold()
                     );
                     let network = pub_offer.offer.network.into();
@@ -1468,8 +1468,8 @@ impl Runtime {
                     let corresponding_address = monero::Address::from_keypair(network, &keypair);
                     info!(
                         "{} | Corresponding address: {}",
-                        swap_id.bright_blue_italic(),
-                        corresponding_address
+                        swap_id.swap_id(),
+                        corresponding_address.addr()
                     );
                     let address = self
                         .xmr_addrs
@@ -1526,15 +1526,15 @@ impl Runtime {
                         .expect("Valid Monero Private Key");
                     info!(
                         "{} | Extracted monero key from Refund tx: {}",
-                        swap_id.bright_blue_italic(),
-                        sk_b.bright_white_italic()
+                        swap_id.swap_id(),
+                        sk_b.bright_white_bold()
                     );
 
                     let sk_a = key_manager.get_or_derive_monero_spend_key()?;
                     let spend = sk_a + sk_b;
                     info!(
                         "{} | Full secret monero spending key: {}",
-                        swap_id.bright_blue_italic(),
+                        swap_id.swap_id(),
                         spend.bright_green_bold()
                     );
 
@@ -1556,7 +1556,7 @@ impl Runtime {
                     let view = view_key_alice + view_key_bob;
                     info!(
                         "{} | Full secret monero view key: {}",
-                        swap_id.bright_blue_italic(),
+                        swap_id.swap_id(),
                         view.bright_green_bold()
                     );
                     let network = pub_offer.offer.network.into();
@@ -1564,8 +1564,8 @@ impl Runtime {
                     let corresponding_address = monero::Address::from_keypair(network, &keypair);
                     info!(
                         "{} | Corresponding address: {}",
-                        swap_id.bright_blue_italic(),
-                        corresponding_address
+                        swap_id.swap_id(),
+                        corresponding_address.addr()
                     );
                     let address = self
                         .xmr_addrs
@@ -1654,10 +1654,9 @@ impl Runtime {
                     _ => success.err(),
                 };
                 info!(
-                    "{} | {} in swap {}, cleaning up data",
-                    swap_id.bright_blue_italic(),
+                    "{} | {} in swap, cleaning up data",
+                    swap_id.swap_id(),
                     &success,
-                    &swap_id.bright_blue_italic(),
                 );
                 self.clean_up_after_swap(&swap_id);
             }
@@ -1665,7 +1664,7 @@ impl Runtime {
             BusMsg::Ctl(Ctl::Checkpoint(Checkpoint { swap_id, state })) => {
                 match state {
                     CheckpointState::CheckpointWallet(CheckpointWallet { wallet, xmr_addr }) => {
-                        info!("Restoring wallet for swap {}", swap_id);
+                        info!("{} | Restoring wallet for swap", swap_id.swap_id());
                         if !self.wallets.contains_key(&swap_id) {
                             self.wallets.insert(swap_id, wallet);
                         } else {


### PR DESCRIPTION
Based on #707

Rework some logs to add uniformity and standardize the code to apply colors.

TODO

- [x] replace '<>' by '…' in trade machine logs when no id found