### PR TITLE
Ci: update containers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,14 +78,14 @@ jobs:
           grpc,
         ]
         bitcoin: [ '23.0' ]
-        electrs: [ 0.9.7 ]
+        electrs: [ 0.9.9 ]
         include:
         - test: bitcoin_syncer
           bitcoin: '22.0'
           electrs: 0.8.11
         - test: bitcoin_syncer
           bitcoin: '22.0'
-          electrs: 0.9.7
+          electrs: 0.9.9
 
     runs-on: ubuntu-latest
     env:
@@ -115,28 +115,28 @@ jobs:
         volumes:
           - bitcoind-data:/data
       monerod:
-        image: ghcr.io/farcaster-project/containers/monerod:0.18.0.0
+        image: ghcr.io/farcaster-project/containers/monerod:0.18.1.2
         env:
           NETWORK: regtest
           OFFLINE: --offline
           DIFFICULTY: 1
       monero-wallet-rpc-1:
-        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.0.0
+        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.1.2
         env:
           MONERO_DAEMON_ADDRESS: monerod:18081
           WALLET_RPC_PORT: 18083
       monero-wallet-rpc-2:
-        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.0.0
+        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.1.2
         env:
           MONERO_DAEMON_ADDRESS: monerod:18081
           WALLET_RPC_PORT: 18083
       monero-wallet-rpc-3:
-        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.0.0
+        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.1.2
         env:
           MONERO_DAEMON_ADDRESS: monerod:18081
           WALLET_RPC_PORT: 18083
       monero-lws:
-        image: ghcr.io/farcaster-project/containers/monero-lws:monerod-0.18.0.0
+        image: ghcr.io/farcaster-project/containers/monero-lws:monerod-0.18.1.2
         env:
           NETWORK: main
           MONERO_DAEMON_ADDRESS: monerod:18082

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.8"
 services:
   bitcoind:
     image: ghcr.io/farcaster-project/containers/bitcoin-core:23.0

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         -fallbackfee=0.00001
         -datadir=/data
   electrs:
-    image: ghcr.io/farcaster-project/containers/electrs:0.9.7
+    image: ghcr.io/farcaster-project/containers/electrs:0.9.9
     depends_on:
       - "bitcoind"
     volumes:
@@ -30,7 +30,7 @@ services:
       - 60401:60401
     command: "/usr/bin/electrs --daemon-dir /data --conf /cfg/electrs.toml"
   monerod:
-    image: ghcr.io/farcaster-project/containers/monerod:0.18.0.0
+    image: ghcr.io/farcaster-project/containers/monerod:0.18.1.2
     environment:
       NETWORK: regtest
       OFFLINE: --offline
@@ -39,7 +39,7 @@ services:
       - 18081:18081
       - 18082:18082
   monero-wallet-rpc-1:
-    image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.0.0
+    image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.1.2
     environment:
       MONERO_DAEMON_ADDRESS: monerod:18081
       WALLET_RPC_PORT: 18083
@@ -48,7 +48,7 @@ services:
     ports:
       - 18083:18083
   monero-wallet-rpc-2:
-    image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.0.0
+    image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.1.2
     environment:
       MONERO_DAEMON_ADDRESS: monerod:18081
       WALLET_RPC_PORT: 18083
@@ -57,7 +57,7 @@ services:
     ports:
       - 18084:18083
   monero-wallet-rpc-3:
-    image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.0.0
+    image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.1.2
     environment:
       MONERO_DAEMON_ADDRESS: monerod:18081
       WALLET_RPC_PORT: 18083
@@ -66,7 +66,7 @@ services:
     ports:
       - 18085:18083
   monero-lws-daemon:
-    image: ghcr.io/farcaster-project/containers/monero-lws:monerod-0.18.0.0
+    image: ghcr.io/farcaster-project/containers/monero-lws:monerod-0.18.1.2
     environment:
       NETWORK: main
       MONERO_DAEMON_ADDRESS: monerod:18082


### PR DESCRIPTION
This PR bumps `electrs` and Monero `rpc`, `wallet` and `lws` version to the latest container images we have on [containers](https://github.com/farcaster-project/containers)