### PR TITLE
feat: log as info level p2p msg sent and received per swap

### DIFF
--- a/src/bus/msg.rs
+++ b/src/bus/msg.rs
@@ -16,27 +16,27 @@ use strict_encoding::{StrictDecode, StrictEncode};
 #[non_exhaustive]
 pub enum Msg {
     #[api(type = 33701)]
-    #[display("maker_commit({0})")]
+    #[display("{0} maker commit")]
     MakerCommit(Commit),
 
     #[api(type = 33702)]
-    #[display("taker_commit({0})")]
+    #[display("{0} taker commit")]
     TakerCommit(TakeCommit),
 
     #[api(type = 33703)]
-    #[display("reveal({0})")]
+    #[display("reveal {0}")]
     Reveal(Reveal),
 
     #[api(type = 33720)]
-    #[display("refund_procedure_signatures(..)")]
+    #[display("refund procedure signatures")]
     RefundProcedureSignatures(RefundProcedureSignatures),
 
     #[api(type = 33710)]
-    #[display("core_arbitrating_setup(..)")]
+    #[display("core arbitrating setup")]
     CoreArbitratingSetup(CoreArbitratingSetup),
 
     #[api(type = 33730)]
-    #[display("buy_procedure_signature(..)")]
+    #[display("buy procedure signature")]
     BuyProcedureSignature(BuyProcedureSignature),
 
     #[api(type = 18)]
@@ -106,20 +106,32 @@ impl Msg {
                 | Msg::Pong(_)
         )
     }
+
+    pub fn is_protocol(&self) -> bool {
+        matches!(
+            self,
+            Msg::MakerCommit(_)
+                | Msg::TakerCommit(_)
+                | Msg::Reveal(_)
+                | Msg::RefundProcedureSignatures(_)
+                | Msg::CoreArbitratingSetup(_)
+                | Msg::BuyProcedureSignature(_)
+        )
+    }
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
 pub enum Reveal {
-    #[display("alice(..)")]
+    #[display("Alice parameters")]
     AliceParameters(RevealAliceParameters),
-    #[display("bob(..)")]
+    #[display("Bob parameters")]
     BobParameters(RevealBobParameters),
-    #[display("proof(..)")]
+    #[display("proof")]
     Proof(RevealProof), // FIXME should be Msg::RevealProof(..)
 }
 
 #[derive(Clone, Debug, Display, From, StrictDecode, StrictEncode)]
-#[display("{swap_id}, ..")]
+#[display("{commit}")]
 pub struct TakeCommit {
     pub commit: Commit,
     pub public_offer: PublicOffer, // TODO: replace by public offer id
@@ -128,8 +140,8 @@ pub struct TakeCommit {
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
 pub enum Commit {
-    #[display("alice(..)")]
+    #[display("Alice")]
     AliceParameters(CommitAliceParameters),
-    #[display("bob(..)")]
+    #[display("Bob")]
     BobParameters(CommitBobParameters),
 }

--- a/src/peerd/runtime.rs
+++ b/src/peerd/runtime.rs
@@ -370,6 +370,15 @@ impl Runtime {
             }
         }
 
+        if message.is_protocol() {
+            let swap_id = message.swap_id();
+            info!(
+                "{} | Sent the {} protocol message",
+                swap_id.bright_blue_italic(),
+                message.bright_white_bold()
+            );
+        }
+
         Ok(())
     }
 
@@ -539,14 +548,22 @@ impl Runtime {
                     request,
                 )?;
             }
+
             BusMsg::Msg(msg) => {
+                let swap_id = msg.swap_id();
+                info!(
+                    "{} | Received the {} protocol message",
+                    swap_id.bright_blue_italic(),
+                    msg.bright_white_bold()
+                );
                 endpoints.send_to(
                     ServiceBus::Msg,
                     self.identity(),
-                    ServiceId::Swap(msg.swap_id()),
+                    ServiceId::Swap(swap_id),
                     request,
                 )?;
             }
+
             other => {
                 error!("BusMsg is not supported by the BRIDGE interface");
                 dbg!(other);


### PR DESCRIPTION
Log outgoing and incoming p2p protocol message in a friendly manner with the corresponding swap id. Next step is to add them in the progress stack too, but I let it for another PR that improve the overall progress feature.