### PR TITLE
Bugfix: Use refund address for sweeping bitcoin through walletd

### DIFF
--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -1620,16 +1620,13 @@ impl Runtime {
 
             BusMsg::Ctl(Ctl::GetSweepBitcoinAddress(source_address)) => {
                 let swap_id = get_swap_id(&source)?;
-                if let Some(Wallet::Bob(BobState { key_manager, .. })) =
-                    self.wallets.get_mut(&swap_id)
+                if let Some(Wallet::Bob(BobState {
+                    key_manager, bob, ..
+                })) = self.wallets.get_mut(&swap_id)
                 {
                     let source_secret_key =
                         key_manager.get_or_derive_bitcoin_key(ArbitratingKeyId::Lock)?;
-                    let destination_address = self
-                        .btc_addrs
-                        .get(&swap_id)
-                        .expect("checked at start of swap")
-                        .clone();
+                    let destination_address = bob.refund_address.clone();
                     endpoints.send_to(
                         ServiceBus::Ctl,
                         self.identity(),


### PR DESCRIPTION
This allows us to circumvent any dangers incurred from getting the btc addresses.