### PR TITLE
Database: Add NodeInfo to CheckpointEntry

### DIFF
--- a/src/bus/types.rs
+++ b/src/bus/types.rs
@@ -6,6 +6,7 @@ use farcaster_core::{
 };
 
 use amplify::{ToYamlString, Wrapper};
+use internet2::addr::NodeId;
 use microservices::rpc;
 use strict_encoding::{NetworkDecode, NetworkEncode};
 
@@ -21,6 +22,7 @@ pub struct CheckpointEntry {
     pub swap_id: SwapId,
     pub public_offer: PublicOffer,
     pub trade_role: TradeRole,
+    pub expected_counterparty_node_id: Option<NodeId>,
 }
 
 #[derive(Clone, Debug, Display, NetworkDecode, NetworkEncode)]

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -313,6 +313,9 @@ pub struct CheckpointSwapd {
     pub txids: HashMap<TxLabel, Txid>,
     pub pending_broadcasts: Vec<bitcoin::Transaction>,
     pub pending_requests: HashMap<ServiceId, Vec<PendingRequest>>,
+    pub local_trade_role: TradeRole,
+    pub connected_counterparty_node_id: Option<NodeId>,
+    pub public_offer: PublicOffer,
 }
 
 impl StrictEncode for CheckpointSwapd {
@@ -323,6 +326,9 @@ impl StrictEncode for CheckpointSwapd {
         len += self.xmr_addr_addendum.strict_encode(&mut e)?;
         len += self.temporal_safety.strict_encode(&mut e)?;
         len += self.pending_broadcasts.strict_encode(&mut e)?;
+        len += self.local_trade_role.strict_encode(&mut e)?;
+        len += self.connected_counterparty_node_id.strict_encode(&mut e)?;
+        len += self.public_offer.strict_encode(&mut e)?;
 
         len += self.txs.len().strict_encode(&mut e)?;
         let res: Result<usize, strict_encoding::Error> =
@@ -381,6 +387,9 @@ impl StrictDecode for CheckpointSwapd {
         let xmr_addr_addendum = Option::<XmrAddressAddendum>::strict_decode(&mut d)?;
         let temporal_safety = TemporalSafety::strict_decode(&mut d)?;
         let pending_broadcasts = Vec::<bitcoin::Transaction>::strict_decode(&mut d)?;
+        let local_trade_role = TradeRole::strict_decode(&mut d)?;
+        let connected_counterparty_node_id = Option::<NodeId>::strict_decode(&mut d)?;
+        let public_offer = PublicOffer::strict_decode(&mut d)?;
 
         let len = usize::strict_decode(&mut d)?;
         let mut txs = HashMap::<TxLabel, bitcoin::Transaction>::new();
@@ -424,6 +433,9 @@ impl StrictDecode for CheckpointSwapd {
             txids,
             pending_requests,
             pending_broadcasts,
+            local_trade_role,
+            connected_counterparty_node_id,
+            public_offer,
         })
     }
 }
@@ -562,6 +574,9 @@ impl Runtime {
                         pending_requests: self.pending_requests().clone(),
                         pending_broadcasts: self.syncer_state.pending_broadcast_txs(),
                         xmr_addr_addendum: self.syncer_state.xmr_addr_addendum.clone(),
+                        local_trade_role: self.local_trade_role,
+                        connected_counterparty_node_id: get_node_id(&self.peer_service),
+                        public_offer: self.public_offer.clone(),
                     }),
                 )?;
             } else {
@@ -811,6 +826,9 @@ impl Runtime {
                             pending_requests: self.pending_requests().clone(),
                             pending_broadcasts: self.syncer_state.pending_broadcast_txs(),
                             xmr_addr_addendum: self.syncer_state.xmr_addr_addendum.clone(),
+                            local_trade_role: self.local_trade_role,
+                            connected_counterparty_node_id: get_node_id(&self.peer_service),
+                            public_offer: self.public_offer.clone(),
                         }),
                     )?;
                 }
@@ -928,6 +946,9 @@ impl Runtime {
                             pending_requests: self.pending_requests().clone(),
                             pending_broadcasts: self.syncer_state.pending_broadcast_txs(),
                             xmr_addr_addendum: self.syncer_state.xmr_addr_addendum.clone(),
+                            local_trade_role: self.local_trade_role,
+                            connected_counterparty_node_id: get_node_id(&self.peer_service),
+                            public_offer: self.public_offer.clone(),
                         }),
                     )?;
                 }
@@ -1052,6 +1073,9 @@ impl Runtime {
                             pending_requests: self.pending_requests().clone(),
                             pending_broadcasts: self.syncer_state.pending_broadcast_txs(),
                             xmr_addr_addendum: self.syncer_state.xmr_addr_addendum.clone(),
+                            local_trade_role: self.local_trade_role,
+                            connected_counterparty_node_id: get_node_id(&self.peer_service),
+                            public_offer: self.public_offer.clone(),
                         }),
                     )?;
                 }
@@ -1483,12 +1507,15 @@ impl Runtime {
                     pending_requests,
                     pending_broadcasts,
                     xmr_addr_addendum,
+                    local_trade_role,
+                    ..
                 }) => {
                     info!("{} | Restoring swap", swap_id.swap_id());
                     self.state = state;
                     self.enquirer = enquirer;
                     self.temporal_safety = temporal_safety;
                     self.pending_requests = pending_requests;
+                    self.local_trade_role = local_trade_role;
                     self.txs = txs.clone();
                     trace!("Watch height bitcoin");
                     let watch_height_bitcoin = self.syncer_state.watch_height(Blockchain::Bitcoin);


### PR DESCRIPTION
Also adds the required members to a swap's checkpoint to allow us to get the required CheckpointEntry members from a a swap checkpoint. 

This is another breaking change to the database schema.
Based on #769 