### PR TITLE
Farcaster: Cleanup dangling swap info on restart

### DIFF
--- a/src/bus/ctl.rs
+++ b/src/bus/ctl.rs
@@ -41,6 +41,9 @@ pub enum CtlMsg {
     #[display(inner)]
     Progress(Progress),
 
+    /// A message sent from farcaster to database on startup to cleanup dangling offer data
+    CleanDanglingOffers,
+
     /// A message sent from farcaster to maker swap service to begin the swap.
     #[display("make_swap({0})")]
     MakeSwap(InitSwap),

--- a/src/databased/runtime.rs
+++ b/src/databased/runtime.rs
@@ -235,8 +235,7 @@ impl Runtime {
                     })
                     .map(|c| c.public_offer)
                     .collect();
-                let dangling_offers: Vec<PublicOffer> = self
-                    .database
+                self.database
                     .get_offers(OfferStatusSelector::InProgress)?
                     .drain(..)
                     .filter_map(|o| {
@@ -246,11 +245,11 @@ impl Runtime {
                             None
                         }
                     })
-                    .collect();
-                for offer in dangling_offers.iter() {
-                    self.database
-                        .set_offer_status(&offer, &OfferStatus::Ended(Outcome::Abort))?;
-                }
+                    .map(|offer| {
+                        self.database
+                            .set_offer_status(&offer, &OfferStatus::Ended(Outcome::Abort))
+                    })
+                    .collect::<Result<_, _>>()?;
             }
 
             _ => {

--- a/src/databased/runtime.rs
+++ b/src/databased/runtime.rs
@@ -247,7 +247,7 @@ impl Runtime {
                     })
                     .map(|offer| {
                         self.database
-                            .set_offer_status(&offer, &OfferStatus::Ended(Outcome::Abort))
+                            .set_offer_status(&offer, &OfferStatus::Ended(Outcome::FailureAbort))
                     })
                     .collect::<Result<_, _>>()?;
             }

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -242,6 +242,12 @@ impl Runtime {
                     }
                     ServiceId::Database => {
                         self.registered_services.insert(source.clone());
+                        endpoints.send_to(
+                            ServiceBus::Ctl,
+                            self.identity(),
+                            ServiceId::Database,
+                            BusMsg::Ctl(CtlMsg::CleanDanglingOffers),
+                        )?;
                     }
                     ServiceId::Wallet => {
                         self.registered_services.insert(source.clone());


### PR DESCRIPTION
If a swap is killed before funding, no checkpoint is written, but the offer status of the involved offer is still set to InProgress. Move the persisted offer status from InProgress to Abort on restart.