### PR TITLE
Cli: Implement endpoint for checking syncer health

### DIFF
--- a/src/bus/ctl.rs
+++ b/src/bus/ctl.rs
@@ -1,6 +1,7 @@
 use std::fmt::{self, Debug};
 use std::str::FromStr;
 
+use farcaster_core::blockchain::Network;
 use farcaster_core::{
     blockchain::Blockchain,
     role::TradeRole,
@@ -18,7 +19,7 @@ use crate::bus::{
     AddressSecretKey, CheckpointEntry, Failure, OfferStatusPair, OptionDetails, Outcome, Progress,
 };
 use crate::swapd::CheckpointSwapd;
-use crate::syncerd::SweepAddressAddendum;
+use crate::syncerd::{Health, SweepAddressAddendum};
 use crate::walletd::runtime::CheckpointWallet;
 use crate::{Error, ServiceId};
 
@@ -158,6 +159,12 @@ pub enum CtlMsg {
 
     #[display("connect failed")]
     ConnectFailed,
+
+    #[display("health_check({0} {1})")]
+    HealthCheck(Blockchain, Network),
+
+    #[display("health_result({0})")]
+    HealthResult(Health),
 }
 
 #[derive(Clone, Debug, Display, NetworkEncode, NetworkDecode)]

--- a/src/bus/types.rs
+++ b/src/bus/types.rs
@@ -11,6 +11,7 @@ use microservices::rpc;
 use strict_encoding::{NetworkDecode, NetworkEncode};
 
 use crate::swapd::StateReport;
+use crate::syncerd::Health;
 
 #[derive(Clone, PartialEq, Eq, Debug, Display, NetworkEncode, NetworkDecode)]
 #[display("{swap_id}, {public_offer}")]
@@ -193,3 +194,22 @@ impl From<FailureCode> for rpc::FailureCode<FailureCode> {
 }
 
 impl rpc::FailureCodeExt for FailureCode {}
+
+#[derive(Clone, Debug, Display, NetworkEncode, NetworkDecode)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
+#[display(HealthReport::to_yaml_string)]
+pub struct HealthReport {
+    pub bitcoin_mainnet_health: Health,
+    pub bitcoin_testnet_health: Health,
+    pub bitcoin_local_health: Health,
+    pub monero_mainnet_health: Health,
+    pub monero_testnet_health: Health,
+    pub monero_local_health: Health,
+}
+
+#[cfg(feature = "serde")]
+impl ToYamlString for HealthReport {}

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -101,6 +101,10 @@ pub enum Command {
     #[clap(aliases = &["lc"])]
     ListCheckpoints,
 
+    /// Checks the health of the syncers
+    #[clap(aliases = &["hc"])]
+    HealthCheck,
+
     /// Restores saved checkpoint of a swap
     #[clap(aliases = &["r"])]
     RestoreCheckpoint {

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -25,7 +25,7 @@ use crate::farcasterd::stats::Stats;
 use crate::farcasterd::syncer_state_machine::{SyncerStateMachine, SyncerStateMachineExecutor};
 use crate::farcasterd::trade_state_machine::{TradeStateMachine, TradeStateMachineExecutor};
 use crate::farcasterd::Opts;
-use crate::syncerd::{Event as SyncerEvent, SweepSuccess, TaskId};
+use crate::syncerd::{Event as SyncerEvent, HealthResult, SweepSuccess, TaskId};
 use crate::{
     bus::ctl::{Keys, LaunchSwap, ProgressStack, Token},
     bus::info::{InfoMsg, NodeInfo, OfferInfo, OfferStatusSelector, ProgressEvent, SwapProgress},
@@ -844,8 +844,15 @@ impl Runtime {
     ) -> Result<Option<SyncerStateMachine>, Error> {
         match (req, source) {
             (BusMsg::Ctl(CtlMsg::SweepAddress(..)), _) => Ok(Some(SyncerStateMachine::Start)),
+            (BusMsg::Ctl(CtlMsg::HealthCheck(..)), _) => Ok(Some(SyncerStateMachine::Start)),
             (
                 BusMsg::Sync(SyncMsg::Event(SyncerEvent::SweepSuccess(SweepSuccess {
+                    id, ..
+                }))),
+                _,
+            ) => Ok(self.syncer_state_machines.remove(&id)),
+            (
+                BusMsg::Sync(SyncMsg::Event(SyncerEvent::HealthResult(HealthResult {
                     id, ..
                 }))),
                 _,

--- a/src/grpcd/proto/farcaster.proto
+++ b/src/grpcd/proto/farcaster.proto
@@ -17,6 +17,21 @@ service Farcaster {
     rpc SweepAddress(SweepAddressRequest) returns (SweepAddressResponse){}
     rpc ConnectSwap(ConnectSwapRequest) returns (ConnectSwapResponse){}
     rpc ListOffers(ListOffersRequest) returns (ListOffersResponse){}
+    rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse){}
+}
+
+message HealthCheckRequest {
+    uint32 id = 1;
+}
+
+message HealthCheckResponse {
+    uint32 id = 1;
+    string bitcoin_mainnet_health = 2;
+    string bitcoin_testnet_health = 3;
+    string bitcoin_local_health = 4;
+    string monero_mainnet_health = 5;
+    string monero_testnet_health = 6;
+    string monero_local_health = 7;
 }
 
 message InfoRequest {

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -2563,6 +2563,10 @@ impl Runtime {
                         }
                     }
                     Event::Empty(_) => debug!("empty event not handled for Bitcoin"),
+
+                    Event::HealthResult(_) => {
+                        debug!("ignoring health result in swapd")
+                    }
                 }
             }
 

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -773,9 +773,17 @@ impl SyncerState {
         self.sweep_addresses.remove(id);
         self.tasks_sources.remove(id);
     }
+
+    pub async fn health_result(&mut self, id: TaskId, health: Health, source: ServiceId) {
+        send_event(
+            &self.tx_event,
+            &mut vec![(Event::HealthResult(HealthResult { id, health }), source)],
+        )
+        .await;
+    }
 }
 
-async fn send_event(tx_event: &TokioSender<BridgeEvent>, events: &mut Vec<(Event, ServiceId)>) {
+pub async fn send_event(tx_event: &TokioSender<BridgeEvent>, events: &mut Vec<(Event, ServiceId)>) {
     for (event, source) in events.drain(..) {
         tx_event
             .send(BridgeEvent { event, source })

--- a/src/syncerd/types.rs
+++ b/src/syncerd/types.rs
@@ -237,6 +237,17 @@ pub struct WatchEstimateFee {
     pub lifetime: u64,
 }
 
+#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
+#[display(Debug)]
+pub struct HealthCheck {
+    pub id: TaskId,
+}
+
 /// Tasks created by the daemon and handle by syncers to process a blockchain
 /// and generate [`Event`] back to the syncer.
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
@@ -255,6 +266,7 @@ pub enum Task {
     SweepAddress(SweepAddress),
     GetTx(GetTx),
     WatchEstimateFee(WatchEstimateFee),
+    HealthCheck(HealthCheck),
     Terminate,
 }
 
@@ -334,6 +346,28 @@ pub enum FeeEstimations {
     },
 }
 
+#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[display(Debug)]
+pub struct HealthResult {
+    pub id: TaskId,
+    pub health: Health,
+}
+
+#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
+#[display(Debug)]
+pub enum Health {
+    Healthy,
+    FaultyElectrum(String),
+    FaultyMoneroDaemon(String),
+    FaultyMoneroRpcWallet(String),
+    ConfigUnavailable(String),
+}
+
 /// Events returned by syncers to the daemon to update the blockchain states.
 /// Events are identified with a unique 32-bits integer that match the [`Task`]
 /// id.
@@ -353,4 +387,5 @@ pub enum Event {
     FeeEstimation(FeeEstimation),
     /// Empty event to signify that a task with a certain id has not produced an initial result
     Empty(TaskId),
+    HealthResult(HealthResult),
 }


### PR DESCRIPTION
This adds a cli command "health-check" for checking the configuration and required environment (e.g. the to-be-connected coin daemons, wallets, etc.) of a syncer.

To this end, this commit also adds a HealthCheck event that can be dispatched to a syncer. The various syncers make simple calls to the respective coin daemons and report their success back in the form of a HealthResult event.

The "health-check" command makes use of the syncer state machine in farcasterd to startup syncers and route calls back to the client.