### PR TITLE
Feat: improve swap-cli commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,6 +1266,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde 1.0.141",
+]
 
 [[package]]
 name = "hex-literal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ dotenv = { version = "0.15", optional = true }
 electrum-client = "0.11.0"
 env_logger = "0.7"
 farcaster_core = "0.5.1"
-hex = "^0.4.3"
+hex = { version = "^0.4.3", features = ["serde"] }
 internet2 = "0.8.3"
 lazy_static = "1.4"
 lmdb = "0.8.0"

--- a/src/bus/rpc.rs
+++ b/src/bus/rpc.rs
@@ -13,6 +13,7 @@ use crate::bus::{
     AddressSecretKey, CheckpointEntry, Failure, List, OfferStatusPair, OptionDetails, Progress,
 };
 use crate::cli::OfferSelector;
+use crate::farcasterd::stats::Stats;
 
 #[derive(Clone, Debug, Display, From, NetworkEncode, NetworkDecode)]
 #[non_exhaustive]
@@ -238,6 +239,8 @@ pub struct NodeInfo {
     pub swaps: Vec<SwapId>,
     #[serde_as(as = "Vec<DisplayFromStr>")]
     pub offers: Vec<PublicOffer>,
+    #[serde(alias = "statistics")]
+    pub stats: Stats,
 }
 
 #[cfg_attr(feature = "serde", serde_as)]

