### PR TITLE
Feature: Extend Grpc implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,9 +141,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9496f0c1d1afb7a2af4338bbe1d969cddfead41d87a9fb3aaa6d0bbc7af648"
+checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f44a0e6200e9d11a1cdc989e4b358f6e3d354fbf48478f345a17f4e43f8635"
+checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
 dependencies = [
  "async-trait",
  "bytes",
@@ -180,6 +180,8 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1016,6 +1018,7 @@ dependencies = [
  "toml",
  "tonic",
  "tonic-build",
+ "tonic-web",
  "uuid",
  "zmq2",
 ]
@@ -3338,6 +3341,24 @@ dependencies = [
  "prost-build",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tonic-web"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3864b1194b9b39ba01fc8f6640dc5554ded967ccaebdd8033341987f6c776431"
+dependencies = [
+ "base64 0.13.0",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project",
+ "tonic",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ sysinfo = { version = "0.18.2" }
 tokio = { version = "1.18.2", features = ["full"] }
 toml = { version = "0.5", optional = true }
 tonic = "0.7.2"
+tonic-web = "0.3.0"
 uuid = { version = "1.1", features = ["v4", "serde"] }
 zmq = { package = "zmq2", version = "0.5.0" }
 

--- a/src/bus/bridge.rs
+++ b/src/bus/bridge.rs
@@ -1,0 +1,32 @@
+use crate::bus::ctl::CtlMsg;
+use crate::bus::info::InfoMsg;
+use crate::bus::p2p::PeerMsg;
+use crate::bus::sync::SyncMsg;
+use crate::bus::ServiceId;
+
+use strict_encoding::{NetworkDecode, NetworkEncode};
+
+#[derive(Clone, Debug, Display, From, NetworkEncode, NetworkDecode)]
+#[non_exhaustive]
+pub enum BridgeMsg {
+    #[display("Bridge Peer {service_id}")]
+    Peer {
+        request: PeerMsg,
+        service_id: ServiceId,
+    },
+    #[display("Bridge Ctl {service_id}")]
+    Ctl {
+        request: CtlMsg,
+        service_id: ServiceId,
+    },
+    #[display("Bridge Rpc {service_id}")]
+    Info {
+        request: InfoMsg,
+        service_id: ServiceId,
+    },
+    #[display("Bridge SyncMsg {service_id}")]
+    Sync {
+        request: SyncMsg,
+        service_id: ServiceId,
+    },
+}

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -12,6 +12,7 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
+pub mod bridge;
 pub mod ctl;
 pub mod info;
 pub mod p2p;
@@ -24,6 +25,7 @@ pub use types::*;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::iter::FromIterator;
 
+use crate::bus::bridge::BridgeMsg;
 use crate::bus::ctl::CtlMsg;
 use crate::bus::info::InfoMsg;
 use crate::bus::p2p::PeerMsg;
@@ -91,6 +93,12 @@ pub enum BusMsg {
     #[display(inner)]
     #[from]
     Sync(SyncMsg),
+
+    /// Wrapper for inner type of bridge messages to be transmitted over bridge busses
+    #[api(type = 5)]
+    #[display(inner)]
+    #[from]
+    Bridge(BridgeMsg),
 }
 
 impl microservices::rpc::Request for BusMsg {}

--- a/src/databased/runtime.rs
+++ b/src/databased/runtime.rs
@@ -268,14 +268,10 @@ impl Runtime {
                         CheckpointEntry::strict_decode(std::io::Cursor::new(info)).ok()
                     })
                     .collect();
-
-                debug!("checkpointed pub offers: {:?}", checkpointed_pub_offers);
-
-                endpoints.send_to(
-                    ServiceBus::Info,
-                    self.identity(),
+                self.send_client_info(
+                    endpoints,
                     source,
-                    BusMsg::Info(InfoMsg::CheckpointList(checkpointed_pub_offers)),
+                    InfoMsg::CheckpointList(checkpointed_pub_offers),
                 )?;
             }
 

--- a/src/databased/runtime.rs
+++ b/src/databased/runtime.rs
@@ -17,7 +17,7 @@ use crate::bus::{
     OfferStatusPair, ServiceBus,
 };
 use crate::{CtlServer, Error, LogStyle, Service, ServiceConfig, ServiceId};
-use microservices::esb::{self, Handler};
+use microservices::esb::{self};
 
 pub fn run(config: ServiceConfig, data_dir: PathBuf) -> Result<(), Error> {
     let runtime = Runtime {
@@ -286,17 +286,10 @@ impl Runtime {
                     _ => None,
                 };
                 if let Some(entry) = entry {
-                    debug!("checkpoint entry: {:?}", entry);
-                    endpoints.send_to(
-                        ServiceBus::Info,
-                        self.identity(),
-                        source,
-                        BusMsg::Info(InfoMsg::CheckpointEntry(entry)),
-                    )?;
+                    self.send_client_info(endpoints, source, InfoMsg::CheckpointEntry(entry))?;
                 } else {
-                    endpoints.send_to(
-                        ServiceBus::Ctl,
-                        self.identity(),
+                    self.send_client_ctl(
+                        endpoints,
                         source,
                         BusMsg::Ctl(CtlMsg::Failure(Failure {
                             code: FailureCode::Unknown,

--- a/src/event.rs
+++ b/src/event.rs
@@ -102,10 +102,36 @@ impl<'esb> Event<'esb> {
             .send_to(ServiceBus::Ctl, self.service, self.source, request)
     }
 
-    /// Finalizes event processing by sending reply request via INFO message bus
+    /// Finalizes event processing by sending reply request via CTL message bus to a client
+    pub fn complete_client_ctl(self, request: BusMsg) -> Result<(), esb::Error<ServiceId>> {
+        let bus = ServiceBus::Ctl;
+        if let ServiceId::GrpcdClient(_) = self.source {
+            self.endpoints
+                .send_to(bus, self.source, ServiceId::Grpcd, request)?;
+        } else {
+            self.endpoints
+                .send_to(bus, self.service, self.source, request)?;
+        }
+        Ok(())
+    }
+
+    /// Finalizes event processing by sending reply request via RPC message bus
     pub fn complete_info(self, request: BusMsg) -> Result<(), esb::Error<ServiceId>> {
         self.endpoints
             .send_to(ServiceBus::Info, self.service, self.source, request)
+    }
+
+    /// Finalizes event processing by sending reply request via RPC message bus to a client
+    pub fn complete_client_info(self, request: BusMsg) -> Result<(), esb::Error<ServiceId>> {
+        let bus = ServiceBus::Info;
+        if let ServiceId::GrpcdClient(_) = self.source {
+            self.endpoints
+                .send_to(bus, self.source, ServiceId::Grpcd, request)?;
+        } else {
+            self.endpoints
+                .send_to(bus, self.service, self.source, request)?;
+        }
+        Ok(())
     }
 
     /// Finalizes event processing by sending reply request via CTL message bus to a specific

--- a/src/event.rs
+++ b/src/event.rs
@@ -178,6 +178,23 @@ impl<'esb> Event<'esb> {
             .send_to(ServiceBus::Info, self.service.clone(), service, request)
     }
 
+    /// Finalizes event processing by sending reply request via RPC message bus to a client
+    pub fn send_client_info(
+        &mut self,
+        service: ServiceId,
+        request: BusMsg,
+    ) -> Result<(), esb::Error<ServiceId>> {
+        let bus = ServiceBus::Info;
+        if let ServiceId::GrpcdClient(_) = service {
+            self.endpoints
+                .send_to(bus, service, ServiceId::Grpcd, request)?;
+        } else {
+            self.endpoints
+                .send_to(bus, self.service.clone(), service, request)?;
+        }
+        Ok(())
+    }
+
     /// Send reply request via MSG message bus to a specific service (different from the event originating service)
     pub fn send_msg_service(
         &mut self,

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -609,12 +609,7 @@ impl Runtime {
                     continue;
                 }
                 trace!("(#{}) Respond to {}: {}", i, respond_to, resp,);
-                endpoints.send_to(
-                    ServiceBus::Info,
-                    self.identity(),
-                    respond_to,
-                    BusMsg::Info(resp),
-                )?;
+                self.send_client_info(endpoints, respond_to, resp)?;
             }
         }
         trace!("Processed all cli notifications");

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -573,12 +573,7 @@ impl Runtime {
                         res
                     })
                     .collect();
-                endpoints.send_to(
-                    ServiceBus::Info,
-                    self.identity(),
-                    source,
-                    BusMsg::Info(InfoMsg::String(res)),
-                )?;
+                self.send_client_info(endpoints, source, InfoMsg::String(res))?;
             }
 
             InfoMsg::NeedsFunding(Blockchain::Bitcoin) => {
@@ -599,12 +594,7 @@ impl Runtime {
                         res
                     })
                     .collect();
-                endpoints.send_to(
-                    ServiceBus::Info,
-                    self.identity(),
-                    source,
-                    BusMsg::Info(InfoMsg::String(res)),
-                )?;
+                self.send_client_info(endpoints, source, InfoMsg::String(res))?;
             }
 
             req => {

--- a/src/farcasterd/syncer_state_machine.rs
+++ b/src/farcasterd/syncer_state_machine.rs
@@ -256,7 +256,7 @@ fn attempt_transition_to_end(
                 .pop()
                 .map(|txid| bitcoin::Txid::from_slice(&txid).ok())
             {
-                event.send_info_service(
+                event.send_client_info(
                     source,
                     BusMsg::Info(InfoMsg::String(format!(
                         "Successfully sweeped address. Transaction Id: {}.",
@@ -264,7 +264,7 @@ fn attempt_transition_to_end(
                     ))),
                 )?;
             } else {
-                event.send_info_service(
+                event.send_client_info(
                     source,
                     BusMsg::Info(InfoMsg::String("Nothing to sweep.".to_string())),
                 )?;

--- a/src/farcasterd/trade_state_machine.rs
+++ b/src/farcasterd/trade_state_machine.rs
@@ -462,13 +462,10 @@ fn attempt_transition_to_restoring_swapd(
             trade_role,
         })) => {
             if let Err(err) = runtime.services_ready() {
-                event.send_ctl_service(
-                    event.source.clone(),
-                    BusMsg::Ctl(CtlMsg::Failure(Failure {
-                        code: FailureCode::Unknown,
-                        info: err.to_string(),
-                    })),
-                )?;
+                event.complete_client_ctl(BusMsg::Ctl(CtlMsg::Failure(Failure {
+                    code: FailureCode::Unknown,
+                    info: err.to_string(),
+                })))?;
                 return Ok(None);
             }
 
@@ -477,7 +474,7 @@ fn attempt_transition_to_restoring_swapd(
                 .send_ctl_service(ServiceId::Swap(swap_id), BusMsg::Ctl(CtlMsg::Hello))
                 .is_ok()
             {
-                event.complete_ctl(BusMsg::Ctl(CtlMsg::Failure(Failure {
+                event.complete_client_ctl(BusMsg::Ctl(CtlMsg::Failure(Failure {
                     code: FailureCode::Unknown,
                     info: "Cannot restore a checkpoint into a running swap.".to_string(),
                 })))?;
@@ -508,7 +505,7 @@ fn attempt_transition_to_restoring_swapd(
                 ],
             )?;
 
-            event.complete_info(BusMsg::Info(InfoMsg::String(
+            event.complete_client_info(BusMsg::Info(InfoMsg::String(
                 "Restoring checkpoint.".to_string(),
             )))?;
 

--- a/src/farcasterd/trade_state_machine.rs
+++ b/src/farcasterd/trade_state_machine.rs
@@ -577,14 +577,14 @@ fn attempt_transition_to_taker_committed(
             debug!("attempting to revoke {}", public_offer);
             if revoke_public_offer == public_offer {
                 info!("Revoked offer {}", public_offer.label());
-                event.complete_info(BusMsg::Info(InfoMsg::String(
+                event.complete_client_info(BusMsg::Info(InfoMsg::String(
                     "Successfully revoked offer.".to_string(),
                 )))?;
                 Ok(None)
             } else {
                 let msg = "Cannot revoke offer, it does not exist".to_string();
                 error!("{}", msg);
-                event.complete_info(BusMsg::Info(InfoMsg::String(msg)))?;
+                event.complete_client_info(BusMsg::Info(InfoMsg::String(msg)))?;
                 Ok(Some(TradeStateMachine::MakeOffer(MakeOffer {
                     public_offer,
                     arb_addr,

--- a/src/farcasterd/trade_state_machine.rs
+++ b/src/farcasterd/trade_state_machine.rs
@@ -314,7 +314,7 @@ fn attempt_transition_to_make_offer(
             // start a listener on the bind_addr
             match runtime.listen(bind_addr) {
                 Err(err) => {
-                    event.complete_ctl(BusMsg::Ctl(CtlMsg::Failure(Failure {
+                    event.complete_client_ctl(BusMsg::Ctl(CtlMsg::Failure(Failure {
                         code: FailureCode::Unknown,
                         info: err.to_string(),
                     })))?;

--- a/src/farcasterd/trade_state_machine.rs
+++ b/src/farcasterd/trade_state_machine.rs
@@ -335,7 +335,7 @@ fn attempt_transition_to_make_offer(
                             status: OfferStatus::Open,
                         })),
                     )?;
-                    event.complete_info(BusMsg::Info(InfoMsg::MadeOffer(MadeOffer {
+                    event.complete_client_info(BusMsg::Info(InfoMsg::MadeOffer(MadeOffer {
                         message: msg,
                         offer_info: OfferInfo {
                             offer: public_offer.to_string(),
@@ -404,7 +404,7 @@ fn attempt_transition_to_take_offer(
             // connect to the remote peer
             match runtime.connect_peer(&peer_node_addr) {
                 Err(err) => {
-                    event.complete_ctl(BusMsg::Ctl(CtlMsg::Failure(Failure {
+                    event.complete_client_ctl(BusMsg::Ctl(CtlMsg::Failure(Failure {
                         code: FailureCode::Unknown,
                         info: err.to_string(),
                     })))?;

--- a/src/farcasterd/trade_state_machine.rs
+++ b/src/farcasterd/trade_state_machine.rs
@@ -384,7 +384,7 @@ fn attempt_transition_to_take_offer(
                     &public_offer.to_string()
                 );
                 warn!("{}", msg.err());
-                event.complete_ctl(BusMsg::Ctl(CtlMsg::Failure(Failure {
+                event.complete_client_ctl(BusMsg::Ctl(CtlMsg::Failure(Failure {
                     code: FailureCode::Unknown,
                     info: msg,
                 })))?;
@@ -426,7 +426,7 @@ fn attempt_transition_to_take_offer(
                             internal_address,
                         })),
                     )?;
-                    event.complete_info(BusMsg::Info(InfoMsg::TookOffer(TookOffer {
+                    event.complete_client_info(BusMsg::Info(InfoMsg::TookOffer(TookOffer {
                         offerid: public_offer.id(),
                         message: offer_registered,
                     })))?;

--- a/src/grpcd/proto/farcaster.proto
+++ b/src/grpcd/proto/farcaster.proto
@@ -61,6 +61,8 @@ message OfferInfoResponse {
     Network network = 9;
     Blockchain arbitrating_blockchain = 10;
     Blockchain accordant_blockchain = 11;
+    string node_id = 12;
+    string peer_address = 13;
 }
 
 message PeersRequest {

--- a/src/grpcd/proto/farcaster.proto
+++ b/src/grpcd/proto/farcaster.proto
@@ -8,6 +8,8 @@ service Farcaster {
     rpc RestoreCheckpoint(RestoreCheckpointRequest) returns (RestoreCheckpointResponse){}
     rpc Make(MakeRequest) returns (MakeResponse){}
     rpc Take(TakeRequest) returns (TakeResponse){}
+    rpc RevokeOffer(RevokeOfferRequest) returns (RevokeOfferResponse){}
+    rpc AbortSwap(AbortSwapRequest) returns (AbortSwapResponse){}
 }
 
 message InfoRequest {
@@ -94,6 +96,24 @@ message TakeRequest {
 }
 
 message TakeResponse {
+    uint32 id = 1;
+}
+
+message RevokeOfferRequest {
+    uint32 id = 1;
+    string public_offer = 2;
+}
+
+message RevokeOfferResponse {
+    uint32 id = 1;
+}
+
+message AbortSwapRequest {
+    uint32 id = 1;
+    string swap_id = 2;
+}
+
+message AbortSwapResponse {
     uint32 id = 1;
 }
 

--- a/src/grpcd/proto/farcaster.proto
+++ b/src/grpcd/proto/farcaster.proto
@@ -3,6 +3,8 @@ package farcaster;
 
 service Farcaster {
     rpc Info(InfoRequest) returns (InfoResponse){}
+    rpc Peers(PeersRequest) returns (PeersResponse){}
+    rpc Checkpoints(CheckpointsRequest) returns (CheckpointsResponse){}
 }
 
 message InfoRequest {
@@ -19,3 +21,26 @@ message InfoResponse {
     repeated string offers = 8;
 }
 
+message PeersRequest {
+    uint32 id = 1;
+}
+
+message PeersResponse {
+    uint32 id = 1;
+    repeated string peers = 2;
+}
+
+message CheckpointsRequest {
+    uint32 id = 1;
+}
+
+message CheckpointsResponse {
+    uint32 id = 1;
+    repeated CheckpointEntry checkpoint_entries = 2;
+}
+
+message CheckpointEntry {
+    string swap_id = 1;
+    string public_offer = 2;
+    string trade_role = 3;
+}

--- a/src/grpcd/proto/farcaster.proto
+++ b/src/grpcd/proto/farcaster.proto
@@ -12,6 +12,7 @@ service Farcaster {
     rpc AbortSwap(AbortSwapRequest) returns (AbortSwapResponse){}
     rpc Progress(ProgressRequest) returns (ProgressResponse){}
     rpc NeedsFunding(NeedsFundingRequest) returns (NeedsFundingResponse){}
+    rpc SweepAddress(SweepAddressRequest) returns (SweepAddressResponse){}
 }
 
 message InfoRequest {
@@ -137,6 +138,17 @@ message NeedsFundingRequest {
 message NeedsFundingResponse {
     uint32 id = 1;
     string funding_infos = 2;
+}
+
+message SweepAddressRequest {
+    uint32 id = 1;
+    string source_address = 2;
+    string destination_address = 3;
+}
+
+message SweepAddressResponse {
+    uint32 id = 1;
+    string message = 2;
 }
 
 enum SwapRole {

--- a/src/grpcd/proto/farcaster.proto
+++ b/src/grpcd/proto/farcaster.proto
@@ -6,6 +6,7 @@ service Farcaster {
     rpc Peers(PeersRequest) returns (PeersResponse){}
     rpc Checkpoints(CheckpointsRequest) returns (CheckpointsResponse){}
     rpc RestoreCheckpoint(RestoreCheckpointRequest) returns (RestoreCheckpointResponse){}
+    rpc Make(MakeRequest) returns (MakeResponse){}
 }
 
 message InfoRequest {
@@ -43,7 +44,12 @@ message CheckpointsResponse {
 message CheckpointEntry {
     string swap_id = 1;
     string public_offer = 2;
-    string trade_role = 3;
+    TradeRole trade_role = 3;
+}
+
+enum TradeRole {
+    MAKER = 0;
+    TAKER = 1;
 }
 
 message RestoreCheckpointRequest {
@@ -54,4 +60,43 @@ message RestoreCheckpointRequest {
 message RestoreCheckpointResponse {
     uint32 id = 1;
     string status = 2;
+}
+
+message MakeRequest {
+    uint32 id = 1;
+    Network network = 2;
+    Blockchain accordant_blockchain = 3;
+    Blockchain arbitrating_blockchain = 4;
+    uint64 accordant_amount = 5;
+    uint64 arbitrating_amount = 6;
+    string arbitrating_addr = 7;
+    string accordant_addr = 8;
+    uint32 cancel_timelock = 9;
+    uint32 punish_timelock = 10;
+    string fee_strategy = 11;
+    SwapRole maker_role = 12;
+    string public_ip_addr = 13;
+    string bind_ip_addr = 14;
+    uint32 port = 15;
+}
+ 
+message MakeResponse {
+    uint32 id = 1;
+    string offer = 2;
+}
+
+enum SwapRole {
+    ALICE = 0;
+    BOB = 1;
+}
+
+enum Network {
+    MAINNET = 0;
+    TESTNET = 1;
+    LOCAL = 2;
+}
+
+enum Blockchain {
+    BITCOIN = 0;
+    MONERO = 1;
 }

--- a/src/grpcd/proto/farcaster.proto
+++ b/src/grpcd/proto/farcaster.proto
@@ -7,6 +7,7 @@ service Farcaster {
     rpc Checkpoints(CheckpointsRequest) returns (CheckpointsResponse){}
     rpc RestoreCheckpoint(RestoreCheckpointRequest) returns (RestoreCheckpointResponse){}
     rpc Make(MakeRequest) returns (MakeResponse){}
+    rpc Take(TakeRequest) returns (TakeResponse){}
 }
 
 message InfoRequest {
@@ -83,6 +84,17 @@ message MakeRequest {
 message MakeResponse {
     uint32 id = 1;
     string offer = 2;
+}
+
+message TakeRequest {
+    uint32 id = 1;
+    string public_offer = 2;
+    string bitcoin_address = 3;
+    string monero_address = 4;
+}
+
+message TakeResponse {
+    uint32 id = 1;
 }
 
 enum SwapRole {

--- a/src/grpcd/proto/farcaster.proto
+++ b/src/grpcd/proto/farcaster.proto
@@ -4,6 +4,8 @@ package farcaster;
 service Farcaster {
     rpc Info(InfoRequest) returns (InfoResponse){}
     rpc Peers(PeersRequest) returns (PeersResponse){}
+    rpc SwapInfo(SwapInfoRequest) returns (SwapInfoResponse){}
+    rpc OfferInfo(OfferInfoRequest) returns (OfferInfoResponse){}
     rpc Checkpoints(CheckpointsRequest) returns (CheckpointsResponse){}
     rpc RestoreCheckpoint(RestoreCheckpointRequest) returns (RestoreCheckpointResponse){}
     rpc Make(MakeRequest) returns (MakeResponse){}
@@ -27,6 +29,38 @@ message InfoResponse {
     repeated string peers = 6;
     repeated string swaps = 7;
     repeated string offers = 8;
+}
+
+message SwapInfoRequest {
+    uint32 id = 1;
+    string swap_id = 2;
+}
+
+message SwapInfoResponse {
+    uint32 id = 1;
+    string maker_peer = 2;
+    uint64 uptime = 3;
+    uint64 since= 4;
+    string public_offer = 5;
+}
+
+message OfferInfoRequest {
+    uint32 id = 1;
+    string public_offer = 2;
+}
+
+message OfferInfoResponse {
+    uint32 id = 1;
+    uint64 arbitrating_amount = 2;
+    uint64 accordant_amount = 3;
+    uint32 cancel_timelock = 4;
+    uint32 punish_timelock = 5;
+    string fee_strategy = 6;
+    SwapRole maker_role = 7;
+    string uuid = 8;
+    Network network = 9;
+    Blockchain arbitrating_blockchain = 10;
+    Blockchain accordant_blockchain = 11;
 }
 
 message PeersRequest {

--- a/src/grpcd/proto/farcaster.proto
+++ b/src/grpcd/proto/farcaster.proto
@@ -5,6 +5,7 @@ service Farcaster {
     rpc Info(InfoRequest) returns (InfoResponse){}
     rpc Peers(PeersRequest) returns (PeersResponse){}
     rpc Checkpoints(CheckpointsRequest) returns (CheckpointsResponse){}
+    rpc RestoreCheckpoint(RestoreCheckpointRequest) returns (RestoreCheckpointResponse){}
 }
 
 message InfoRequest {
@@ -43,4 +44,14 @@ message CheckpointEntry {
     string swap_id = 1;
     string public_offer = 2;
     string trade_role = 3;
+}
+
+message RestoreCheckpointRequest {
+    uint32 id = 1;
+    string swap_id = 2;
+}
+
+message RestoreCheckpointResponse {
+    uint32 id = 1;
+    string status = 2;
 }

--- a/src/grpcd/proto/farcaster.proto
+++ b/src/grpcd/proto/farcaster.proto
@@ -10,6 +10,8 @@ service Farcaster {
     rpc Take(TakeRequest) returns (TakeResponse){}
     rpc RevokeOffer(RevokeOfferRequest) returns (RevokeOfferResponse){}
     rpc AbortSwap(AbortSwapRequest) returns (AbortSwapResponse){}
+    rpc Progress(ProgressRequest) returns (ProgressResponse){}
+    rpc NeedsFunding(NeedsFundingRequest) returns (NeedsFundingResponse){}
 }
 
 message InfoRequest {
@@ -115,6 +117,26 @@ message AbortSwapRequest {
 
 message AbortSwapResponse {
     uint32 id = 1;
+}
+
+message ProgressRequest {
+    uint32 id = 1;
+    string swap_id = 2;
+}
+
+message ProgressResponse {
+    uint32 id = 1;
+    repeated string progress = 2;
+}
+
+message NeedsFundingRequest {
+    uint32 id = 1;
+    Blockchain blockchain = 2;
+}
+
+message NeedsFundingResponse {
+    uint32 id = 1;
+    string funding_infos = 2;
 }
 
 enum SwapRole {

--- a/src/grpcd/runtime.rs
+++ b/src/grpcd/runtime.rs
@@ -439,7 +439,9 @@ impl Farcaster for FarcasterService {
                 };
                 Ok(GrpcResponse::new(reply))
             }
-            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, code: _ }))) => {
+                Err(Status::internal(info))
+            }
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }
@@ -494,7 +496,9 @@ impl Farcaster for FarcasterService {
                 let reply = farcaster::AbortSwapResponse { id };
                 Ok(GrpcResponse::new(reply))
             }
-            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, code: _ }))) => {
+                Err(Status::internal(info))
+            }
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }
@@ -525,7 +529,9 @@ impl Farcaster for FarcasterService {
                 };
                 Ok(GrpcResponse::new(reply))
             }
-            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, code: _ }))) => {
+                Err(Status::internal(info))
+            }
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }
@@ -558,7 +564,9 @@ impl Farcaster for FarcasterService {
                 };
                 Ok(GrpcResponse::new(reply))
             }
-            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, code: _ }))) => {
+                Err(Status::internal(info))
+            }
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }
@@ -586,7 +594,7 @@ impl Farcaster for FarcasterService {
             match oneshot_rx.await {
                 Ok(BusMsg::Info(InfoMsg::AddressSecretKey(AddressSecretKey::Bitcoin {
                     secret_key,
-                    ..
+                    address: _,
                 }))) => {
                     let oneshot_rx = self
                         .process_request(BusMsg::Bridge(BridgeMsg::Ctl {
@@ -605,7 +613,7 @@ impl Farcaster for FarcasterService {
                             let reply = SweepAddressResponse { id, message };
                             Ok(GrpcResponse::new(reply))
                         }
-                        Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => {
+                        Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, code: _ }))) => {
                             Err(Status::internal(info))
                         }
                         _ => Err(Status::internal(format!("Received invalid response"))),
@@ -630,7 +638,7 @@ impl Farcaster for FarcasterService {
                 Ok(BusMsg::Info(InfoMsg::AddressSecretKey(AddressSecretKey::Monero {
                     view,
                     spend,
-                    ..
+                    address: _,
                 }))) => {
                     let oneshot_rx = self
                         .process_request(BusMsg::Bridge(BridgeMsg::Ctl {
@@ -650,7 +658,7 @@ impl Farcaster for FarcasterService {
                             let reply = SweepAddressResponse { id, message };
                             Ok(GrpcResponse::new(reply))
                         }
-                        Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => {
+                        Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, code: _ }))) => {
                             Err(Status::internal(info))
                         }
                         _ => Err(Status::internal(format!("Received invalid response"))),
@@ -743,7 +751,9 @@ impl Farcaster for FarcasterService {
                 let reply = farcaster::TakeResponse { id };
                 Ok(GrpcResponse::new(reply))
             }
-            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, code: _ }))) => {
+                Err(Status::internal(info))
+            }
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }

--- a/src/grpcd/runtime.rs
+++ b/src/grpcd/runtime.rs
@@ -207,7 +207,7 @@ impl Farcaster for FarcasterService {
                 Ok(GrpcResponse::new(reply))
             }
             Err(error) => Err(Status::internal(format!("{}", error))),
-            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::invalid_argument("received invalid response")),
         }
     }
@@ -232,7 +232,7 @@ impl Farcaster for FarcasterService {
                 Ok(GrpcResponse::new(reply))
             }
             Err(error) => Err(Status::internal(format!("{}", error))),
-            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::invalid_argument("received invalid response")),
         }
     }
@@ -264,7 +264,7 @@ impl Farcaster for FarcasterService {
                 Ok(GrpcResponse::new(reply))
             }
             Err(error) => Err(Status::internal(format!("{}", error))),
-            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::invalid_argument("received invalid response")),
         }
     }
@@ -306,13 +306,13 @@ impl Farcaster for FarcasterService {
                         };
                         Ok(GrpcResponse::new(reply))
                     }
-                    Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => {
+                    Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => {
                         Err(Status::internal(info))
                     }
                     _ => Err(Status::internal(format!("Received invalid response"))),
                 }
             }
-            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }
@@ -439,7 +439,7 @@ impl Farcaster for FarcasterService {
                 };
                 Ok(GrpcResponse::new(reply))
             }
-            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }
@@ -467,7 +467,7 @@ impl Farcaster for FarcasterService {
                 let reply = farcaster::RevokeOfferResponse { id };
                 Ok(GrpcResponse::new(reply))
             }
-            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }
@@ -525,7 +525,7 @@ impl Farcaster for FarcasterService {
                 };
                 Ok(GrpcResponse::new(reply))
             }
-            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }
@@ -558,7 +558,7 @@ impl Farcaster for FarcasterService {
                 };
                 Ok(GrpcResponse::new(reply))
             }
-            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }
@@ -605,13 +605,15 @@ impl Farcaster for FarcasterService {
                             let reply = SweepAddressResponse { id, message };
                             Ok(GrpcResponse::new(reply))
                         }
-                        Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => {
+                        Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => {
                             Err(Status::internal(info))
                         }
                         _ => Err(Status::internal(format!("Received invalid response"))),
                     }
                 }
-                Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+                Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => {
+                    Err(Status::internal(info))
+                }
                 _ => Err(Status::internal(format!("Received invalid response"))),
             }
         } else if let (Ok(source_address), Ok(destination_address)) = (
@@ -648,13 +650,15 @@ impl Farcaster for FarcasterService {
                             let reply = SweepAddressResponse { id, message };
                             Ok(GrpcResponse::new(reply))
                         }
-                        Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => {
+                        Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => {
                             Err(Status::internal(info))
                         }
                         _ => Err(Status::internal(format!("Received invalid response"))),
                     }
                 }
-                Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+                Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => {
+                    Err(Status::internal(info))
+                }
                 _ => Err(Status::internal(format!("Received invalid response"))),
             }
         } else {
@@ -739,7 +743,7 @@ impl Farcaster for FarcasterService {
                 let reply = farcaster::TakeResponse { id };
                 Ok(GrpcResponse::new(reply))
             }
-            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
+            Ok(BusMsg::Ctl(CtlMsg::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }

--- a/src/grpcd/runtime.rs
+++ b/src/grpcd/runtime.rs
@@ -351,7 +351,7 @@ impl Farcaster for FarcasterService {
             cancel_timelock: int_cancel_timelock,
             punish_timelock: int_punish_timelock,
             fee_strategy: str_fee_strategy,
-            maker_role: grpc_trade_role,
+            maker_role: grpc_swap_role,
             public_ip_addr: str_public_ip_addr,
             bind_ip_addr: str_bind_ip_addr,
             port,
@@ -375,7 +375,7 @@ impl Farcaster for FarcasterService {
             .map_err(|_| Status::invalid_argument("accordant_address"))?;
         let cancel_timelock = CSVTimelock::new(int_cancel_timelock);
         let punish_timelock = CSVTimelock::new(int_punish_timelock);
-        let maker_role: SwapRole = farcaster::SwapRole::from_i32(grpc_trade_role)
+        let maker_role: SwapRole = farcaster::SwapRole::from_i32(grpc_swap_role)
             .ok_or(Status::invalid_argument("maker role"))?
             .into();
         let public_ip_addr = IpAddr::from_str(&str_public_ip_addr)
@@ -383,7 +383,7 @@ impl Farcaster for FarcasterService {
         let bind_ip_addr = IpAddr::from_str(&str_bind_ip_addr)
             .map_err(|_| Status::invalid_argument("bind ip address"))?;
         let fee_strategy: FeeStrategy<SatPerVByte> = FeeStrategy::from_str(&str_fee_strategy).map_err(|_| Status::invalid_argument("
-        fee strategy is required to be formated as a fixed value, e.g. 100 satoshi/vByt or a range, e.g. 50 satoshi/vByte-150 satoshi/vByte "))?;
+        fee strategy is required to be formated as a fixed value, e.g. \"100 satoshi/vByte\" or a range, e.g. \"50 satoshi/vByte-150 satoshi/vByte\" "))?;
 
         // Monero local address types are mainnet address types
         if network != accordant_addr.network.into() && network != Network::Local {

--- a/src/grpcd/runtime.rs
+++ b/src/grpcd/runtime.rs
@@ -235,6 +235,7 @@ impl Farcaster for FarcasterService {
                 Ok(GrpcResponse::new(reply))
             }
             Err(error) => Err(Status::internal(format!("{}", error))),
+            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::invalid_argument("received invalid response")),
         }
     }
@@ -259,6 +260,7 @@ impl Farcaster for FarcasterService {
                 Ok(GrpcResponse::new(reply))
             }
             Err(error) => Err(Status::internal(format!("{}", error))),
+            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::invalid_argument("received invalid response")),
         }
     }
@@ -290,6 +292,7 @@ impl Farcaster for FarcasterService {
                 Ok(GrpcResponse::new(reply))
             }
             Err(error) => Err(Status::internal(format!("{}", error))),
+            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::invalid_argument("received invalid response")),
         }
     }
@@ -331,9 +334,13 @@ impl Farcaster for FarcasterService {
                         };
                         Ok(GrpcResponse::new(reply))
                     }
+                    Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => {
+                        Err(Status::internal(info))
+                    }
                     _ => Err(Status::internal(format!("Received invalid response"))),
                 }
             }
+            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }
@@ -460,6 +467,7 @@ impl Farcaster for FarcasterService {
                 };
                 Ok(GrpcResponse::new(reply))
             }
+            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }
@@ -487,6 +495,7 @@ impl Farcaster for FarcasterService {
                 let reply = farcaster::RevokeOfferResponse { id };
                 Ok(GrpcResponse::new(reply))
             }
+            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }
@@ -544,6 +553,7 @@ impl Farcaster for FarcasterService {
                 };
                 Ok(GrpcResponse::new(reply))
             }
+            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }
@@ -576,6 +586,7 @@ impl Farcaster for FarcasterService {
                 };
                 Ok(GrpcResponse::new(reply))
             }
+            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }
@@ -622,9 +633,13 @@ impl Farcaster for FarcasterService {
                             let reply = SweepAddressResponse { id, message };
                             Ok(GrpcResponse::new(reply))
                         }
+                        Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => {
+                            Err(Status::internal(info))
+                        }
                         _ => Err(Status::internal(format!("Received invalid response"))),
                     }
                 }
+                Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
                 _ => Err(Status::internal(format!("Received invalid response"))),
             }
         } else if let (Ok(source_address), Ok(destination_address)) = (
@@ -661,9 +676,13 @@ impl Farcaster for FarcasterService {
                             let reply = SweepAddressResponse { id, message };
                             Ok(GrpcResponse::new(reply))
                         }
+                        Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => {
+                            Err(Status::internal(info))
+                        }
                         _ => Err(Status::internal(format!("Received invalid response"))),
                     }
                 }
+                Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
                 _ => Err(Status::internal(format!("Received invalid response"))),
             }
         } else {
@@ -748,6 +767,7 @@ impl Farcaster for FarcasterService {
                 let reply = farcaster::TakeResponse { id };
                 Ok(GrpcResponse::new(reply))
             }
+            Ok(BusMsg::Ctl(Ctl::Failure(Failure { info, .. }))) => Err(Status::internal(info)),
             _ => Err(Status::internal(format!("Received invalid response"))),
         }
     }

--- a/src/grpcd/runtime.rs
+++ b/src/grpcd/runtime.rs
@@ -338,6 +338,8 @@ impl Farcaster for FarcasterService {
                 public_offer.offer.accordant_blockchain,
             )
             .into(),
+            node_id: public_offer.node_id.to_string(),
+            peer_address: public_offer.peer_address.to_string(),
         };
         Ok(GrpcResponse::new(reply))
     }

--- a/src/grpcd/runtime.rs
+++ b/src/grpcd/runtime.rs
@@ -221,7 +221,11 @@ impl Farcaster for FarcasterService {
                     uptime: info.uptime.as_secs(),
                     since: info.since,
                     peers: info.peers.iter().map(|peer| format!("{}", peer)).collect(),
-                    swaps: info.swaps.iter().map(|swap| format!("{}", swap)).collect(),
+                    swaps: info
+                        .swaps
+                        .iter()
+                        .map(|swap| format!("{:#x}", swap))
+                        .collect(),
                     offers: info
                         .offers
                         .iter()

--- a/src/grpcd/runtime.rs
+++ b/src/grpcd/runtime.rs
@@ -813,8 +813,13 @@ fn response_loop(
 
 fn server_loop(service: FarcasterService, addr: SocketAddr) -> tokio::task::JoinHandle<()> {
     tokio::task::spawn(async move {
+        let web_service = tonic_web::config()
+            .allow_all_origins()
+            .enable(FarcasterServer::new(service));
+
         Server::builder()
-            .add_service(FarcasterServer::new(service))
+            .accept_http1(true)
+            .add_service(web_service)
             .serve(addr)
             .await
             .expect("error running grpc server");

--- a/src/grpcd/runtime.rs
+++ b/src/grpcd/runtime.rs
@@ -79,30 +79,11 @@ impl From<TradeRole> for farcaster::TradeRole {
     }
 }
 
-impl From<SwapRole> for farcaster::SwapRole {
-    fn from(t: SwapRole) -> farcaster::SwapRole {
-        match t {
-            SwapRole::Alice => farcaster::SwapRole::Alice,
-            SwapRole::Bob => farcaster::SwapRole::Bob,
-        }
-    }
-}
-
 impl From<farcaster::SwapRole> for SwapRole {
     fn from(t: farcaster::SwapRole) -> SwapRole {
         match t {
             farcaster::SwapRole::Alice => SwapRole::Alice,
             farcaster::SwapRole::Bob => SwapRole::Bob,
-        }
-    }
-}
-
-impl From<Network> for farcaster::Network {
-    fn from(t: Network) -> farcaster::Network {
-        match t {
-            Network::Mainnet => farcaster::Network::Mainnet,
-            Network::Testnet => farcaster::Network::Testnet,
-            Network::Local => farcaster::Network::Local,
         }
     }
 }
@@ -113,15 +94,6 @@ impl From<farcaster::Network> for Network {
             farcaster::Network::Mainnet => Network::Mainnet,
             farcaster::Network::Testnet => Network::Testnet,
             farcaster::Network::Local => Network::Local,
-        }
-    }
-}
-
-impl From<Blockchain> for farcaster::Blockchain {
-    fn from(t: Blockchain) -> farcaster::Blockchain {
-        match t {
-            Blockchain::Monero => farcaster::Blockchain::Monero,
-            Blockchain::Bitcoin => farcaster::Blockchain::Bitcoin,
         }
     }
 }

--- a/tests/cfg/fc2.ci.toml
+++ b/tests/cfg/fc2.ci.toml
@@ -1,3 +1,7 @@
+[farcasterd.grpc]
+use_grpc = true
+port = 23433
+
 [syncers.local]
 electrum_server = "tcp://electrs:60401"
 monero_daemon = "http://monerod:18081"

--- a/tests/cfg/fc2.toml
+++ b/tests/cfg/fc2.toml
@@ -1,3 +1,7 @@
+[farcasterd.grpc]
+use_grpc = true
+port = 23433
+
 [syncers.local]
 electrum_server = "tcp://localhost:60401"
 monero_daemon = "http://localhost:18081"

--- a/tests/grpc.rs
+++ b/tests/grpc.rs
@@ -3,6 +3,7 @@ extern crate log;
 
 use crate::farcaster::{
     farcaster_client::FarcasterClient, CheckpointsRequest, MakeRequest, PeersRequest,
+    RevokeOfferRequest,
 };
 use bitcoincore_rpc::RpcApi;
 use farcaster::InfoRequest;
@@ -69,6 +70,14 @@ async fn grpc_server_functional_test() {
     });
 
     let response = farcaster_client.make(request).await;
+    println!("response: {:?}", response);
+    let offer = response.unwrap().into_inner().offer;
+
+    let request = tonic::Request::new(RevokeOfferRequest {
+        id: 4,
+        public_offer: offer.to_string(),
+    });
+    let response = farcaster_client.revoke_offer(request).await;
     println!("response: {:?}", response);
 
     kill_all();

--- a/tests/grpc.rs
+++ b/tests/grpc.rs
@@ -2,11 +2,13 @@
 extern crate log;
 
 use crate::farcaster::{
-    farcaster_client::FarcasterClient, CheckpointsRequest, MakeRequest, PeersRequest,
-    RevokeOfferRequest, TakeRequest,
+    farcaster_client::FarcasterClient, AbortSwapRequest, CheckpointsRequest, InfoResponse,
+    MakeRequest, NeedsFundingRequest, PeersRequest, ProgressRequest, RevokeOfferRequest,
+    SweepAddressRequest, TakeRequest,
 };
 use bitcoincore_rpc::RpcApi;
-use farcaster::{InfoRequest, MakeResponse};
+use farcaster::{InfoRequest, MakeResponse, NeedsFundingResponse};
+use farcaster_node::bus::ctl::BitcoinFundingInfo;
 use std::{str::FromStr, sync::Arc, time};
 use tonic::transport::Endpoint;
 use utils::fc::*;
@@ -86,9 +88,11 @@ async fn grpc_server_functional_test() {
     let response = farcaster_client_1.revoke_offer(request).await;
     assert_eq!(response.unwrap().into_inner().id, 4);
 
+    // make another offer
     let request = tonic::Request::new(make_request.clone());
     let response = farcaster_client_1.make(request).await;
-    assert_eq!(response.unwrap().into_inner().id, 3);
+    let MakeResponse { id, offer } = response.unwrap().into_inner();
+    assert_eq!(id, 3);
 
     let (xmr_address, _xmr_address_wallet_name) =
         monero_new_dest_address(Arc::clone(&monero_wallet)).await;
@@ -104,5 +108,68 @@ async fn grpc_server_functional_test() {
     let response = farcaster_client_2.take(request).await;
     assert_eq!(response.unwrap().into_inner().id, 5);
 
+    tokio::time::sleep(time::Duration::from_secs(5)).await;
+
+    let request = tonic::Request::new(InfoRequest { id: 6 });
+    let InfoResponse { swaps, .. } = farcaster_client_2.info(request).await.unwrap().into_inner();
+    let swap_id = swaps[0].clone();
+
+    tokio::time::sleep(time::Duration::from_secs(5)).await;
+
+    let request = tonic::Request::new(ProgressRequest {
+        id: 10,
+        swap_id: swap_id.clone(),
+    });
+    let response = farcaster_client_2.progress(request).await;
+    println!("response: {:?}", response);
+    assert_eq!(response.unwrap().into_inner().id, 10);
+
+    tokio::time::sleep(time::Duration::from_secs(5)).await;
+
+    let request = tonic::Request::new(NeedsFundingRequest {
+        id: 11,
+        blockchain: farcaster::Blockchain::Bitcoin.into(),
+    });
+    let response = farcaster_client_1.needs_funding(request).await;
+    println!("response: {:?}", response);
+    let NeedsFundingResponse { id, funding_infos } = response.unwrap().into_inner();
+    assert_eq!(id, 11);
+
+    let funding_info = BitcoinFundingInfo::from_str(&funding_infos).unwrap();
+    bitcoin_rpc
+        .send_to_address(
+            &funding_info.address,
+            funding_info.amount,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    // tokio::time::sleep(time::Duration::from_secs(5)).await;
+    let request = tonic::Request::new(AbortSwapRequest { id: 12, swap_id });
+    let response = farcaster_client_1.abort_swap(request).await;
+    println!("response: {:?}", response);
+    assert_eq!(response.unwrap().into_inner().id, 12);
+
     kill_all();
+
+    let _ = setup_clients().await;
+    let btc_address = bitcoin_rpc.get_new_address(None, None).unwrap();
+    let channel_1 = Endpoint::from_static("http://0.0.0.0:23432")
+        .connect()
+        .await
+        .unwrap();
+    let mut farcaster_client_1 = FarcasterClient::new(channel_1);
+    let request = tonic::Request::new(SweepAddressRequest {
+        id: 13,
+        source_address: funding_info.address.to_string(),
+        destination_address: btc_address.to_string(),
+    });
+    let response = farcaster_client_1.sweep_address(request).await;
+    println!("response: {:?}", response);
+    assert_eq!(response.unwrap().into_inner().id, 13);
 }

--- a/tests/grpc.rs
+++ b/tests/grpc.rs
@@ -3,8 +3,9 @@ extern crate log;
 
 use crate::farcaster::{
     farcaster_client::FarcasterClient, AbortSwapRequest, CheckpointsRequest, InfoResponse,
-    MakeRequest, NeedsFundingRequest, PeersRequest, ProgressRequest, RestoreCheckpointRequest,
-    RevokeOfferRequest, SweepAddressRequest, TakeRequest,
+    MakeRequest, NeedsFundingRequest, OfferInfoRequest, PeersRequest, ProgressRequest,
+    RestoreCheckpointRequest, RevokeOfferRequest, SwapInfoRequest, SweepAddressRequest,
+    TakeRequest,
 };
 use bitcoincore_rpc::RpcApi;
 use farcaster::{InfoRequest, MakeResponse, NeedsFundingResponse};
@@ -101,6 +102,14 @@ async fn grpc_server_functional_test() {
     let (xmr_address, _xmr_address_wallet_name) =
         monero_new_dest_address(Arc::clone(&monero_wallet)).await;
     let btc_address = bitcoin_rpc.get_new_address(None, None).unwrap();
+
+    // Test Offer info
+    let offer_info_request = tonic::Request::new(OfferInfoRequest {
+        id: 21,
+        public_offer: offer.clone().to_string(),
+    });
+    let response = farcaster_client_2.offer_info(offer_info_request).await;
+    assert_eq!(response.unwrap().into_inner().id, 21);
 
     // Test take offer
     let take_request = TakeRequest {
@@ -224,6 +233,14 @@ async fn grpc_server_functional_test() {
             None,
         )
         .unwrap();
+
+    // test swap info
+    let request = tonic::Request::new(SwapInfoRequest {
+        id: 20,
+        swap_id: swap_id.clone(),
+    });
+    let response = farcaster_client_1.swap_info(request).await;
+    assert_eq!(response.unwrap().into_inner().id, 20);
     // wait for lock
     tokio::time::sleep(time::Duration::from_secs(5)).await;
     kill_all();

--- a/tests/grpc.rs
+++ b/tests/grpc.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate log;
 
-use crate::farcaster::farcaster_client::FarcasterClient;
+use crate::farcaster::{farcaster_client::FarcasterClient, CheckpointsRequest, PeersRequest};
 use farcaster::InfoRequest;
 use std::time;
 use tonic::transport::Endpoint;
@@ -30,6 +30,15 @@ async fn grpc_server_functional_test() {
     let request = tonic::Request::new(InfoRequest { id: 0 });
     let response = farcaster_client.info(request).await;
     assert_eq!(response.unwrap().into_inner().id, 0);
+
+    let request = tonic::Request::new(PeersRequest { id: 1 });
+    let response = farcaster_client.peers(request).await;
+    assert_eq!(response.unwrap().into_inner().id, 1);
+
+    let request = tonic::Request::new(CheckpointsRequest { id: 2 });
+    let response = farcaster_client.checkpoints(request).await;
+    println!("response: {:?}", response);
+    assert_eq!(response.unwrap().into_inner().id, 2);
 
     kill_all();
 }


### PR DESCRIPTION
This pull requests implements additional endpoints for listing peers and checkpoint entries, restoring checkpoints, making and taking offers, revoking offers, aborting swaps, and sweeping coins. 

The grpc server can now handle sending to arbitrary services. Additionally, sending messages back to the client has been extended for including grpc as a possible client, where applicable.

In order to route all possible grpc request messages across all possible service busses through the grpc daemon bridge, a separate BridgeMsg message type was added, acting as a wrapper for the messages and their destination.

Getting full test coverage on this PR is nigh impossible, since there are an abundance of failure paths. This PR does extend the tests though by adding a happy path test for each possible grpc request.

I'd also like to request additional scrutiny of the chosen protobuf types. There are a lot of primitive types that might have better alternatives. I especially dislike the excessive usage of strings. The `needs_funding` and `progress` responses are currently only strings that need to be additionally interpreted and parsed by grpc clients. However, these calls should be refactored outside of this PR.