### PR TITLE
Add richer data to the progress messages

### DIFF
--- a/src/bus/info.rs
+++ b/src/bus/info.rs
@@ -289,7 +289,6 @@ pub struct SwapInfo {
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub connection: Option<NodeAddr>,
     pub connected: bool,
-    pub state: String,
     #[serde_as(as = "DurationSeconds")]
     pub uptime: Duration,
     pub since: u64,
@@ -297,6 +296,7 @@ pub struct SwapInfo {
     pub local_trade_role: TradeRole,
     pub local_swap_role: SwapRole,
     pub connected_counterparty_node_id: Option<NodeId>,
+    pub state: StateReport,
 }
 
 #[cfg_attr(feature = "serde", serde_as)]

--- a/src/bus/info.rs
+++ b/src/bus/info.rs
@@ -15,9 +15,11 @@ use crate::bus::{
 };
 use crate::cli::OfferSelector;
 use crate::farcasterd::stats::Stats;
+use crate::swapd::StateReport;
 use crate::syncerd::runtime::SyncerdTask;
 
 use super::ctl::FundingInfo;
+use super::StateTransition;
 
 #[derive(Clone, Debug, Display, From, NetworkEncode, NetworkDecode)]
 #[non_exhaustive]
@@ -332,8 +334,9 @@ pub struct FundingInfos {
 pub enum ProgressEvent {
     #[serde(rename = "message")]
     Message(String),
+    StateUpdate(StateReport),
     #[serde(rename = "transition")]
-    StateTransition(String),
+    StateTransition(StateTransition),
     #[serde(rename = "success")]
     Success(OptionDetails),
     #[serde(rename = "failure")]

--- a/src/bus/info.rs
+++ b/src/bus/info.rs
@@ -334,6 +334,7 @@ pub struct FundingInfos {
 pub enum ProgressEvent {
     #[serde(rename = "message")]
     Message(String),
+    #[serde(rename = "update")]
     StateUpdate(StateReport),
     #[serde(rename = "transition")]
     StateTransition(StateTransition),

--- a/src/bus/types.rs
+++ b/src/bus/types.rs
@@ -80,14 +80,14 @@ impl ToYamlString for OfferStatusPair {}
     serde(crate = "serde_crate")
 )]
 pub enum Outcome {
-    #[display("Success(Swapped)")]
-    Buy,
-    #[display("Failure(Refunded)")]
-    Refund,
-    #[display("Failure(Punished)")]
-    Punish,
-    #[display("Failure(Aborted)")]
-    Abort,
+    #[display("Success Swap")]
+    SuccessSwap,
+    #[display("Failure Refund")]
+    FailureRefund,
+    #[display("Failure Punish")]
+    FailurePunish,
+    #[display("Failure Abort")]
+    FailureAbort,
 }
 
 #[derive(Clone, Debug, Display, NetworkEncode, NetworkDecode)]

--- a/src/bus/types.rs
+++ b/src/bus/types.rs
@@ -10,6 +10,8 @@ use internet2::addr::NodeId;
 use microservices::rpc;
 use strict_encoding::{NetworkDecode, NetworkEncode};
 
+use crate::swapd::StateReport;
+
 #[derive(Clone, PartialEq, Eq, Debug, Display, NetworkEncode, NetworkDecode)]
 #[display("{swap_id}, {public_offer}")]
 #[cfg_attr(
@@ -71,7 +73,7 @@ pub struct OfferStatusPair {
 #[cfg(feature = "serde")]
 impl ToYamlString for OfferStatusPair {}
 
-#[derive(Clone, Debug, Eq, PartialEq, Display, NetworkEncode, NetworkDecode)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Display, NetworkEncode, NetworkDecode)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -92,7 +94,20 @@ pub enum Outcome {
 #[display(inner)]
 pub enum Progress {
     Message(String),
-    StateTransition(String),
+    StateUpdate(StateReport),
+    StateTransition(StateTransition),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Display, NetworkEncode, NetworkDecode)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
+#[display("State transition: {old_state} -> {new_state}")]
+pub struct StateTransition {
+    pub old_state: StateReport,
+    pub new_state: StateReport,
 }
 
 #[derive(Wrapper, Clone, PartialEq, Eq, Debug, From, Default, NetworkEncode, NetworkDecode)]

--- a/src/databased/runtime.rs
+++ b/src/databased/runtime.rs
@@ -747,7 +747,7 @@ fn test_lmdb_state() {
     assert_eq!(offer_1, offers_retrieved[0].offer);
 
     database
-        .set_offer_status(&offer_1, &OfferStatus::Ended(Outcome::Buy))
+        .set_offer_status(&offer_1, &OfferStatus::Ended(Outcome::SuccessSwap))
         .unwrap();
     let offers_retrieved = database.get_offers(OfferStatusSelector::Ended).unwrap();
     assert_eq!(offer_1, offers_retrieved[0].offer);
@@ -758,7 +758,7 @@ fn test_lmdb_state() {
     let offers_retrieved = database.get_offers(OfferStatusSelector::All).unwrap();
     let status_1 = OfferStatusPair {
         offer: offer_1,
-        status: OfferStatus::Ended(Outcome::Buy),
+        status: OfferStatus::Ended(Outcome::SuccessSwap),
     };
     let status_2 = OfferStatusPair {
         offer: offer_2,

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -367,6 +367,14 @@ impl Runtime {
                 let queue = self.progress.get_mut(&source).expect("checked/added above");
                 let prog = match event {
                     CtlMsg::Progress(p) => {
+                        // Replace the latest state update message in the queue
+                        if let Progress::StateUpdate(_) = p {
+                            if let Some(ProgressStack::Progress(Progress::StateUpdate(_))) =
+                                queue.back()
+                            {
+                                queue.pop_back();
+                            }
+                        }
                         (ProgressStack::Progress(p.clone()), InfoMsg::Progress(p))
                     }
                     CtlMsg::Success(s) => (ProgressStack::Success(s.clone()), InfoMsg::Success(s)),
@@ -500,7 +508,12 @@ impl Runtime {
                             ProgressStack::Progress(Progress::Message(m)) => {
                                 swap_progress
                                     .progress
-                                    .push(ProgressEvent::Message(m.clone()));
+                                    .push(ProgressEvent::Message(m.to_string()));
+                            }
+                            ProgressStack::Progress(Progress::StateUpdate(s)) => {
+                                swap_progress
+                                    .progress
+                                    .push(ProgressEvent::StateUpdate(s.clone()));
                             }
                             ProgressStack::Progress(Progress::StateTransition(t)) => {
                                 swap_progress

--- a/src/farcasterd/stats.rs
+++ b/src/farcasterd/stats.rs
@@ -30,10 +30,10 @@ pub struct Stats {
 impl Stats {
     pub fn incr_outcome(&mut self, outcome: &Outcome) {
         match outcome {
-            Outcome::Buy => self.success += 1,
-            Outcome::Refund => self.refund += 1,
-            Outcome::Punish => self.punish += 1,
-            Outcome::Abort => self.abort += 1,
+            Outcome::SuccessSwap => self.success += 1,
+            Outcome::FailureRefund => self.refund += 1,
+            Outcome::FailurePunish => self.punish += 1,
+            Outcome::FailureAbort => self.abort += 1,
         };
     }
 

--- a/src/farcasterd/trade_state_machine.rs
+++ b/src/farcasterd/trade_state_machine.rs
@@ -1540,16 +1540,16 @@ fn attempt_transition_to_end(
             runtime.clean_up_after_swap(&swap_id, event.endpoints)?;
             runtime.stats.incr_outcome(&outcome);
             match outcome {
-                Outcome::Buy => {
+                Outcome::SuccessSwap => {
                     debug!("Success on swap {}", swap_id);
                 }
-                Outcome::Refund => {
+                Outcome::FailureRefund => {
                     warn!("Refund on swap {}", swap_id);
                 }
-                Outcome::Punish => {
+                Outcome::FailurePunish => {
                     warn!("Punish on swap {}", swap_id);
                 }
-                Outcome::Abort => {
+                Outcome::FailureAbort => {
                     warn!("Aborted swap {}", swap_id);
                 }
             }

--- a/src/grpcd/proto/farcaster.proto
+++ b/src/grpcd/proto/farcaster.proto
@@ -187,7 +187,141 @@ message ProgressRequest {
 
 message ProgressResponse {
     uint32 id = 1;
-    repeated string progress = 2;
+    repeated Progress progress = 2;
+}
+
+message Progress {
+    oneof progress {
+        string message = 1;
+        State state_update = 2;
+        StateTransition state_transition = 3;
+        string failure = 4;
+        string success = 5;
+    }
+}
+
+message StateTransition {
+    State old_state = 1;
+    State new_state = 2;
+}
+
+message State {
+    oneof state {
+        StartA start_a = 1;
+        CommitA commit_a = 2;
+        RevealA reveal_a = 3;
+        RefundSigA refund_sig_a = 4;
+        FinishA finish_a = 5;
+        StartB start_b = 6;
+        CommitB commit_b = 7;
+        RevealB reveal_b = 8;
+        CoreArbB core_arb_b = 9;
+        BuySigB buy_sig_b = 10;
+        FinishB finish_b = 11;
+    }
+}
+
+message StartA {}
+message CommitA {}
+message RevealA {}
+message FinishA {
+    Outcome outcome = 1;
+}
+message StartB {}
+message CommitB {}
+message RevealB {}
+message FinishB {
+    Outcome outcome = 1;
+}
+
+message RefundSigA {
+    uint64 arb_block_height = 1;
+    uint64 acc_block_height = 2;
+    bool arb_locked = 3;
+    bool acc_locked = 4;
+    bool buy_published = 5;
+    bool cancel_seen = 6;
+    bool refund_seen = 7;
+    bool overfunded = 8;
+    oneof arb_lock_confirmations {
+        uint32 arb_confs = 9;
+    }
+    oneof acc_lock_confirmations {
+        uint32 acc_confs = 10;
+    }
+    oneof blocks_until_cancel_possible {
+        int64 cancel_blocks = 11;
+    }
+    oneof cancel_confirmations {
+        uint32 cancel_confs = 12;
+    }
+    oneof blocks_until_punish_possible {
+        int64 punish_blocks = 13;
+    }
+    oneof blocks_until_safe_buy {
+        uint32 buy_blocks = 14;
+    }
+}
+
+message CoreArbB {
+    uint64 arb_block_height = 1;
+    uint64 acc_block_height = 2;
+    bool arb_locked = 3;
+    bool acc_locked = 4;
+    bool buy_published = 5;
+    bool refund_seen = 7;
+    oneof arb_lock_confirmations {
+        uint32 arb_confs = 9;
+    }
+    oneof acc_lock_confirmations {
+        uint32 acc_confs = 10;
+    }
+    oneof blocks_until_cancel_possible {
+        int64 cancel_blocks = 11;
+    }
+    oneof cancel_confirmations {
+        uint32 cancel_confs = 12;
+    }
+    oneof blocks_until_refund {
+        int64 refund_blocks = 13;
+    }
+    oneof blocks_until_punish_possible {
+        int64 punish_blocks = 14;
+    }
+}
+
+message BuySigB {
+    uint64 arb_block_height = 1;
+    uint64 acc_block_height = 2;
+    bool buy_tx_seen = 3;
+    oneof arb_lock_confirmations {
+        uint32 arb_confs = 4;
+    }
+    oneof acc_lock_confirmations {
+        uint32 acc_confs = 5;
+    }
+    oneof blocks_until_cancel_possible {
+        int64 cancel_blocks = 6;
+    }
+    oneof cancel_confirmations {
+        uint32 cancel_confs = 7;
+    }
+    oneof blocks_until_refund {
+        int64 refund_blocks = 8;
+    }
+    oneof blocks_until_punish_possible {
+        int64 punish_blocks = 9;
+    }
+    oneof blocks_until_safe_monero_buy_sweep {
+        uint32 buy_monero_blocks = 10;
+    }
+}
+
+enum Outcome {
+    SuccessSwap = 0;
+    FailureRefund = 1;
+    FailurePunish = 2;
+    FailureAbort = 3;
 }
 
 message ConnectSwapRequest {

--- a/src/grpcd/runtime.rs
+++ b/src/grpcd/runtime.rs
@@ -4,9 +4,13 @@ use crate::bus::ctl::ProtoPublicOffer;
 use crate::bus::ctl::PubOffer;
 use crate::bus::info::Address;
 use crate::bus::info::OfferStatusSelector;
+use crate::bus::info::ProgressEvent;
 use crate::bus::AddressSecretKey;
 use crate::bus::Failure;
+use crate::bus::OptionDetails;
+use crate::bus::Outcome;
 use crate::service::Endpoints;
+use crate::swapd::StateReport;
 use crate::syncerd::SweepAddressAddendum;
 use crate::syncerd::SweepBitcoinAddress;
 use crate::syncerd::SweepMoneroAddress;
@@ -76,6 +80,10 @@ use self::farcaster::SweepAddressRequest;
 use self::farcaster::SweepAddressResponse;
 use self::farcaster::TakeRequest;
 use self::farcaster::TakeResponse;
+use self::farcaster::{
+    BuySigB, CommitA, CommitB, CoreArbB, FinishA, FinishB, RefundSigA, RevealA, RevealB, StartA,
+    StartB,
+};
 
 pub mod farcaster {
     tonic::include_proto!("farcaster");
@@ -153,6 +161,161 @@ impl From<farcaster::OfferSelector> for OfferStatusSelector {
             farcaster::OfferSelector::Open => OfferStatusSelector::Open,
             farcaster::OfferSelector::InProgress => OfferStatusSelector::InProgress,
             farcaster::OfferSelector::Ended => OfferStatusSelector::Ended,
+        }
+    }
+}
+
+impl From<Outcome> for farcaster::Outcome {
+    fn from(t: Outcome) -> farcaster::Outcome {
+        match t {
+            Outcome::SuccessSwap => farcaster::Outcome::SuccessSwap,
+            Outcome::FailureRefund => farcaster::Outcome::FailureRefund,
+            Outcome::FailurePunish => farcaster::Outcome::FailurePunish,
+            Outcome::FailureAbort => farcaster::Outcome::FailureAbort,
+        }
+    }
+}
+
+impl From<StateReport> for farcaster::State {
+    fn from(state_report: StateReport) -> farcaster::State {
+        match state_report.clone() {
+            StateReport::StartA => farcaster::State {
+                state: Some(farcaster::state::State::StartA(StartA {})),
+            },
+            StateReport::CommitA => farcaster::State {
+                state: Some(farcaster::state::State::CommitA(CommitA {})),
+            },
+            StateReport::RevealA => farcaster::State {
+                state: Some(farcaster::state::State::RevealA(RevealA {})),
+            },
+            StateReport::RefundSigA {
+                arb_block_height,
+                acc_block_height,
+                arb_locked,
+                acc_locked,
+                buy_published,
+                cancel_seen,
+                refund_seen,
+                overfunded,
+                arb_lock_confirmations,
+                acc_lock_confirmations,
+                blocks_until_cancel_possible,
+                cancel_confirmations,
+                blocks_until_punish_possible,
+                blocks_until_safe_buy,
+            } => farcaster::State {
+                state: Some(farcaster::state::State::RefundSigA(RefundSigA {
+                    arb_block_height,
+                    acc_block_height,
+                    arb_locked,
+                    acc_locked,
+                    buy_published,
+                    cancel_seen,
+                    refund_seen,
+                    overfunded,
+                    arb_lock_confirmations: arb_lock_confirmations
+                        .map(|c| farcaster::refund_sig_a::ArbLockConfirmations::ArbConfs(c)),
+                    acc_lock_confirmations: acc_lock_confirmations
+                        .map(|c| farcaster::refund_sig_a::AccLockConfirmations::AccConfs(c)),
+                    blocks_until_cancel_possible: blocks_until_cancel_possible.map(|b| {
+                        farcaster::refund_sig_a::BlocksUntilCancelPossible::CancelBlocks(b)
+                    }),
+                    cancel_confirmations: cancel_confirmations
+                        .map(|c| farcaster::refund_sig_a::CancelConfirmations::CancelConfs(c)),
+                    blocks_until_punish_possible: blocks_until_punish_possible.map(|b| {
+                        farcaster::refund_sig_a::BlocksUntilPunishPossible::PunishBlocks(b)
+                    }),
+                    blocks_until_safe_buy: blocks_until_safe_buy
+                        .map(|b| farcaster::refund_sig_a::BlocksUntilSafeBuy::BuyBlocks(b)),
+                })),
+            },
+            StateReport::FinishA(outcome) => farcaster::State {
+                state: Some(farcaster::state::State::FinishA(FinishA {
+                    outcome: farcaster::Outcome::from(outcome).into(),
+                })),
+            },
+            StateReport::StartB => farcaster::State {
+                state: Some(farcaster::state::State::StartB(StartB {})),
+            },
+            StateReport::CommitB => farcaster::State {
+                state: Some(farcaster::state::State::CommitB(CommitB {})),
+            },
+            StateReport::RevealB => farcaster::State {
+                state: Some(farcaster::state::State::RevealB(RevealB {})),
+            },
+            StateReport::CoreArbB {
+                arb_block_height,
+                acc_block_height,
+                arb_locked,
+                acc_locked,
+                buy_published,
+                refund_seen,
+                arb_lock_confirmations,
+                acc_lock_confirmations,
+                blocks_until_cancel_possible,
+                cancel_confirmations,
+                blocks_until_refund,
+                blocks_until_punish_possible,
+            } => farcaster::State {
+                state: Some(farcaster::state::State::CoreArbB(CoreArbB {
+                    arb_block_height,
+                    acc_block_height,
+                    arb_locked,
+                    acc_locked,
+                    buy_published,
+                    refund_seen,
+                    arb_lock_confirmations: arb_lock_confirmations
+                        .map(|c| farcaster::core_arb_b::ArbLockConfirmations::ArbConfs(c)),
+                    acc_lock_confirmations: acc_lock_confirmations
+                        .map(|c| farcaster::core_arb_b::AccLockConfirmations::AccConfs(c)),
+                    blocks_until_cancel_possible: blocks_until_cancel_possible
+                        .map(|b| farcaster::core_arb_b::BlocksUntilCancelPossible::CancelBlocks(b)),
+                    cancel_confirmations: cancel_confirmations
+                        .map(|c| farcaster::core_arb_b::CancelConfirmations::CancelConfs(c)),
+                    blocks_until_refund: blocks_until_refund
+                        .map(|b| farcaster::core_arb_b::BlocksUntilRefund::RefundBlocks(b)),
+                    blocks_until_punish_possible: blocks_until_punish_possible
+                        .map(|b| farcaster::core_arb_b::BlocksUntilPunishPossible::PunishBlocks(b)),
+                })),
+            },
+            StateReport::BuySigB {
+                arb_block_height,
+                acc_block_height,
+                buy_tx_seen,
+                arb_lock_confirmations,
+                acc_lock_confirmations,
+                blocks_until_cancel_possible,
+                cancel_confirmations,
+                blocks_until_refund,
+                blocks_until_punish_possible,
+                blocks_until_safe_monero_buy_sweep,
+            } => farcaster::State {
+                state: Some(farcaster::state::State::BuySigB(BuySigB {
+                    arb_block_height,
+                    acc_block_height,
+                    buy_tx_seen,
+                    arb_lock_confirmations: arb_lock_confirmations
+                        .map(|c| farcaster::buy_sig_b::ArbLockConfirmations::ArbConfs(c)),
+                    acc_lock_confirmations: acc_lock_confirmations
+                        .map(|c| farcaster::buy_sig_b::AccLockConfirmations::AccConfs(c)),
+                    blocks_until_cancel_possible: blocks_until_cancel_possible
+                        .map(|b| farcaster::buy_sig_b::BlocksUntilCancelPossible::CancelBlocks(b)),
+                    cancel_confirmations: cancel_confirmations
+                        .map(|c| farcaster::buy_sig_b::CancelConfirmations::CancelConfs(c)),
+                    blocks_until_refund: blocks_until_refund
+                        .map(|b| farcaster::buy_sig_b::BlocksUntilRefund::RefundBlocks(b)),
+                    blocks_until_punish_possible: blocks_until_punish_possible
+                        .map(|b| farcaster::buy_sig_b::BlocksUntilPunishPossible::PunishBlocks(b)),
+                    blocks_until_safe_monero_buy_sweep: blocks_until_safe_monero_buy_sweep.map(
+                        |b| farcaster::buy_sig_b::BlocksUntilSafeMoneroBuySweep::BuyMoneroBlocks(b),
+                    ),
+                })),
+            },
+            StateReport::FinishB(outcome) => farcaster::State {
+                state: Some(farcaster::state::State::FinishB(FinishB {
+                    outcome: farcaster::Outcome::from(outcome).into(),
+                })),
+            },
         }
     }
 }
@@ -692,11 +855,45 @@ impl Farcaster for FarcasterService {
             .await?;
 
         match oneshot_rx.await {
-            Ok(BusMsg::Info(InfoMsg::SwapProgress(progress))) => {
+            Ok(BusMsg::Info(InfoMsg::SwapProgress(mut progress))) => {
                 let reply = ProgressResponse {
                     id,
-                    progress: progress.progress.iter().map(|p| p.to_string()).collect(),
+                    progress: progress
+                        .progress
+                        .drain(..)
+                        .map(|p| match p {
+                            ProgressEvent::Message(m) => farcaster::Progress {
+                                progress: Some(farcaster::progress::Progress::Message(
+                                    m.to_string(),
+                                )),
+                            },
+                            ProgressEvent::StateUpdate(su) => farcaster::Progress {
+                                progress: Some(farcaster::progress::Progress::StateUpdate(
+                                    su.into(),
+                                )),
+                            },
+                            ProgressEvent::StateTransition(st) => farcaster::Progress {
+                                progress: Some(farcaster::progress::Progress::StateTransition(
+                                    farcaster::StateTransition {
+                                        old_state: Some(st.old_state.into()),
+                                        new_state: Some(st.new_state.into()),
+                                    },
+                                )),
+                            },
+                            ProgressEvent::Failure(Failure { info, .. }) => farcaster::Progress {
+                                progress: Some(farcaster::progress::Progress::Failure(
+                                    info.to_string(),
+                                )),
+                            },
+                            ProgressEvent::Success(OptionDetails(s)) => farcaster::Progress {
+                                progress: Some(farcaster::progress::Progress::Success(
+                                    s.unwrap_or("".to_string()),
+                                )),
+                            },
+                        })
+                        .collect(),
                 };
+
                 Ok(GrpcResponse::new(reply))
             }
             res => process_error_response(res),

--- a/src/service.rs
+++ b/src/service.rs
@@ -403,23 +403,6 @@ where
         Ok(())
     }
 
-    fn report_state_transition_progress_message_to(
-        &mut self,
-        senders: &mut Endpoints,
-        dest: impl TryToServiceId,
-        msg: impl ToString,
-    ) -> Result<(), Error> {
-        if let Some(dest) = dest.try_to_service_id() {
-            senders.send_to(
-                ServiceBus::Ctl,
-                self.identity(),
-                dest,
-                BusMsg::Ctl(CtlMsg::Progress(Progress::StateTransition(msg.to_string()))),
-            )?;
-        }
-        Ok(())
-    }
-
     fn report_failure_to(
         &mut self,
         senders: &mut Endpoints,

--- a/src/swapd/mod.rs
+++ b/src/swapd/mod.rs
@@ -15,6 +15,7 @@
 #[cfg(feature = "shell")]
 mod opts;
 mod runtime;
+mod state_report;
 mod swap_state;
 mod syncer_client;
 mod temporal_safety;
@@ -24,5 +25,6 @@ pub use opts::Opts;
 pub use runtime::get_swap_id;
 pub use runtime::run;
 pub use runtime::CheckpointSwapd;
+pub use state_report::StateReport;
 pub use swap_state::State;
 pub use swap_state::SwapCheckpointType;

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -1674,9 +1674,9 @@ impl Runtime {
                 let connection = self.peer_service.node_addr();
                 let info = SwapInfo {
                     swap_id,
-                    state: self.state.to_string(),
                     connection,
                     connected: self.connected,
+                    state: self.latest_state_report.clone(),
                     uptime: SystemTime::now()
                         .duration_since(self.started)
                         .unwrap_or_else(|_| Duration::from_secs(0)),

--- a/src/swapd/state_report.rs
+++ b/src/swapd/state_report.rs
@@ -1,0 +1,176 @@
+use farcaster_core::{blockchain::Blockchain, transaction::TxLabel};
+use strict_encoding::{NetworkDecode, NetworkEncode};
+
+use crate::bus::{Outcome, Progress, StateTransition};
+
+use super::{
+    swap_state::{AliceState, BobState},
+    syncer_client::SyncerState,
+    temporal_safety::TemporalSafety,
+    State,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Display, NetworkEncode, NetworkDecode)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
+#[display(Debug)]
+pub enum StateReport {
+    StartA,
+    CommitA,
+    RevealA,
+    RefundSigA {
+        arb_block_height: u64,
+        acc_block_height: u64,
+        arb_locked: bool,
+        acc_locked: bool,
+        buy_published: bool,
+        cancel_seen: bool,
+        refund_seen: bool,
+        overfunded: bool,
+        arb_lock_confirmations: Option<u32>,
+        acc_lock_confirmations: Option<u32>,
+        blocks_until_cancel_possible: Option<i64>,
+        cancel_confirmations: Option<u32>,
+        blocks_until_punish_possible: Option<i64>,
+        blocks_until_safe_buy: Option<u32>,
+    },
+    FinishA(Outcome),
+    StartB,
+    CommitB,
+    RevealB,
+    CorearbB {
+        arb_block_height: u64,
+        acc_block_height: u64,
+        arb_locked: bool,
+        acc_locked: bool,
+        buy_published: bool,
+        refund_seen: bool,
+        arb_lock_confirmations: Option<u32>,
+        acc_lock_confirmations: Option<u32>,
+        blocks_until_cancel_possible: Option<i64>,
+        cancel_confirmations: Option<u32>,
+        blocks_until_refund: Option<i64>,
+        blocks_until_punish_possible: Option<i64>,
+    },
+    BuySigB {
+        arb_block_height: u64,
+        acc_block_height: u64,
+        buy_tx_seen: bool,
+        arb_lock_confirmations: Option<u32>,
+        acc_lock_confirmations: Option<u32>,
+        blocks_until_cancel_possible: Option<i64>,
+        cancel_confirmations: Option<u32>,
+        blocks_until_refund: Option<i64>,
+        blocks_until_punish_possible: Option<i64>,
+        blocks_until_safe_monero_buy_sweep: Option<u32>,
+    },
+    FinishB(Outcome),
+}
+
+impl StateReport {
+    pub fn new(
+        state: &State,
+        temp_safety: &TemporalSafety,
+        syncer_state: &SyncerState,
+    ) -> StateReport {
+        match state {
+            State::Alice(AliceState::StartA { .. }) => StateReport::StartA,
+            State::Alice(AliceState::CommitA { .. }) => StateReport::CommitA,
+            State::Alice(AliceState::RevealA { .. }) => StateReport::RevealA,
+            State::Alice(AliceState::RefundSigA {
+                btc_locked,
+                xmr_locked,
+                buy_published,
+                cancel_seen,
+                refund_seen,
+                overfunded,
+                ..
+            }) => StateReport::RefundSigA {
+                arb_block_height: syncer_state.bitcoin_height,
+                acc_block_height: syncer_state.monero_height,
+                arb_locked: *btc_locked,
+                acc_locked: *xmr_locked,
+                buy_published: *buy_published,
+                cancel_seen: *cancel_seen,
+                refund_seen: *refund_seen,
+                overfunded: *overfunded,
+                arb_lock_confirmations: syncer_state.get_confs(TxLabel::Lock),
+                acc_lock_confirmations: syncer_state.get_confs(TxLabel::AccLock),
+                blocks_until_cancel_possible: syncer_state
+                    .get_confs(TxLabel::Lock)
+                    .map(|confs| temp_safety.blocks_until_cancel(confs)),
+                cancel_confirmations: syncer_state.get_confs(TxLabel::Cancel),
+                blocks_until_punish_possible: syncer_state
+                    .get_confs(TxLabel::Cancel)
+                    .map(|confs| temp_safety.blocks_until_punish_after_cancel(confs)),
+                blocks_until_safe_buy: syncer_state
+                    .get_confs(TxLabel::Lock)
+                    .map(|c| temp_safety.btc_finality_thr.checked_sub(c).unwrap_or(0)),
+            },
+            State::Alice(AliceState::FinishA(outcome)) => StateReport::FinishA(outcome.clone()),
+            State::Bob(BobState::StartB { .. }) => StateReport::StartB,
+            State::Bob(BobState::CommitB { .. }) => StateReport::CommitB,
+            State::Bob(BobState::RevealB { .. }) => StateReport::RevealB,
+            State::Bob(BobState::CorearbB { buy_tx_seen, .. }) => StateReport::CorearbB {
+                buy_published: *buy_tx_seen,
+                arb_block_height: syncer_state.bitcoin_height,
+                acc_block_height: syncer_state.monero_height,
+                arb_locked: temp_safety.final_tx(
+                    syncer_state.get_confs(TxLabel::Lock).unwrap_or(0),
+                    Blockchain::Bitcoin,
+                ),
+                acc_locked: temp_safety.final_tx(
+                    syncer_state.get_confs(TxLabel::AccLock).unwrap_or(0),
+                    Blockchain::Bitcoin,
+                ),
+                refund_seen: syncer_state.get_confs(TxLabel::Refund).is_some(),
+                arb_lock_confirmations: syncer_state.get_confs(TxLabel::Lock),
+                acc_lock_confirmations: syncer_state.get_confs(TxLabel::AccLock),
+                blocks_until_cancel_possible: syncer_state
+                    .get_confs(TxLabel::Lock)
+                    .map(|confs| temp_safety.blocks_until_cancel(confs)),
+                cancel_confirmations: syncer_state.get_confs(TxLabel::Cancel),
+                blocks_until_refund: None,
+                blocks_until_punish_possible: syncer_state
+                    .get_confs(TxLabel::Cancel)
+                    .map(|confs| temp_safety.blocks_until_punish_after_cancel(confs)),
+            },
+            State::Bob(BobState::BuySigB { buy_tx_seen, .. }) => StateReport::BuySigB {
+                buy_tx_seen: *buy_tx_seen,
+                arb_block_height: syncer_state.bitcoin_height,
+                acc_block_height: syncer_state.monero_height,
+                arb_lock_confirmations: syncer_state.get_confs(TxLabel::Lock),
+                acc_lock_confirmations: syncer_state.get_confs(TxLabel::AccLock),
+                blocks_until_cancel_possible: syncer_state
+                    .get_confs(TxLabel::Lock)
+                    .map(|confs| temp_safety.blocks_until_cancel(confs)),
+                cancel_confirmations: syncer_state.get_confs(TxLabel::Cancel),
+                blocks_until_refund: None,
+                blocks_until_punish_possible: syncer_state
+                    .get_confs(TxLabel::Cancel)
+                    .map(|confs| temp_safety.blocks_until_punish_after_cancel(confs)),
+                blocks_until_safe_monero_buy_sweep: syncer_state
+                    .get_confs(TxLabel::AccLock)
+                    .map(|c| temp_safety.sweep_monero_thr.checked_sub(c).unwrap_or(0)),
+            },
+            State::Bob(BobState::FinishB(outcome)) => StateReport::FinishB(outcome.clone()),
+        }
+    }
+
+    pub fn generate_progress_update_or_transition(
+        &self,
+        new_state_report: &StateReport,
+    ) -> Progress {
+        if std::mem::discriminant(self) == std::mem::discriminant(new_state_report) {
+            Progress::StateUpdate(new_state_report.clone())
+        } else {
+            Progress::StateTransition(StateTransition {
+                old_state: self.clone(),
+                new_state: new_state_report.clone(),
+            })
+        }
+    }
+}

--- a/src/swapd/state_report.rs
+++ b/src/swapd/state_report.rs
@@ -16,11 +16,14 @@ use super::{
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[display(Debug)]
 pub enum StateReport {
+    #[display("StartA")]
     StartA,
+    #[display("CommitA")]
     CommitA,
+    #[display("RevealA")]
     RevealA,
+    #[display(Debug)]
     RefundSigA {
         arb_block_height: u64,
         acc_block_height: u64,
@@ -37,11 +40,16 @@ pub enum StateReport {
         blocks_until_punish_possible: Option<i64>,
         blocks_until_safe_buy: Option<u32>,
     },
+    #[display("{0}")]
     FinishA(Outcome),
+    #[display("StartB")]
     StartB,
+    #[display("CommitB")]
     CommitB,
+    #[display("RevealB")]
     RevealB,
-    CorearbB {
+    #[display(Debug)]
+    CoreArbB {
         arb_block_height: u64,
         acc_block_height: u64,
         arb_locked: bool,
@@ -55,6 +63,7 @@ pub enum StateReport {
         blocks_until_refund: Option<i64>,
         blocks_until_punish_possible: Option<i64>,
     },
+    #[display(Debug)]
     BuySigB {
         arb_block_height: u64,
         acc_block_height: u64,
@@ -67,6 +76,7 @@ pub enum StateReport {
         blocks_until_punish_possible: Option<i64>,
         blocks_until_safe_monero_buy_sweep: Option<u32>,
     },
+    #[display("{0}")]
     FinishB(Outcome),
 }
 
@@ -114,7 +124,7 @@ impl StateReport {
             State::Bob(BobState::StartB { .. }) => StateReport::StartB,
             State::Bob(BobState::CommitB { .. }) => StateReport::CommitB,
             State::Bob(BobState::RevealB { .. }) => StateReport::RevealB,
-            State::Bob(BobState::CorearbB { buy_tx_seen, .. }) => StateReport::CorearbB {
+            State::Bob(BobState::CorearbB { buy_tx_seen, .. }) => StateReport::CoreArbB {
                 buy_published: *buy_tx_seen,
                 arb_block_height: syncer_state.bitcoin_height,
                 acc_block_height: syncer_state.monero_height,

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -9,6 +9,7 @@ use crate::bus::p2p::Commit;
 use crate::bus::Outcome;
 
 #[derive(Display, Debug, Clone, StrictEncode, StrictDecode)]
+
 pub enum AliceState {
     // #[display("Start: {0:#?} {1:#?}")]
     #[display("Start")]

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -9,7 +9,6 @@ use crate::bus::p2p::Commit;
 use crate::bus::Outcome;
 
 #[derive(Display, Debug, Clone, StrictEncode, StrictDecode)]
-
 pub enum AliceState {
     // #[display("Start: {0:#?} {1:#?}")]
     #[display("Start")]

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -265,7 +265,7 @@ impl State {
         matches!(self, State::Bob(BobState::BuySigB { .. }))
     }
     pub fn b_outcome_abort(&self) -> bool {
-        matches!(self, State::Bob(BobState::FinishB(Outcome::Abort)))
+        matches!(self, State::Bob(BobState::FinishB(Outcome::FailureAbort)))
     }
     pub fn remote_commit(&self) -> Option<&Commit> {
         match self {

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -54,6 +54,7 @@ pub struct SyncerState {
     pub monero_amount: monero::Amount,
     pub bitcoin_amount: bitcoin::Amount,
     pub xmr_addr_addendum: Option<XmrAddressAddendum>,
+    pub confirmations: HashMap<TxLabel, Option<u32>>,
     pub awaiting_funding: bool,
     pub btc_fee_estimate_sat_per_kvb: Option<u64>,
 }
@@ -385,6 +386,8 @@ impl SyncerState {
                     }
                 }
             }
+            self.confirmations
+                .insert(txlabel.clone(), confirmations.clone());
         } else {
             error!(
                 "received event with unknown transaction and task id {}",
@@ -417,6 +420,10 @@ impl SyncerState {
             BusMsg::Sync(SyncMsg::Task(watch_height_xmr_task)),
         )?;
         Ok(())
+    }
+
+    pub fn get_confs(&self, label: TxLabel) -> Option<u32> {
+        self.confirmations.get(&label).map(|c| c.clone()).flatten()
     }
 }
 

--- a/src/swapd/temporal_safety.rs
+++ b/src/swapd/temporal_safety.rs
@@ -49,10 +49,16 @@ impl TemporalSafety {
         self.final_tx(lock_confirmations, Blockchain::Bitcoin)
             && lock_confirmations > (self.cancel_timelock - self.race_thr + 1)
     }
+    pub fn blocks_until_stop_funding(&self, lock_confirmations: u32) -> i64 {
+        self.cancel_timelock as i64 - (self.race_thr as i64 + 1 + lock_confirmations as i64)
+    }
     /// lock must be final, valid after lock_minedblock + cancel_timelock
     pub fn valid_cancel(&self, lock_confirmations: u32) -> bool {
         self.final_tx(lock_confirmations, Blockchain::Bitcoin)
             && lock_confirmations >= self.cancel_timelock
+    }
+    pub fn blocks_until_cancel(&self, lock_confirmations: u32) -> i64 {
+        self.cancel_timelock as i64 - lock_confirmations as i64
     }
     /// lock must be final, but buy shall not be raced with cancel
     pub fn safe_buy(&self, lock_confirmations: u32) -> bool {
@@ -67,5 +73,8 @@ impl TemporalSafety {
     pub fn valid_punish(&self, cancel_confirmations: u32) -> bool {
         self.final_tx(cancel_confirmations, Blockchain::Bitcoin)
             && cancel_confirmations >= self.punish_timelock
+    }
+    pub fn blocks_until_punish_after_cancel(&self, cancel_confirmations: u32) -> i64 {
+        self.punish_timelock as i64 - cancel_confirmations as i64
     }
 }

--- a/src/swapd/temporal_safety.rs
+++ b/src/swapd/temporal_safety.rs
@@ -49,6 +49,7 @@ impl TemporalSafety {
         self.final_tx(lock_confirmations, Blockchain::Bitcoin)
             && lock_confirmations > (self.cancel_timelock - self.race_thr + 1)
     }
+    // blocks remaining until funding will be stopped for safety, because it is too close to cancel. Adds the same +1 offset as in stop_funding_before_cancel
     pub fn blocks_until_stop_funding(&self, lock_confirmations: u32) -> i64 {
         self.cancel_timelock as i64 - (self.race_thr as i64 + 1 + lock_confirmations as i64)
     }
@@ -57,6 +58,7 @@ impl TemporalSafety {
         self.final_tx(lock_confirmations, Blockchain::Bitcoin)
             && lock_confirmations >= self.cancel_timelock
     }
+    /// blocks remaining until cancel, copies logic from valid_cancel
     pub fn blocks_until_cancel(&self, lock_confirmations: u32) -> i64 {
         self.cancel_timelock as i64 - lock_confirmations as i64
     }
@@ -70,10 +72,12 @@ impl TemporalSafety {
         self.final_tx(cancel_confirmations, Blockchain::Bitcoin)
             && cancel_confirmations <= (self.punish_timelock - self.race_thr)
     }
+    /// cancel must be final, valid after cancel_confirmations > punish_timelock
     pub fn valid_punish(&self, cancel_confirmations: u32) -> bool {
         self.final_tx(cancel_confirmations, Blockchain::Bitcoin)
             && cancel_confirmations >= self.punish_timelock
     }
+    /// blocks remaning until punish, copies logic from valid_punish
     pub fn blocks_until_punish_after_cancel(&self, cancel_confirmations: u32) -> i64 {
         self.punish_timelock as i64 - cancel_confirmations as i64
     }

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -1353,7 +1353,7 @@ impl Runtime {
             CtlMsg::SwapOutcome(success) => {
                 let swap_id = get_swap_id(&source)?;
                 let success = match success {
-                    Outcome::Buy => success.bright_green_bold(),
+                    Outcome::SuccessSwap => success.bright_green_bold(),
                     _ => success.err(),
                 };
                 info!(

--- a/tests/swap.rs
+++ b/tests/swap.rs
@@ -4,8 +4,9 @@ extern crate log;
 use bitcoincore_rpc::RpcApi;
 use farcaster_core::swap::SwapId;
 use farcaster_node::bus::ctl::{BitcoinFundingInfo, FundingInfo, MoneroFundingInfo};
-use farcaster_node::bus::info::{FundingInfos, NodeInfo};
-use farcaster_node::bus::CheckpointEntry;
+use farcaster_node::bus::info::{FundingInfos, NodeInfo, ProgressEvent, SwapProgress};
+use farcaster_node::bus::{CheckpointEntry, Outcome, StateTransition};
+use farcaster_node::swapd::StateReport;
 use futures::future::join_all;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -982,20 +983,12 @@ async fn run_restore_checkpoint_bob_pre_buy_alice_pre_buy(
         .send_to_address(&address, amount, None, None, None, None, None, None)
         .unwrap();
 
-    info!("waiting for AliceState(RefundSigs");
-    retry_until_finish_state_transition(
-        cli_alice_progress_args.clone(),
-        "AliceState(RefundSigs".to_string(),
-    )
-    .await;
+    info!("waiting for RefundSigA");
+    retry_until_state_transition(cli_alice_progress_args.clone(), "RefundSigA".to_string()).await;
 
-    // run until BobState(CoreArb) is received
-    info!("waiting for BobState(CoreArb)");
-    retry_until_finish_state_transition(
-        cli_bob_progress_args.clone(),
-        "BobState(CoreArb)".to_string(),
-    )
-    .await;
+    // run until CoreArbB is received
+    info!("waiting for CoreArbB");
+    retry_until_state_transition(cli_bob_progress_args.clone(), "CoreArbB".to_string()).await;
 
     // run until the funding infos are cleared again
     info!("waiting for the bitcoin funding info to clear");
@@ -1024,12 +1017,8 @@ async fn run_restore_checkpoint_bob_pre_buy_alice_pre_buy(
         .await
         .unwrap();
 
-    // run until BobState(BuySig) is received
-    retry_until_finish_state_transition(
-        cli_bob_progress_args.clone(),
-        "BobState(BuySig)".to_string(),
-    )
-    .await;
+    // run until BuySigB is received
+    retry_until_state_transition(cli_bob_progress_args.clone(), "BuySigB".to_string()).await;
 
     tokio::time::sleep(time::Duration::from_secs(10)).await;
 
@@ -1051,10 +1040,10 @@ async fn run_restore_checkpoint_bob_pre_buy_alice_pre_buy(
         .generate_to_address(5, &reusable_btc_address())
         .unwrap();
 
-    // run until the AliceState(Finish) is received
-    retry_until_finish_state_transition(
+    // run until the SuccessSwap outcome is received
+    retry_until_finish_transition(
         cli_alice_progress_args.clone(),
-        "AliceState(Finish(Success(Swapped)))".to_string(),
+        StateReport::FinishA(Outcome::SuccessSwap),
     )
     .await;
 
@@ -1092,10 +1081,10 @@ async fn run_restore_checkpoint_bob_pre_buy_alice_pre_buy(
         .await
         .unwrap();
 
-    // run until the BobState(Finish) is received
+    // run until SuccessSwap is received
     retry_until_bob_finish_state_transition(
         cli_bob_progress_args.clone(),
-        "BobState(Finish(Success(Swapped)))".to_string(),
+        StateReport::FinishB(Outcome::SuccessSwap),
         monero_regtest.clone(),
     )
     .await;
@@ -1154,20 +1143,12 @@ async fn run_restore_checkpoint_bob_pre_buy_alice_pre_lock(
         .send_to_address(&address, amount, None, None, None, None, None, None)
         .unwrap();
 
-    info!("waiting for AliceState(RefundSigs");
-    retry_until_finish_state_transition(
-        cli_alice_progress_args.clone(),
-        "AliceState(RefundSigs".to_string(),
-    )
-    .await;
+    info!("waiting for RefundSigA");
+    retry_until_state_transition(cli_alice_progress_args.clone(), "RefundSigA".to_string()).await;
 
-    // run until BobState(CoreArb) is received
-    info!("waiting for BobState(CoreArb)");
-    retry_until_finish_state_transition(
-        cli_bob_progress_args.clone(),
-        "BobState(CoreArb)".to_string(),
-    )
-    .await;
+    // run until CoreArbB is received
+    info!("waiting for CoreArbB");
+    retry_until_state_transition(cli_bob_progress_args.clone(), "CoreArbB".to_string()).await;
 
     // run until the funding infos are cleared again
     info!("waiting for the bitcoin funding info to clear");
@@ -1225,10 +1206,10 @@ async fn run_restore_checkpoint_bob_pre_buy_alice_pre_lock(
         .generate_to_address(3, &reusable_btc_address())
         .unwrap();
 
-    // run until the BobState(Finish(Failure(Refunded))) is received
-    retry_until_finish_state_transition(
+    // run until FailureRefund is received
+    retry_until_finish_transition(
         cli_bob_progress_args.clone(),
-        "BobState(Finish(Failure(Refunded)))".to_string(),
+        StateReport::FinishB(Outcome::FailureRefund),
     )
     .await;
 
@@ -1266,10 +1247,10 @@ async fn run_restore_checkpoint_bob_pre_buy_alice_pre_lock(
         .await
         .unwrap();
 
-    // run until the BobState(Finish) is received
-    retry_until_finish_state_transition(
+    // run until FailureRefund is received
+    retry_until_finish_transition(
         cli_alice_progress_args.clone(),
-        "AliceState(Finish(Failure(Refunded)))".to_string(),
+        StateReport::FinishA(Outcome::FailureRefund),
     )
     .await;
 
@@ -1330,20 +1311,12 @@ async fn run_refund_swap_alice_overfunds(
         .send_to_address(&address, amount, None, None, None, None, None, None)
         .unwrap();
 
-    info!("waiting for AliceState(RefundSigs");
-    retry_until_finish_state_transition(
-        cli_alice_progress_args.clone(),
-        "AliceState(RefundSigs".to_string(),
-    )
-    .await;
+    info!("waiting for RefundSigA");
+    retry_until_state_transition(cli_alice_progress_args.clone(), "RefundSigA".to_string()).await;
 
-    // run until BobState(CoreArb) is received
-    info!("waiting for BobState(CoreArb)");
-    retry_until_finish_state_transition(
-        cli_bob_progress_args.clone(),
-        "BobState(CoreArb)".to_string(),
-    )
-    .await;
+    // run until CoreArbB is received
+    info!("waiting for CoreArbB");
+    retry_until_state_transition(cli_bob_progress_args.clone(), "CoreArbB".to_string()).await;
 
     // run until the funding infos are cleared again
     info!("waiting for the bitcoin funding info to clear");
@@ -1378,12 +1351,8 @@ async fn run_refund_swap_alice_overfunds(
         .await
         .unwrap();
 
-    // run until BobState(BuySig) is received
-    retry_until_finish_state_transition(
-        cli_bob_progress_args.clone(),
-        "BobState(BuySig)".to_string(),
-    )
-    .await;
+    // run until BuySigB is received
+    retry_until_state_transition(cli_bob_progress_args.clone(), "BuySigB".to_string()).await;
 
     tokio::time::sleep(time::Duration::from_secs(20)).await;
 
@@ -1410,10 +1379,10 @@ async fn run_refund_swap_alice_overfunds(
         .generate_to_address(3, &reusable_btc_address())
         .unwrap();
 
-    // run until the BobState(Finish(Failure(Refunded))) is received
-    retry_until_finish_state_transition(
+    // run until FailureRefund is received
+    retry_until_finish_transition(
         cli_bob_progress_args.clone(),
-        "BobState(Finish(Failure(Refunded)))".to_string(),
+        StateReport::FinishB(Outcome::FailureRefund),
     )
     .await;
 
@@ -1451,10 +1420,10 @@ async fn run_refund_swap_alice_overfunds(
         .await
         .unwrap();
 
-    // run until the AliceState(Finish) is received
-    retry_until_finish_state_transition(
+    // run until FailureRefund is received
+    retry_until_finish_transition(
         cli_alice_progress_args.clone(),
-        "AliceState(Finish(Failure(Refunded)))".to_string(),
+        StateReport::FinishA(Outcome::FailureRefund),
     )
     .await;
 
@@ -1509,20 +1478,12 @@ async fn run_refund_swap_race_cancel(
         .send_to_address(&address, amount, None, None, None, None, None, None)
         .unwrap();
 
-    info!("waiting for AliceState(RefundSigs");
-    retry_until_finish_state_transition(
-        cli_alice_progress_args.clone(),
-        "AliceState(RefundSigs".to_string(),
-    )
-    .await;
+    info!("waiting for RefundSigA");
+    retry_until_state_transition(cli_alice_progress_args.clone(), "RefundSigA".to_string()).await;
 
-    // run until BobState(CoreArb) is received
-    info!("waiting for BobState(CoreArb)");
-    retry_until_finish_state_transition(
-        cli_bob_progress_args.clone(),
-        "BobState(CoreArb)".to_string(),
-    )
-    .await;
+    // run until CoreArbB is received
+    info!("waiting for CoreArbB");
+    retry_until_state_transition(cli_bob_progress_args.clone(), "CoreArbB".to_string()).await;
 
     // run until the funding infos are cleared again
     info!("waiting for the bitcoin funding info to clear");
@@ -1565,10 +1526,10 @@ async fn run_refund_swap_race_cancel(
         .generate_to_address(3, &reusable_btc_address())
         .unwrap();
 
-    // run until the BobState(Finish(Failure(Refunded))) is received
-    retry_until_finish_state_transition(
+    // run until FailureRefund is received
+    retry_until_finish_transition(
         cli_bob_progress_args.clone(),
-        "BobState(Finish(Failure(Refunded)))".to_string(),
+        StateReport::FinishB(Outcome::FailureRefund),
     )
     .await;
 
@@ -1606,10 +1567,10 @@ async fn run_refund_swap_race_cancel(
         .await
         .unwrap();
 
-    // run until the BobState(Finish) is received
-    retry_until_finish_state_transition(
+    // run until FailureRefund is received
+    retry_until_finish_transition(
         cli_alice_progress_args.clone(),
-        "AliceState(Finish(Failure(Refunded)))".to_string(),
+        StateReport::FinishA(Outcome::FailureRefund),
     )
     .await;
 
@@ -1663,20 +1624,12 @@ async fn run_refund_swap_kill_alice_after_funding(
         .send_to_address(&address, amount, None, None, None, None, None, None)
         .unwrap();
 
-    info!("waiting for AliceState(RefundSigs");
-    retry_until_finish_state_transition(
-        cli_alice_progress_args.clone(),
-        "AliceState(RefundSigs".to_string(),
-    )
-    .await;
+    info!("waiting for RefundSigA");
+    retry_until_state_transition(cli_alice_progress_args.clone(), "RefundSigA".to_string()).await;
 
-    // run until BobState(CoreArb) is received
-    info!("waiting for BobState(CoreArb)");
-    retry_until_finish_state_transition(
-        cli_bob_progress_args.clone(),
-        "BobState(CoreArb)".to_string(),
-    )
-    .await;
+    // run until CoreArbB is received
+    info!("waiting for CoreArbB");
+    retry_until_state_transition(cli_bob_progress_args.clone(), "CoreArbB".to_string()).await;
 
     // run until the funding infos are cleared again
     info!("waiting for the bitcoin funding info to clear");
@@ -1722,10 +1675,10 @@ async fn run_refund_swap_kill_alice_after_funding(
         .generate_to_address(3, &reusable_btc_address())
         .unwrap();
 
-    // run until the BobState(Finish(Failure(Refunded))) is received
-    retry_until_finish_state_transition(
+    // run until FailureRefund is received
+    retry_until_finish_transition(
         cli_bob_progress_args.clone(),
-        "BobState(Finish(Failure(Refunded)))".to_string(),
+        StateReport::FinishB(Outcome::FailureRefund),
     )
     .await;
 
@@ -1774,20 +1727,12 @@ async fn run_refund_swap_alice_does_not_fund(
         .send_to_address(&address, amount, None, None, None, None, None, None)
         .unwrap();
 
-    info!("waiting for AliceState(RefundSigs");
-    retry_until_finish_state_transition(
-        cli_alice_progress_args.clone(),
-        "AliceState(RefundSigs".to_string(),
-    )
-    .await;
+    info!("waiting for RefundSigA");
+    retry_until_state_transition(cli_alice_progress_args.clone(), "RefundSigA".to_string()).await;
 
-    // run until BobState(CoreArb) is received
-    info!("waiting for BobState(CoreArb)");
-    retry_until_finish_state_transition(
-        cli_bob_progress_args.clone(),
-        "BobState(CoreArb)".to_string(),
-    )
-    .await;
+    // run until CoreArbB is received
+    info!("waiting for CoreArbB");
+    retry_until_state_transition(cli_bob_progress_args.clone(), "CoreArbB".to_string()).await;
 
     // run until the funding infos are cleared again
     info!("waiting for the bitcoin funding info to clear");
@@ -1814,10 +1759,10 @@ async fn run_refund_swap_alice_does_not_fund(
         .generate_to_address(3, &reusable_btc_address())
         .unwrap();
 
-    // run until the AliceState(Finish(Failure(Refunded))) is received
-    retry_until_finish_state_transition(
+    // run until FailureRefund is received
+    retry_until_finish_transition(
         cli_alice_progress_args.clone(),
-        "AliceState(Finish(Failure(Refunded)))".to_string(),
+        StateReport::FinishA(Outcome::FailureRefund),
     )
     .await;
 
@@ -1831,10 +1776,10 @@ async fn run_refund_swap_alice_does_not_fund(
         .generate_to_address(3, &reusable_btc_address())
         .unwrap();
 
-    // run until the BobState(Finish(Failure(Refunded))) is received
-    retry_until_finish_state_transition(
+    // run until FailureRefund is received
+    retry_until_finish_transition(
         cli_bob_progress_args.clone(),
-        "BobState(Finish(Failure(Refunded)))".to_string(),
+        StateReport::FinishB(Outcome::FailureRefund),
     )
     .await;
 
@@ -1886,20 +1831,12 @@ async fn run_punish_swap_kill_bob_before_monero_funding(
         .send_to_address(&address, amount, None, None, None, None, None, None)
         .unwrap();
 
-    info!("waiting for AliceState(RefundSigs");
-    retry_until_finish_state_transition(
-        cli_alice_progress_args.clone(),
-        "AliceState(RefundSigs".to_string(),
-    )
-    .await;
+    info!("waiting for RefundSigA");
+    retry_until_state_transition(cli_alice_progress_args.clone(), "RefundSigA".to_string()).await;
 
-    // run until BobState(CoreArb) is received
-    info!("waiting for BobState(CoreArb)");
-    retry_until_finish_state_transition(
-        cli_bob_progress_args.clone(),
-        "BobState(CoreArb)".to_string(),
-    )
-    .await;
+    // run until CoreArbB is received
+    info!("waiting for CoreArbB");
+    retry_until_state_transition(cli_bob_progress_args.clone(), "CoreArbB".to_string()).await;
 
     // run until the funding infos are cleared again
     info!("waiting for the bitcoin funding info to clear");
@@ -1974,10 +1911,10 @@ async fn run_punish_swap_kill_bob_before_monero_funding(
 
     info!("generated 20 bitcoin blocks");
 
-    // run until the AliceState(Finish) is received
-    retry_until_finish_state_transition(
+    // run until the FailurePunish is received
+    retry_until_finish_transition(
         cli_alice_progress_args.clone(),
-        "AliceState(Finish(Failure(Punished)))".to_string(),
+        StateReport::FinishA(Outcome::FailurePunish),
     )
     .await;
 
@@ -2219,20 +2156,20 @@ async fn run_swaps_parallel(
     }
 
     for (swap_id, SwapParams { data_dir_alice, .. }) in swap_info.iter() {
-        info!("waiting for AliceState(RefundSigs");
-        retry_until_finish_state_transition(
+        info!("waiting for RefundSigA");
+        retry_until_state_transition(
             progress_args(data_dir_alice.clone(), *swap_id),
-            "AliceState(RefundSigs".to_string(),
+            "RefundSigA".to_string(),
         )
         .await;
     }
 
-    // run until BobState(CoreArb) is received
+    // run until CoreArbB is received
     for (swap_id, SwapParams { data_dir_bob, .. }) in swap_info.iter() {
-        info!("waiting for BobState(CoreArb)");
-        retry_until_finish_state_transition(
+        info!("waiting for CoreArbB");
+        retry_until_state_transition(
             progress_args(data_dir_bob.clone(), *swap_id),
-            "BobState(CoreArb)".to_string(),
+            "CoreArbB".to_string(),
         )
         .await;
     }
@@ -2280,12 +2217,12 @@ async fn run_swaps_parallel(
         .await
         .unwrap();
 
-    // run until BobState(BuySig) is received
+    // run until BuySigB is received
     for (swap_id, SwapParams { data_dir_bob, .. }) in swap_info.iter() {
-        info!("waiting for BobState(BuySig)");
-        retry_until_finish_state_transition(
+        info!("waiting for BuySigB");
+        retry_until_state_transition(
             progress_args(data_dir_bob.clone(), *swap_id),
-            "BobState(BuySig)".to_string(),
+            "BuySigB".to_string(),
         )
         .await;
     }
@@ -2297,11 +2234,11 @@ async fn run_swaps_parallel(
         .generate_to_address(5, &reusable_btc_address())
         .unwrap();
 
-    // run until the AliceState(Finish) is received
+    // run until the SuccessSwap is received
     for (swap_id, SwapParams { data_dir_alice, .. }) in swap_info.iter() {
-        retry_until_finish_state_transition(
+        retry_until_finish_transition(
             progress_args(data_dir_alice.clone(), *swap_id),
-            "AliceState(Finish(Success(Swapped)))".to_string(),
+            StateReport::FinishA(Outcome::SuccessSwap),
         )
         .await;
     }
@@ -2364,12 +2301,11 @@ async fn run_swaps_parallel(
         .await
         .unwrap();
 
-    // run until the BobState(Finish) is received
+    // run until SuccessSwap is received
     for (swap_id, SwapParams { data_dir_bob, .. }) in swap_info.iter() {
-        retry_until_finish_state_transition(
+        retry_until_finish_transition(
             progress_args(data_dir_bob.clone(), *swap_id),
-            "BobState(Finish(Success(Swapped)))".to_string(),
-            // monero_regtest.clone(),
+            StateReport::FinishB(Outcome::SuccessSwap),
         )
         .await;
     }
@@ -2588,20 +2524,12 @@ async fn run_swap_bob_maker_manual_monero_sweep(
         .send_to_address(&address, amount, None, None, None, None, None, None)
         .unwrap();
 
-    info!("waiting for AliceState(RefundSigs");
-    retry_until_finish_state_transition(
-        cli_alice_progress_args.clone(),
-        "AliceState(RefundSigs".to_string(),
-    )
-    .await;
+    info!("waiting for RefundSigA");
+    retry_until_state_transition(cli_alice_progress_args.clone(), "RefundSigA".to_string()).await;
 
-    // run until BobState(CoreArb) is received
-    info!("waiting for BobState(CoreArb)");
-    retry_until_finish_state_transition(
-        cli_bob_progress_args.clone(),
-        "BobState(CoreArb)".to_string(),
-    )
-    .await;
+    // run until CoreArbB is received
+    info!("waiting for CoreArbB");
+    retry_until_state_transition(cli_bob_progress_args.clone(), "CoreArbB".to_string()).await;
 
     // run until the funding infos are cleared again
     info!("waiting for the bitcoin funding info to clear");
@@ -2629,12 +2557,8 @@ async fn run_swap_bob_maker_manual_monero_sweep(
         .await
         .unwrap();
 
-    // run until BobState(BuySig) is received
-    retry_until_finish_state_transition(
-        cli_bob_progress_args.clone(),
-        "BobState(BuySig)".to_string(),
-    )
-    .await;
+    // run until BuySigB is received
+    retry_until_state_transition(cli_bob_progress_args.clone(), "BuySigB".to_string()).await;
 
     tokio::time::sleep(time::Duration::from_secs(10)).await;
 
@@ -2643,10 +2567,10 @@ async fn run_swap_bob_maker_manual_monero_sweep(
         .generate_to_address(5, &reusable_btc_address())
         .unwrap();
 
-    // run until the AliceState(Finish) is received
-    retry_until_finish_state_transition(
+    // run until the SuccessSwap is received
+    retry_until_finish_transition(
         cli_alice_progress_args.clone(),
-        "AliceState(Finish(Success(Swapped)))".to_string(),
+        StateReport::FinishA(Outcome::SuccessSwap),
     )
     .await;
 
@@ -2752,20 +2676,12 @@ async fn run_swap(
         .send_to_address(&address, amount, None, None, None, None, None, None)
         .unwrap();
 
-    info!("waiting for AliceState(RefundSigs");
-    retry_until_finish_state_transition(
-        cli_alice_progress_args.clone(),
-        "AliceState(RefundSigs".to_string(),
-    )
-    .await;
+    info!("waiting for RefundSigA");
+    retry_until_state_transition(cli_alice_progress_args.clone(), "RefundSigA".to_string()).await;
 
-    // run until BobState(CoreArb) is received
-    info!("waiting for BobState(CoreArb)");
-    retry_until_finish_state_transition(
-        cli_bob_progress_args.clone(),
-        "BobState(CoreArb)".to_string(),
-    )
-    .await;
+    // run until CoreArbB is received
+    info!("waiting for CoreArbB");
+    retry_until_state_transition(cli_bob_progress_args.clone(), "CoreArbB".to_string()).await;
 
     // run until the funding infos are cleared again
     info!("waiting for the bitcoin funding info to clear");
@@ -2793,12 +2709,8 @@ async fn run_swap(
         .await
         .unwrap();
 
-    // run until BobState(BuySig) is received
-    retry_until_finish_state_transition(
-        cli_bob_progress_args.clone(),
-        "BobState(BuySig)".to_string(),
-    )
-    .await;
+    // run until BuySigB is received
+    retry_until_state_transition(cli_bob_progress_args.clone(), "BuySigB".to_string()).await;
 
     tokio::time::sleep(time::Duration::from_secs(10)).await;
 
@@ -2807,10 +2719,10 @@ async fn run_swap(
         .generate_to_address(5, &reusable_btc_address())
         .unwrap();
 
-    // run until the AliceState(Finish) is received
-    retry_until_finish_state_transition(
+    // run until the SuccessSwap is received
+    retry_until_finish_transition(
         cli_alice_progress_args.clone(),
-        "AliceState(Finish(Success(Swapped)))".to_string(),
+        StateReport::FinishA(Outcome::SuccessSwap),
     )
     .await;
 
@@ -2848,10 +2760,10 @@ async fn run_swap(
         .await
         .unwrap();
 
-    // run until the BobState(Finish) is received
+    // run until SuccessSwap is received
     retry_until_bob_finish_state_transition(
         cli_bob_progress_args.clone(),
-        "BobState(Finish(Success(Swapped)))".to_string(),
+        StateReport::FinishB(Outcome::SuccessSwap),
         monero_regtest.clone(),
     )
     .await;
@@ -3290,28 +3202,37 @@ async fn retry_until_monero_funding_address(
     panic!("timeout before any monero funding address could be retrieved");
 }
 
+fn output_to_progress(stdout: Vec<String>) -> SwapProgress {
+    serde_yaml::from_str(
+        &stdout
+            .iter()
+            .map(|line| format!("{}{}", line, "\n"))
+            .collect::<String>(),
+    )
+    .unwrap()
+}
+
 async fn retry_until_bob_finish_state_transition(
     args: Vec<String>,
-    finish_state: String,
+    finish_state: StateReport,
     monero_regtest: monero_rpc::RegtestDaemonJsonRpcClient,
-) -> Vec<String> {
+) -> bool {
     for _ in 0..ALLOWED_RETRIES {
         let (stdout, _stderr) = run("../swap-cli", args.clone()).unwrap();
 
-        let bob_finish: Vec<String> = stdout
-            .iter()
-            .filter_map(|element| {
-                info!("cli: {}", element);
-                if element.contains(&finish_state) {
-                    Some(element.to_string())
+        let progress = output_to_progress(stdout);
+        if progress.progress.iter().any(|v| {
+            if let ProgressEvent::StateTransition(StateTransition { new_state, .. }) = v {
+                if *new_state == finish_state {
+                    true
                 } else {
-                    None
+                    false
                 }
-            })
-            .collect();
-
-        if !bob_finish.is_empty() {
-            return bob_finish;
+            } else {
+                false
+            }
+        }) {
+            return true;
         }
 
         monero_regtest
@@ -3327,27 +3248,46 @@ async fn retry_until_bob_finish_state_transition(
     );
 }
 
-async fn retry_until_finish_state_transition(
-    args: Vec<String>,
-    finish_state: String,
-) -> Vec<String> {
+async fn retry_until_state_transition(args: Vec<String>, finish_state: String) -> bool {
     for _ in 0..ALLOWED_RETRIES {
         let (stdout, _stderr) = run("../swap-cli", args.clone()).unwrap();
 
-        let alice_finish: Vec<String> = stdout
-            .iter()
-            .filter_map(|element| {
-                info!("cli: {}", element);
-                if element.contains(&finish_state) {
-                    Some(element.to_string())
-                } else {
-                    None
-                }
-            })
-            .collect();
+        let progress = output_to_progress(stdout);
+        if progress.progress.iter().any(|v| {
+            if let ProgressEvent::StateTransition(_) = v {
+                v.to_string().contains(&finish_state)
+            } else {
+                false
+            }
+        }) {
+            return true;
+        }
 
-        if !alice_finish.is_empty() {
-            return alice_finish;
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
+    }
+    panic!(
+        "timeout before finish state {:?} could be retrieved",
+        finish_state
+    );
+}
+
+async fn retry_until_finish_transition(args: Vec<String>, finish_state: StateReport) -> bool {
+    for _ in 0..ALLOWED_RETRIES {
+        let (stdout, _stderr) = run("../swap-cli", args.clone()).unwrap();
+
+        let progress = output_to_progress(stdout);
+        if progress.progress.iter().any(|v| {
+            if let ProgressEvent::StateTransition(StateTransition { new_state, .. }) = v {
+                if *new_state == finish_state {
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        }) {
+            return true;
         }
 
         tokio::time::sleep(time::Duration::from_secs(1)).await;

--- a/tests/swap.rs
+++ b/tests/swap.rs
@@ -870,7 +870,7 @@ async fn run_restore_alice_pre_lock(
 
     // run until SuccessSwap is received
     retry_until_bob_finish_state_transition(
-        cli_bob_progress_args.clone(),
+        cli_alice_progress_args.clone(),
         StateReport::FinishA(Outcome::SuccessSwap),
         monero_regtest.clone(),
     )

--- a/tests/swap.rs
+++ b/tests/swap.rs
@@ -813,20 +813,12 @@ async fn run_restore_alice_pre_lock(
         .send_to_address(&address, amount, None, None, None, None, None, None)
         .unwrap();
 
-    info!("waiting for AliceState(RefundSigs");
-    retry_until_finish_state_transition(
-        cli_alice_progress_args.clone(),
-        "AliceState(RefundSigs".to_string(),
-    )
-    .await;
+    info!("waiting for RefundSigA");
+    retry_until_state_transition(cli_alice_progress_args.clone(), "RefundSigA".to_string()).await;
 
-    // run until BobState(CoreArb) is received
-    info!("waiting for BobState(CoreArb)");
-    retry_until_finish_state_transition(
-        cli_bob_progress_args.clone(),
-        "BobState(CoreArb)".to_string(),
-    )
-    .await;
+    // run until CoreArbB is received
+    info!("waiting for CoreArbB");
+    retry_until_state_transition(cli_bob_progress_args.clone(), "CoreArbB".to_string()).await;
 
     // run until the funding infos are cleared again
     info!("waiting for the bitcoin funding info to clear");
@@ -866,12 +858,8 @@ async fn run_restore_alice_pre_lock(
         .await
         .unwrap();
 
-    // run until BobState(BuySig) is received
-    retry_until_finish_state_transition(
-        cli_bob_progress_args.clone(),
-        "BobState(BuySig)".to_string(),
-    )
-    .await;
+    // run until BuySigB is received
+    retry_until_state_transition(cli_bob_progress_args.clone(), "BuySigB".to_string()).await;
 
     tokio::time::sleep(time::Duration::from_secs(10)).await;
 
@@ -880,10 +868,11 @@ async fn run_restore_alice_pre_lock(
         .generate_to_address(5, &reusable_btc_address())
         .unwrap();
 
-    // run until the AliceState(Finish) is received
-    retry_until_finish_state_transition(
-        cli_alice_progress_args.clone(),
-        "AliceState(Finish(Success(Swapped)))".to_string(),
+    // run until SuccessSwap is received
+    retry_until_bob_finish_state_transition(
+        cli_bob_progress_args.clone(),
+        StateReport::FinishA(Outcome::SuccessSwap),
+        monero_regtest.clone(),
     )
     .await;
 
@@ -921,10 +910,10 @@ async fn run_restore_alice_pre_lock(
         .await
         .unwrap();
 
-    // run until the BobState(Finish) is received
+    // run until SuccessSwap is received
     retry_until_bob_finish_state_transition(
         cli_bob_progress_args.clone(),
-        "BobState(Finish(Success(Swapped)))".to_string(),
+        StateReport::FinishB(Outcome::SuccessSwap),
         monero_regtest.clone(),
     )
     .await;


### PR DESCRIPTION
There are now three possible progress messages that a swap can issue. I message is just a string containing information. A transition goes from an old state to a new state. A state update updates the current state. Farcasterd only keeps the latest state update around, any previous state updates are discarded.

The progress now serves additional information about the confirmation status of various transactions during a swap. Additionally, it provides the block height of a running swap daemon.

I can be pretty flexible with the provided information here, so please let me know what additions / changes / re-designs you want.

Sample Output:

```
> swap1-cli progress 0xaf373e2400556909ab5b90959242979ac6bb05e0c48888d24533095fc7ead6ab                          

progress:
  - message: Proposing to take swap 0xbad3…3565 to Maker remote peer
  - transition:
      old_state: StartA
      new_state: CommitA
  - transition:
      old_state: CommitA
      new_state: RevealA
  - transition:
      old_state: RevealA
      new_state:
        RefundSigA:
          arb_block_height: 2405384
          acc_block_height: 1219189
          arb_locked: false
          acc_locked: false
          buy_published: false
          cancel_seen: false
          refund_seen: false
          overfunded: false
          arb_lock_confirmations: ~
          acc_lock_confirmations: ~
          blocks_until_cancel_possible: ~
          cancel_confirmations: ~
          blocks_until_punish_possible: ~
          blocks_until_safe_buy: ~
  - StateUpdate:
      RefundSigA:
        arb_block_height: 2405386
        acc_block_height: 1219192
        arb_locked: true
        acc_locked: true
        buy_published: true
        cancel_seen: false
        refund_seen: false
        overfunded: false
        arb_lock_confirmations: 2
        acc_lock_confirmations: 1
        blocks_until_cancel_possible: 2
        cancel_confirmations: ~
        blocks_until_punish_possible: ~
        blocks_until_safe_buy: 0
  - transition:
      old_state:
        RefundSigA:
          arb_block_height: 2405386
          acc_block_height: 1219192
          arb_locked: true
          acc_locked: true
          buy_published: true
          cancel_seen: false
          refund_seen: false
          overfunded: false
          arb_lock_confirmations: 2
          acc_lock_confirmations: 1
          blocks_until_cancel_possible: 2
          cancel_confirmations: ~
          blocks_until_punish_possible: ~
          blocks_until_safe_buy: 0
      new_state:
        FinishA: SuccessSwap
```