### PR TITLE
Fix(syncer_client): remove dangerous unwrap in handle tx confs

### DIFF
--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -359,14 +359,16 @@ impl SyncerState {
                     "confirmations".bright_green_bold()
                 );
                 self.tasks.final_txs.insert(*txlabel, true);
-            } else if self.tasks.final_txs.contains_key(txlabel) {
-                debug!(
-                    "{} | Tx {} {} with {} {}",
+            } else if let Some(finality) = self.tasks.final_txs.get(txlabel) {
+                info!(
+                    "{} | Tx {} {}",
                     self.swap_id.swap_id(),
                     txlabel.label(),
-                    "final".bright_green_bold(),
-                    confirmations.unwrap().bright_green_bold(),
-                    "confirmations".bright_green_bold()
+                    if *finality {
+                        "final".bright_green_bold()
+                    } else {
+                        "non-final".red_bold()
+                    },
                 );
             } else {
                 match confirmations {


### PR DESCRIPTION
Fix issue reported by @Lederstrumpf on IRC

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/swapd/syncer_client.rs:368:35
```

This PR change the printing logic of this dangerous `unwrap` (the one before is safe as the condition checks for `is_some`) to not print the variable `confirmations`. Previous code checked if the tx was inserted in the final tx map, now if retrieve the value in the map and print `final` or `non-final`.

A general comments on this piece of code: the map structure is not really used as I only found `insert(txlabel, true)` and nothing else, this is equivalent to simply using a set.