### PR TITLE
Peerd: Use message receipts to confirm receival

### DIFF
--- a/src/bus/ctl.rs
+++ b/src/bus/ctl.rs
@@ -13,7 +13,7 @@ use bitcoin::Transaction;
 use internet2::addr::{InetSocketAddr, NodeAddr};
 use strict_encoding::{NetworkDecode, NetworkEncode};
 
-use crate::bus::p2p::{Commit, TakerCommit};
+use crate::bus::p2p::{Commit, PeerMsg, TakerCommit};
 use crate::bus::{
     AddressSecretKey, CheckpointEntry, Failure, OfferStatusPair, OptionDetails, Outcome, Progress,
 };
@@ -140,6 +140,9 @@ pub enum CtlMsg {
 
     #[display("transaction({0})")]
     Tx(Tx),
+
+    #[display("failed peer message")]
+    FailedPeerMessage(PeerMsg),
 }
 
 #[derive(Clone, Debug, Display, NetworkEncode, NetworkDecode)]

--- a/src/bus/p2p.rs
+++ b/src/bus/p2p.rs
@@ -62,6 +62,10 @@ pub enum PeerMsg {
     #[api(type = 33801)]
     #[display("error_shutdown()")]
     PeerReceiverRuntimeShutdown,
+
+    #[api(type = 33802)]
+    #[display("msg_receipt {0}")]
+    MsgReceipt(Receipt),
 }
 
 impl PeerMsg {
@@ -76,6 +80,7 @@ impl PeerMsg {
             PeerMsg::Abort(Abort { swap_id, .. }) => *swap_id,
             PeerMsg::CoreArbitratingSetup(CoreArbitratingSetup { swap_id, .. }) => *swap_id,
             PeerMsg::BuyProcedureSignature(BuyProcedureSignature { swap_id, .. }) => *swap_id,
+            PeerMsg::MsgReceipt(Receipt { swap_id, .. }) => *swap_id,
             PeerMsg::Ping(_)
             | PeerMsg::Pong(_)
             | PeerMsg::PingPeer
@@ -99,6 +104,7 @@ impl PeerMsg {
                 | PeerMsg::BuyProcedureSignature(_)
                 | PeerMsg::Ping(_)
                 | PeerMsg::Pong(_)
+                | PeerMsg::MsgReceipt(_)
         )
     }
 
@@ -174,4 +180,11 @@ impl Commit {
             Self::BobParameters(c) => c.swap_id,
         }
     }
+}
+
+#[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
+#[display("receipt")]
+pub struct Receipt {
+    pub swap_id: SwapId,
+    pub msg_type: internet2::TypeId,
 }

--- a/src/peerd/runtime.rs
+++ b/src/peerd/runtime.rs
@@ -12,9 +12,11 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
+use farcaster_core::swap::SwapId;
 use internet2::addr::LocalNode;
 use microservices::peer::PeerReceiver;
 use microservices::peer::RecvMessage;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::thread::spawn;
 use std::time::{Duration, SystemTime};
@@ -33,6 +35,7 @@ use microservices::node::TryService;
 use microservices::peer::{self, PeerConnection, PeerSender, SendMessage};
 use microservices::ZMQ_CONTEXT;
 