--- a/src/bus/rpc.rs
+++ b/src/bus/rpc.rs
@@ -214,6 +214,7 @@ impl StrictDecode for TookOffer {
 )]
 #[display(SyncerInfo::to_yaml_string)]
 pub struct SyncerInfo {
+    pub syncer: String,
     #[serde_as(as = "DurationSeconds")]
     pub uptime: Duration,
     pub since: u64,

--- a/src/bus/rpc.rs
+++ b/src/bus/rpc.rs
@@ -14,6 +14,7 @@ use crate::bus::{
 };
 use crate::cli::OfferSelector;
 use crate::farcasterd::stats::Stats;
+use crate::syncerd::runtime::SyncerdTask;
 
 #[derive(Clone, Debug, Display, From, NetworkEncode, NetworkDecode)]
 #[non_exhaustive]
@@ -124,7 +125,7 @@ pub enum Rpc {
     // - ListTasks section
     #[display(inner)]
     #[from]
-    TaskList(List<u64>),
+    TaskList(List<SyncerdTask>),
     // - End ListTasks section
 
     // - ListOffers section
@@ -206,7 +207,7 @@ impl StrictDecode for TookOffer {
 }
 
 #[cfg_attr(feature = "serde", serde_as)]
-#[derive(Clone, PartialEq, Eq, Debug, Display, NetworkEncode, NetworkDecode)]
+#[derive(Clone, Debug, Display, NetworkEncode, NetworkDecode)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -218,8 +219,7 @@ pub struct SyncerInfo {
     #[serde_as(as = "DurationSeconds")]
     pub uptime: Duration,
     pub since: u64,
-    #[serde_as(as = "Vec<DisplayFromStr>")]
-    pub tasks: Vec<u64>,
+    pub tasks: Vec<SyncerdTask>,
 }
 
 #[cfg_attr(feature = "serde", serde_as)]

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -104,6 +104,14 @@ impl Exec for Command {
                 runtime.report_response_or_fail()?;
             }
 
+            Command::ListTasks {
+                blockchain,
+                network,
+            } => {
+                runtime.request_rpc(ServiceId::Syncer(blockchain, network), Rpc::ListTasks)?;
+                runtime.report_response_or_fail()?;
+            }
+
             Command::ListListens => {
                 runtime.request_rpc(ServiceId::Farcasterd, Rpc::ListListens)?;
                 runtime.report_response_or_fail()?;

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -25,7 +25,12 @@ use microservices::shell::Exec;
 use clap::IntoApp;
 use clap_complete::generate;
 use clap_complete::shells::*;
-use farcaster_core::{blockchain::Network, negotiation::PublicOffer, role::SwapRole, swap::SwapId};
+use farcaster_core::{
+    blockchain::{Blockchain, Network},
+    negotiation::PublicOffer,
+    role::SwapRole,
+    swap::SwapId,
+};
 
 use super::Command;
 use crate::bus::BusMsg;
@@ -44,29 +49,37 @@ impl Exec for Command {
         debug!("Performing {:?}: {}", self, self);
         match self {
             Command::Info { subject } => {
-                if let Some(subj) = subject {
-                    if let Ok(node_addr) = NodeAddr::from_str(&subj) {
-                        runtime.request_rpc(ServiceId::Peer(node_addr), Rpc::GetInfo)?;
-                    } else if let Ok(swap_id) = SwapId::from_str(&subj) {
-                        runtime.request_rpc(ServiceId::Swap(swap_id), Rpc::GetInfo)?;
-                    } else {
-                        let err = format!(
-                            "{}",
-                            "Subject parameter must be either remote node \
-                            address or swap id"
-                                .err()
-                        );
-                        return Err(Error::Other(err));
+                let err = format!(
+                    "{}",
+                    "Subject parameter must be either remote node address, swap id, or syncer"
+                        .err()
+                );
+                match subject.len() {
+                    0 => runtime.request_rpc(ServiceId::Farcasterd, Rpc::GetInfo)?,
+                    1 => {
+                        let subj = subject.get(0).expect("vec of lenght 1");
+                        if let Ok(node_addr) = NodeAddr::from_str(&subj) {
+                            runtime.request_rpc(ServiceId::Peer(node_addr), Rpc::GetInfo)?;
+                        } else if let Ok(swap_id) = SwapId::from_str(&subj) {
+                            runtime.request_rpc(ServiceId::Swap(swap_id), Rpc::GetInfo)?;
+                        } else {
+                            return Err(Error::Other(err));
+                        }
                     }
-                } else {
-                    // subject is none
-                    runtime.request_rpc(ServiceId::Farcasterd, Rpc::GetInfo)?;
+                    2 => {
+                        let blockchain =
+                            Blockchain::from_str(&subject.get(0).expect("vec of lenght 2"))?;
+                        let network = Network::from_str(&subject.get(1).expect("vec of lenght 2"))?;
+                        runtime
+                            .request_rpc(ServiceId::Syncer(blockchain, network), Rpc::GetInfo)?;
+                    }
+                    _ => return Err(Error::Other(err)),
                 }
                 match runtime.response()? {
                     BusMsg::Rpc(Rpc::NodeInfo(info)) => println!("{}", info),
                     BusMsg::Rpc(Rpc::PeerInfo(info)) => println!("{}", info),
                     BusMsg::Rpc(Rpc::SwapInfo(info)) => println!("{}", info),
-                    // TODO add syncer info
+                    BusMsg::Rpc(Rpc::SyncerInfo(info)) => println!("{}", info),
                     _ => {
                         return Err(Error::Other(
                             "Server returned unrecognizable response".to_string(),

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -51,8 +51,9 @@ pub enum Command {
     /// General information about the running node
     #[display("info<{subject:?}>")]
     Info {
-        /// Remote peer address or swap id. If absent, returns information about the node itself
-        subject: Option<String>,
+        /// Remote peer address, swap id, or blockchain and network. If absent, returns information
+        /// about the node itself
+        subject: Vec<String>,
     },
 
     /// Lists existing peer connections

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -51,8 +51,7 @@ pub enum Command {
     /// General information about the running node
     #[display("info<{subject:?}>")]
     Info {
-        /// Remote peer address or temporary/permanent/short channel id. If
-        /// absent, returns information about the node itself
+        /// Remote peer address or swap id. If absent, returns information about the node itself
         subject: Option<String>,
     },
 

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -87,6 +87,16 @@ pub enum Command {
     #[clap(aliases = &["ll"])]
     ListListens,
 
+    /// Lists tasks currently treated by a syncer
+    #[clap(aliases = &["lt"])]
+    ListTasks {
+        /// The blockchain for which we want to list the tasks
+        blockchain: Blockchain,
+
+        /// The network for which we want to list the tasks
+        network: Network,
+    },
+
     /// Lists saved checkpoints of the swaps
     #[clap(aliases = &["lc"])]
     ListCheckpoints,

--- a/src/farcasterd/mod.rs
+++ b/src/farcasterd/mod.rs
@@ -15,6 +15,7 @@
 #[cfg(feature = "shell")]
 mod opts;
 mod runtime;
+pub mod stats;
 mod syncer_state_machine;
 mod trade_state_machine;
 

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -21,12 +21,13 @@ use crate::bus::{BusMsg, List, ServiceBus};
 use crate::event::StateMachineExecutor;
 use crate::farcasterd::syncer_state_machine::{SyncerStateMachine, SyncerStateMachineExecutor};
 use crate::farcasterd::trade_state_machine::{TradeStateMachine, TradeStateMachineExecutor};
+use crate::farcasterd::stats::Stats;
 use crate::farcasterd::Opts;
 use crate::syncerd::{Event as SyncerEvent, SweepSuccess, TaskId};
 use crate::{
     bus::ctl::{Keys, LaunchSwap, ProgressStack, Token},
     bus::rpc::{OfferInfo, OfferStatusSelector, ProgressEvent, Rpc, SwapProgress},
-    bus::{Failure, FailureCode, Outcome, Progress},
+    bus::{Failure, FailureCode, Progress},
     clap::Parser,
     error::SyncerError,
     service::Endpoints,
@@ -126,130 +127,6 @@ pub struct Runtime {
 }
 
 impl CtlServer for Runtime {}
-
-#[derive(Default)]
-pub struct Stats {
-    success: u64,
-    refund: u64,
-    punish: u64,
-    abort: u64,
-    initialized: u64,
-    awaiting_funding_btc: HashSet<SwapId>,
-    awaiting_funding_xmr: HashSet<SwapId>,
-    funded_xmr: u64,
-    funded_btc: u64,
-    funding_canceled_xmr: u64,
-    funding_canceled_btc: u64,
-}
-
-impl Stats {
-    pub fn incr_outcome(&mut self, outcome: &Outcome) {
-        match outcome {
-            Outcome::Buy => self.success += 1,
-            Outcome::Refund => self.refund += 1,
-            Outcome::Punish => self.punish += 1,
-            Outcome::Abort => self.abort += 1,
-        };
-    }
-
-    pub fn incr_initiated(&mut self) {
-        self.initialized += 1;
-    }
-
-    pub fn incr_awaiting_funding(&mut self, blockchain: &Blockchain, swapid: SwapId) {
-        let newly_inserted = match blockchain {
-            Blockchain::Monero => self.awaiting_funding_xmr.insert(swapid),
-            Blockchain::Bitcoin => self.awaiting_funding_btc.insert(swapid),
-        };
-        if !newly_inserted {
-            warn!(
-                "{} | This swap was already in awaiting {} funding",
-                swapid.bright_blue_italic(),
-                blockchain.bright_white_bold()
-            );
-        }
-    }
-
-    pub fn incr_funded(&mut self, blockchain: &Blockchain, swapid: &SwapId) {
-        let present_in_set = match blockchain {
-            Blockchain::Monero => {
-                self.funded_xmr += 1;
-                self.awaiting_funding_xmr.remove(swapid)
-            }
-            Blockchain::Bitcoin => {
-                self.funded_btc += 1;
-                self.awaiting_funding_btc.remove(swapid)
-            }
-        };
-        if !present_in_set {
-            warn!(
-                "{} | This swap wasn't awaiting {} funding",
-                swapid.bright_blue_italic(),
-                "Bitcoin".bright_white_bold()
-            );
-        }
-    }
-
-    pub fn incr_funding_canceled(&mut self, blockchain: &Blockchain, swapid: &SwapId) {
-        let present_in_set = match blockchain {
-            Blockchain::Monero => {
-                let presence = self.awaiting_funding_xmr.remove(swapid);
-                self.funding_canceled_xmr += 1;
-                presence
-            }
-            Blockchain::Bitcoin => {
-                let presence = self.awaiting_funding_btc.remove(swapid);
-                self.funding_canceled_btc += 1;
-                presence
-            }
-        };
-        if !present_in_set {
-            warn!(
-                "{} | This swap wasn't awaiting {} funding",
-                swapid.bright_blue_italic(),
-                "Bitcoin".bright_white_bold()
-            );
-        }
-    }
-
-    pub fn success_rate(&self) -> f64 {
-        let Stats {
-            success,
-            refund,
-            punish,
-            abort,
-            initialized,
-            awaiting_funding_btc,
-            awaiting_funding_xmr,
-            funded_btc,
-            funded_xmr,
-            funding_canceled_xmr,
-            funding_canceled_btc,
-        } = self;
-        let total = success + refund + punish + abort;
-        let rate = *success as f64 / (total as f64);
-        info!(
-            "Swapped({}) | Refunded({}) / Punished({}) | Aborted({}) | Initialized({}) / AwaitingFundingXMR({}) / AwaitingFundingBTC({}) / FundedXMR({}) / FundedBTC({}) / FundingCanceledXMR({}) / FundingCanceledBTC({})",
-            success.bright_white_bold(),
-            refund.bright_white_bold(),
-            punish.bright_white_bold(),
-            abort.bright_white_bold(),
-            initialized,
-            awaiting_funding_xmr.len().bright_white_bold(),
-            awaiting_funding_btc.len().bright_white_bold(),
-            funded_xmr.bright_white_bold(),
-            funded_btc.bright_white_bold(),
-            funding_canceled_xmr.bright_white_bold(),
-            funding_canceled_btc.bright_white_bold(),
-        );
-        info!(
-            "{} = {:>4.3}%",
-            "Swap success".bright_blue_bold(),
-            (rate * 100.).bright_yellow_bold(),
-        );
-        rate
-    }
-}
 
 impl esb::Handler<ServiceBus> for Runtime {
     type Request = BusMsg;
@@ -502,6 +379,7 @@ impl Runtime {
                             .iter()
                             .filter_map(|tsm| tsm.open_offer())
                             .collect(),
+                        stats: self.stats.clone(),
                     }),
                 )?;
             }

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -19,9 +19,9 @@ use crate::bus::rpc::NodeInfo;
 use crate::bus::sync::SyncMsg;
 use crate::bus::{BusMsg, List, ServiceBus};
 use crate::event::StateMachineExecutor;
+use crate::farcasterd::stats::Stats;
 use crate::farcasterd::syncer_state_machine::{SyncerStateMachine, SyncerStateMachineExecutor};
 use crate::farcasterd::trade_state_machine::{TradeStateMachine, TradeStateMachineExecutor};
-use crate::farcasterd::stats::Stats;
 use crate::farcasterd::Opts;
 use crate::syncerd::{Event as SyncerEvent, SweepSuccess, TaskId};
 use crate::{

--- a/src/farcasterd/stats.rs
+++ b/src/farcasterd/stats.rs
@@ -1,0 +1,137 @@
+use std::collections::HashSet;
+
+use farcaster_core::{blockchain::Blockchain, swap::SwapId};
+use strict_encoding::{NetworkDecode, NetworkEncode};
+
+use crate::bus::Outcome;
+use crate::LogStyle;
+
+#[cfg_attr(feature = "serde", serde_as)]
+#[derive(Default, Clone, PartialEq, Eq, Debug, NetworkEncode, NetworkDecode)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
+pub struct Stats {
+    success: u64,
+    refund: u64,
+    punish: u64,
+    abort: u64,
+    initialized: u64,
+    awaiting_funding_btc: HashSet<SwapId>,
+    awaiting_funding_xmr: HashSet<SwapId>,
+    funded_xmr: u64,
+    funded_btc: u64,
+    funding_canceled_xmr: u64,
+    funding_canceled_btc: u64,
+}
+
+impl Stats {
+    pub fn incr_outcome(&mut self, outcome: &Outcome) {
+        match outcome {
+            Outcome::Buy => self.success += 1,
+            Outcome::Refund => self.refund += 1,
+            Outcome::Punish => self.punish += 1,
+            Outcome::Abort => self.abort += 1,
+        };
+    }
+
+    pub fn incr_initiated(&mut self) {
+        self.initialized += 1;
+    }
+
+    pub fn incr_awaiting_funding(&mut self, blockchain: &Blockchain, swapid: SwapId) {
+        let newly_inserted = match blockchain {
+            Blockchain::Monero => self.awaiting_funding_xmr.insert(swapid),
+            Blockchain::Bitcoin => self.awaiting_funding_btc.insert(swapid),
+        };
+        if !newly_inserted {
+            warn!(
+                "{} | This swap was already in awaiting {} funding",
+                swapid.bright_blue_italic(),
+                blockchain.bright_white_bold()
+            );
+        }
+    }
+
+    pub fn incr_funded(&mut self, blockchain: &Blockchain, swapid: &SwapId) {
+        let present_in_set = match blockchain {
+            Blockchain::Monero => {
+                self.funded_xmr += 1;
+                self.awaiting_funding_xmr.remove(swapid)
+            }
+            Blockchain::Bitcoin => {
+                self.funded_btc += 1;
+                self.awaiting_funding_btc.remove(swapid)
+            }
+        };
+        if !present_in_set {
+            warn!(
+                "{} | This swap wasn't awaiting {} funding",
+                swapid.bright_blue_italic(),
+                "Bitcoin".bright_white_bold()
+            );
+        }
+    }
+
+    pub fn incr_funding_canceled(&mut self, blockchain: &Blockchain, swapid: &SwapId) {
+        let present_in_set = match blockchain {
+            Blockchain::Monero => {
+                let presence = self.awaiting_funding_xmr.remove(swapid);
+                self.funding_canceled_xmr += 1;
+                presence
+            }
+            Blockchain::Bitcoin => {
+                let presence = self.awaiting_funding_btc.remove(swapid);
+                self.funding_canceled_btc += 1;
+                presence
+            }
+        };
+        if !present_in_set {
+            warn!(
+                "{} | This swap wasn't awaiting {} funding",
+                swapid.bright_blue_italic(),
+                "Bitcoin".bright_white_bold()
+            );
+        }
+    }
+
+    pub fn success_rate(&self) -> f64 {
+        let Stats {
+            success,
+            refund,
+            punish,
+            abort,
+            initialized,
+            awaiting_funding_btc,
+            awaiting_funding_xmr,
+            funded_btc,
+            funded_xmr,
+            funding_canceled_xmr,
+            funding_canceled_btc,
+        } = self;
+        let total = success + refund + punish + abort;
+        let rate = *success as f64 / (total as f64);
+        info!(
+            "Swapped({}) | Refunded({}) / Punished({}) | Aborted({}) | Initialized({}) / AwaitingFundingXMR({}) / AwaitingFundingBTC({}) / FundedXMR({}) / FundedBTC({}) / FundingCanceledXMR({}) / FundingCanceledBTC({})",
+            success.bright_white_bold(),
+            refund.bright_white_bold(),
+            punish.bright_white_bold(),
+            abort.bright_white_bold(),
+            initialized,
+            awaiting_funding_xmr.len().bright_white_bold(),
+            awaiting_funding_btc.len().bright_white_bold(),
+            funded_xmr.bright_white_bold(),
+            funded_btc.bright_white_bold(),
+            funding_canceled_xmr.bright_white_bold(),
+            funding_canceled_btc.bright_white_bold(),
+        );
+        info!(
+            "{} = {:>4.3}%",
+            "Swap success".bright_blue_bold(),
+            (rate * 100.).bright_yellow_bold(),
+        );
+        rate
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -61,6 +61,11 @@ lazy_static! {
     StrictEncode,
     StrictDecode,
 )]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct ClientName([u8; 32]);
 
 impl Display for ClientName {
@@ -122,6 +127,11 @@ impl From<Opts> for ServiceConfig {
 
 /// Identifiers of daemons participating in LNP Node
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Display, From, StrictEncode, StrictDecode)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub enum ServiceId {
     #[display("loopback")]
     Loopback,

--- a/src/syncerd/runtime.rs
+++ b/src/syncerd/runtime.rs
@@ -201,6 +201,7 @@ impl Runtime {
                     endpoints,
                     source,
                     Rpc::SyncerInfo(SyncerInfo {
+                        syncer: self.identity().to_string(),
                         uptime: SystemTime::now()
                             .duration_since(self.started)
                             .unwrap_or_else(|_| Duration::from_secs(0)),

--- a/src/syncerd/runtime.rs
+++ b/src/syncerd/runtime.rs
@@ -34,6 +34,7 @@ use std::time::{Duration, SystemTime};
 use farcaster_core::blockchain::{Blockchain, Network};
 use microservices::esb::{self, Handler};
 use microservices::ZMQ_CONTEXT;
+use strict_encoding::{StrictDecode, StrictEncode};
 
 pub trait Synclet {
     fn run(
@@ -46,6 +47,13 @@ pub trait Synclet {
     ) -> Result<(), Error>;
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Display, StrictEncode, StrictDecode)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
+#[display(Debug)]
 pub struct SyncerdTask {
     pub task: Task,
     pub source: ServiceId,
@@ -88,7 +96,7 @@ pub struct Runtime {
     identity: ServiceId,
     syncer: Box<dyn Synclet>,
     started: SystemTime,
-    tasks: HashSet<u64>, // FIXME
+    tasks: HashSet<SyncerdTask>,
     tx: Sender<SyncerdTask>,
 }
 
@@ -239,10 +247,12 @@ impl Runtime {
     ) -> Result<(), Error> {
         match request {
             SyncMsg::Task(task) => {
-                match self.tx.send(SyncerdTask {
+                let t = SyncerdTask {
                     task: task.clone(),
                     source,
-                }) {
+                };
+                self.tasks.insert(t.clone());
+                match self.tx.send(t) {
                     Ok(()) => trace!("Task successfully sent to syncer runtime"),
                     Err(e) => error!("Failed to send task with error: {}", e.to_string()),
                 };

--- a/src/syncerd/types.rs
+++ b/src/syncerd/types.rs
@@ -1,12 +1,24 @@
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
 use strict_encoding::{StrictDecode, StrictEncode};
 
 #[derive(
     Clone, Copy, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Ord, PartialOrd, Hash,
 )]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub struct TaskId(pub u32);
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub enum AddressAddendum {
     Monero(XmrAddressAddendum),
@@ -14,6 +26,11 @@ pub enum AddressAddendum {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub struct BtcAddressAddendum {
     /// The blockchain height where to start the query (not inclusive).
@@ -22,16 +39,29 @@ pub struct BtcAddressAddendum {
     pub address: bitcoin::Address,
 }
 
+#[cfg_attr(feature = "serde", serde_as)]
 #[derive(Clone, Debug, Display, Eq, PartialEq, Hash, StrictEncode, StrictDecode)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub struct XmrAddressAddendum {
+    #[serde_as(as = "DisplayFromStr")]
     pub spend_key: monero::PublicKey,
+    #[serde_as(as = "DisplayFromStr")]
     pub view_key: monero::PrivateKey,
     /// The blockchain height where to start the query (not inclusive).
     pub from_height: u64,
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub struct SweepAddress {
     pub retry: bool,
@@ -42,22 +72,41 @@ pub struct SweepAddress {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub enum SweepAddressAddendum {
     Monero(SweepMoneroAddress),
     Bitcoin(SweepBitcoinAddress),
 }
 
+#[cfg_attr(feature = "serde", serde_as)]
 #[derive(Clone, Debug, Display, Eq, PartialEq, Hash, StrictEncode, StrictDecode)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub struct SweepMoneroAddress {
+    #[serde_as(as = "DisplayFromStr")]
     pub source_spend_key: monero::PrivateKey,
+    #[serde_as(as = "DisplayFromStr")]
     pub source_view_key: monero::PrivateKey,
     pub destination_address: monero::Address,
+    #[serde(with = "monero::util::amount::serde::as_xmr")]
     pub minimum_balance: monero::Amount,
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub struct SweepBitcoinAddress {
     pub source_secret_key: bitcoin::secp256k1::SecretKey,
@@ -66,6 +115,11 @@ pub struct SweepBitcoinAddress {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub struct Abort {
     pub task_target: TaskTarget,
@@ -73,12 +127,22 @@ pub struct Abort {
 }
 
 #[derive(Clone, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub enum TaskTarget {
     TaskId(TaskId),
     AllTasks,
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub struct WatchHeight {
     pub id: TaskId,
@@ -86,6 +150,11 @@ pub struct WatchHeight {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub struct WatchAddress {
     pub id: TaskId,
@@ -95,6 +164,11 @@ pub struct WatchAddress {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub enum Boolean {
     True,
@@ -111,29 +185,52 @@ impl From<Boolean> for bool {
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub struct WatchTransaction {
     pub id: TaskId,
     pub lifetime: u64,
+    #[serde(with = "hex")]
     pub hash: Vec<u8>,
     pub confirmation_bound: u32,
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub struct BroadcastTransaction {
     pub id: TaskId,
+    #[serde(with = "hex")]
     pub tx: Vec<u8>,
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub struct GetTx {
     pub id: TaskId,
+    #[serde(with = "hex")]
     pub hash: Vec<u8>,
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub struct WatchEstimateFee {
     pub id: TaskId,
@@ -143,6 +240,11 @@ pub struct WatchEstimateFee {
 /// Tasks created by the daemon and handle by syncers to process a blockchain
 /// and generate [`Event`] back to the syncer.
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[display(Debug)]
 pub enum Task {
     Abort(Abort),


### PR DESCRIPTION
Based on #707 

This PR introduce the implementation of `info <blockchain> <network>` and `list-tasks <blockchain> <network>` to return the list of tasks a _syncer has received_ (and not the current list of tasks, this need a bit more work because of the current syncer state).

It also extend the `info` command to return the `stats` that are printed in the logs (number of funded, swaped, canceled, etc).