+use crate::bus::p2p::Receipt;
 use crate::bus::{
     ctl::CtlMsg,
     info::{InfoMsg, PeerInfo},
@@ -149,6 +152,7 @@ pub fn run(
         messages_received: 0,
         awaited_pong: None,
         thread_flag_tx,
+        unchecked_msg_cache: empty!(),
     };
     let mut service = Service::service(config, runtime)?;
     service.add_bridge_service_bus(rx)?;
@@ -286,6 +290,8 @@ pub struct Runtime {
     messages_received: usize,
     awaited_pong: Option<u16>,
 
+    unchecked_msg_cache: HashMap<(SwapId, internet2::TypeId), PeerMsg>,
+
     thread_flag_tx: std::sync::mpsc::Sender<()>,
 }
 
@@ -326,8 +332,8 @@ impl esb::Handler<ServiceBus> for Runtime {
             (ServiceBus::Ctl, BusMsg::Ctl(req)) => self.handle_ctl(endpoints, source, req),
             // RPC command bus, only accept BusMsg::Info
             (ServiceBus::Info, BusMsg::Info(req)) => self.handle_info(endpoints, source, req),
-            // Internal peerd bridge for inner communication, accept all type of request
-            (ServiceBus::Bridge, request) => self.handle_bridge(endpoints, source, request),
+            // Internal peerd bridge for inner communication, only accept BusMsg::P2p
+            (ServiceBus::Bridge, BusMsg::P2p(req)) => self.handle_bridge(endpoints, source, req),
             // All other pairs are not supported
             (_, request) => Err(Error::NotSupported(bus, request.to_string())),
         }
@@ -343,7 +349,7 @@ impl esb::Handler<ServiceBus> for Runtime {
 }
 
 impl Runtime {
-    /// send messages over the bridge
+    /// send messages over the peer connection
     fn handle_msg(
         &mut self,
         endpoints: &mut Endpoints,
@@ -361,6 +367,15 @@ impl Runtime {
             debug!("Error sending to remote peer in peerd runtime: {}", err);
             // If this is the listener-forked peerd, i.e. the maker's peerd, terminate it.
             if self.forked_from_listener {
+                for (_, cached_msg) in self.unchecked_msg_cache.drain() {
+                    // Draining cached messages to the various running swaps
+                    endpoints.send_to(
+                        ServiceBus::Ctl,
+                        self.identity.clone(),
+                        ServiceId::Swap(cached_msg.swap_id()),
+                        BusMsg::Ctl(CtlMsg::FailedPeerMessage(cached_msg)),
+                    )?;
+                }
                 endpoints.send_to(
                     ServiceBus::Ctl,
                     self.identity(),
@@ -374,7 +389,21 @@ impl Runtime {
             while let Err(err) = self.reconnect_peer() {
                 warn!("error during reconnection attempt: {}", err);
             }
+
+            for cached_msg in self.unchecked_msg_cache.values() {
+                if let Err(err) = self.peer_sender.send_message(cached_msg.clone()) {
+                    debug!(
+                        "Error re-sending cache messages to remote peer in peerd runtime: {}",
+                        err
+                    );
+                    break;
+                }
+            }
         }
+
+        // add the message to the unchecked cache
+        self.unchecked_msg_cache
+            .insert((message.swap_id(), message.get_type()), message.clone());
 
         if message.is_protocol() {
             let swap_id = message.swap_id();
@@ -498,24 +527,22 @@ impl Runtime {
     fn handle_bridge(
         &mut self,
         endpoints: &mut Endpoints,
-        _source: ServiceId,
-        request: BusMsg,
+        source: ServiceId,
+        request: PeerMsg,
     ) -> Result<(), Error> {
         debug!("BRIDGE RPC request: {}", request);
 
-        if let BusMsg::P2p(_) = request {
-            self.messages_received += 1;
-        }
+        self.messages_received += 1;
 
         match &request {
-            BusMsg::P2p(PeerMsg::PingPeer) => self.ping()?,
+            PeerMsg::PingPeer => self.ping()?,
 
-            BusMsg::P2p(PeerMsg::Ping(pong_size)) => {
+            PeerMsg::Ping(pong_size) => {
                 debug!("receiving ping, ponging back");
                 self.pong(*pong_size)?
             }
 
-            BusMsg::P2p(PeerMsg::Pong(noise)) => {
+            PeerMsg::Pong(noise) => {
                 match self.awaited_pong {
                     None => error!("Unexpected pong from the remote peer"),
                     Some(len) if len as usize != noise.len() => {
@@ -526,7 +553,7 @@ impl Runtime {
                 self.awaited_pong = None;
             }
 
-            BusMsg::P2p(PeerMsg::PeerReceiverRuntimeShutdown) => {
+            PeerMsg::PeerReceiverRuntimeShutdown => {
                 warn!("Exiting peerd receiver runtime");
                 // If this is the listener-forked peerd, i.e. the maker's peerd, terminate it.
                 if self.forked_from_listener {
@@ -536,6 +563,19 @@ impl Runtime {
                         ServiceId::Farcasterd,
                         BusMsg::Ctl(CtlMsg::PeerdTerminated),
                     )?;
+                    for ((swap_id, _), cached_msg) in self.unchecked_msg_cache.drain() {
+                        // Draining cached messages to the various running swaps
+                        debug!(
+                            "Returning cache message {} back to swap {}",
+                            cached_msg, swap_id
+                        );
+                        endpoints.send_to(
+                            ServiceBus::Ctl,
+                            self.identity.clone(),
+                            ServiceId::Swap(swap_id),
+                            BusMsg::Ctl(CtlMsg::FailedPeerMessage(cached_msg)),
+                        )?;
+                    }
                     warn!("Exiting peerd");
                     std::process::exit(0);
                 }
@@ -543,25 +583,50 @@ impl Runtime {
                 while let Err(err) = self.reconnect_peer() {
                     warn!("error during reconnection attempt: {}", err);
                 }
+                for cached_msg in self.unchecked_msg_cache.values() {
+                    info!("re-emitting cached message after reconnect: {}", cached_msg);
+                    if let Err(err) = self.peer_sender.send_message(cached_msg.clone()) {
+                        debug!(
+                            "Error re-sending cache messages to remote peer in peerd runtime: {}",
+                            err
+                        );
+                        break;
+                    }
+                }
+            }
+
+            PeerMsg::MsgReceipt(receipt) => {
+                debug!("received receipt: {:?}", receipt);
+                self.unchecked_msg_cache
+                    .remove(&(receipt.swap_id, receipt.msg_type));
             }
 
             // swap initiation message
-            BusMsg::P2p(PeerMsg::TakerCommit(_)) => {
+            PeerMsg::TakerCommit(_) => {
                 let swap_id = request.swap_id();
-                info!(
-                    "{} | Received the {} protocol message",
-                    swap_id.swap_id(),
-                    request.label()
-                );
+                let msg_type = request.get_type();
                 endpoints.send_to(
                     ServiceBus::Msg,
                     self.identity(),
                     ServiceId::Farcasterd,
-                    request,
+                    BusMsg::P2p(request),
+                )?;
+
+                // send a receipt back to the remote peer
+                self.handle_msg(
+                    endpoints,
+                    source,
+                    PeerMsg::MsgReceipt(Receipt { swap_id, msg_type }),
                 )?;
             }
 
-            BusMsg::P2p(msg) => {
+            msg => {
+                // send a receipt back to the remote peer
+                self.peer_sender.send_message(PeerMsg::MsgReceipt(Receipt {
+                    swap_id: request.swap_id(),
+                    msg_type: request.get_type(),
+                }))?;
+
                 let swap_id = msg.swap_id();
                 info!(
                     "{} | Received the {} protocol message",
@@ -572,14 +637,8 @@ impl Runtime {
                     ServiceBus::Msg,
                     self.identity(),
                     ServiceId::Swap(swap_id),
-                    request,
+                    BusMsg::P2p(request),
                 )?;
-            }
-
-            other => {
-                error!("BusMsg is not supported by the BRIDGE interface");
-                dbg!(other);
-                return Err(Error::NotSupported(ServiceBus::Bridge, request.to_string()));
             }
         }
         Ok(())

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -1477,6 +1477,14 @@ impl Runtime {
                 self.pending_peer_request.clear();
             }
 
+            CtlMsg::FailedPeerMessage(msg) => {
+                warn!(
+                    "{} | Sending the peer message {} failed. Adding to pending peer requests",
+                    self.swap_id, msg
+                );
+                self.pending_peer_request.push(msg);
+            }
+
             CtlMsg::Checkpoint(Checkpoint { swap_id, state }) => match state {
                 CheckpointState::CheckpointSwapd(CheckpointSwapd {
                     state,

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -1096,8 +1096,8 @@ impl Runtime {
         source: ServiceId,
         request: CtlMsg,
     ) -> Result<(), Error> {
-        match (&request, &source) {
-            (CtlMsg::Hello, _) => {
+        match request {
+            CtlMsg::Hello => {
                 info!(
                     "{} | Service {} daemon is now {}",
                     self.swap_id.swap_id(),
@@ -1105,25 +1105,6 @@ impl Runtime {
                     "connected"
                 );
             }
-            (_, ServiceId::Syncer(..)) if self.syncer_state.any_syncer(&source) => {
-            }
-            (
-                _,
-                ServiceId::Farcasterd
-                | ServiceId::Wallet
-                | ServiceId::Database
-                | ServiceId::GrpcdClient(_)
-                | ServiceId::Grpcd
-            ) => {}
-            (CtlMsg::AbortSwap, ServiceId::Client(_)) => {}
-            _ => return Err(Error::Farcaster(
-                "Permission Error: only Farcasterd, Wallet, Client and Syncer can can control swapd"
-                    .to_string(),
-            )),
-        };
-
-        match request {
-            // Terminate this service.
             CtlMsg::Terminate if source == ServiceId::Farcasterd => {
                 info!(
                     "{} | {}",

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -66,18 +66,6 @@ impl SyncerState {
             u64::MAX
         }
     }
-    pub fn syncer(&self, blockchain: Blockchain) -> &ServiceId {
-        match blockchain {
-            Blockchain::Bitcoin => &self.bitcoin_syncer,
-            Blockchain::Monero => &self.monero_syncer,
-        }
-    }
-    pub fn is_syncer(&self, blockchain: Blockchain, source: &ServiceId) -> bool {
-        self.syncer(blockchain) == source
-    }
-    pub fn any_syncer(&self, source: &ServiceId) -> bool {
-        self.is_syncer(Blockchain::Bitcoin, source) || self.is_syncer(Blockchain::Monero, source)
-    }
     pub fn bitcoin_syncer(&self) -> ServiceId {
         self.bitcoin_syncer.clone()
     }


### PR DESCRIPTION
Peer messages sent to a remote peer are now cached until the remote peer has replied with a corresponding receipt.

If the connection fails in a listener spawned peerd, the cache is emptied before peerd shuts down and the messages are sent back to their respective origin (swapd). Swapd then processes them into its own cache.

If the connection fails in a connecting peerd, the cache is only emptied once the reconnect has been a success. Messages are not sent back to their origin.