### PR TITLE
Database: Change secret key encoding

### DIFF
--- a/src/bus/types.rs
+++ b/src/bus/types.rs
@@ -30,14 +30,29 @@ pub enum AddressSecretKey {
     #[display("addr_key({address}, ..)")]
     Bitcoin {
         address: bitcoin::Address,
-        secret_key: bitcoin::secp256k1::SecretKey,
+        secret_key_info: BitcoinSecretKeyInfo,
     },
     #[display("addr_key({address}, ..)")]
     Monero {
         address: monero::Address,
-        view: monero::PrivateKey,
-        spend: monero::PrivateKey,
+        secret_key_info: MoneroSecretKeyInfo,
     },
+}
+
+#[derive(Clone, Debug, Display, Eq, PartialEq, NetworkDecode, NetworkEncode)]
+#[display("bitcoin secret key info")]
+pub struct BitcoinSecretKeyInfo {
+    pub swap_id: Option<SwapId>,
+    pub secret_key: bitcoin::secp256k1::SecretKey,
+}
+
+#[derive(Clone, Debug, Display, Eq, PartialEq, NetworkDecode, NetworkEncode)]
+#[display("monero secret key info")]
+pub struct MoneroSecretKeyInfo {
+    pub swap_id: Option<SwapId>,
+    pub view: monero::PrivateKey,
+    pub spend: monero::PrivateKey,
+    pub creation_height: Option<u64>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Display, NetworkEncode, NetworkDecode)]

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -403,7 +403,7 @@ impl Exec for Command {
                     InfoMsg::GetAddressSecretKey(Address::Bitcoin(source_address.clone())),
                 )?;
                 if let BusMsg::Info(InfoMsg::AddressSecretKey(AddressSecretKey::Bitcoin {
-                    secret_key,
+                    secret_key_info,
                     ..
                 })) = runtime.report_failure()?
                 {
@@ -411,7 +411,7 @@ impl Exec for Command {
                         ServiceId::Farcasterd,
                         CtlMsg::SweepAddress(SweepAddressAddendum::Bitcoin(SweepBitcoinAddress {
                             source_address,
-                            source_secret_key: secret_key,
+                            source_secret_key: secret_key_info.secret_key,
                             destination_address,
                         })),
                     )?;
@@ -430,16 +430,15 @@ impl Exec for Command {
                     InfoMsg::GetAddressSecretKey(Address::Monero(source_address)),
                 )?;
                 if let BusMsg::Info(InfoMsg::AddressSecretKey(AddressSecretKey::Monero {
-                    view,
-                    spend,
+                    secret_key_info,
                     ..
                 })) = runtime.report_failure()?
                 {
                     runtime.request_ctl(
                         ServiceId::Farcasterd,
                         CtlMsg::SweepAddress(SweepAddressAddendum::Monero(SweepMoneroAddress {
-                            source_spend_key: spend,
-                            source_view_key: view,
+                            source_spend_key: secret_key_info.spend,
+                            source_view_key: secret_key_info.view,
                             destination_address,
                             minimum_balance: monero::Amount::from_pico(0),
                         })),

--- a/src/databased/runtime.rs
+++ b/src/databased/runtime.rs
@@ -1,3 +1,4 @@
+use crate::bus::{BitcoinSecretKeyInfo, MoneroSecretKeyInfo};
 use farcaster_core::blockchain::Blockchain;
 use farcaster_core::swap::btcxmr::PublicOffer;
 use farcaster_core::swap::SwapId;
@@ -6,15 +7,13 @@ use std::convert::TryInto;
 use std::path::PathBuf;
 use strict_encoding::{StrictDecode, StrictEncode};
 
-use crate::Endpoints;
-use bitcoin::secp256k1::SecretKey;
-
 use crate::bus::{
     ctl::{Checkpoint, CheckpointState, CtlMsg},
     info::{Address, InfoMsg, OfferStatusSelector},
     AddressSecretKey, BusMsg, CheckpointEntry, Failure, FailureCode, List, OfferStatus,
     OfferStatusPair, ServiceBus,
 };
+use crate::Endpoints;
 use crate::{CtlServer, Error, LogStyle, Service, ServiceConfig, ServiceId};
 use microservices::esb::{self};
 
@@ -206,18 +205,18 @@ impl Runtime {
 
             CtlMsg::SetAddressSecretKey(AddressSecretKey::Bitcoin {
                 address,
-                secret_key,
+                secret_key_info,
             }) => {
-                self.database.set_bitcoin_address(&address, &secret_key)?;
+                self.database
+                    .set_bitcoin_address(&address, &secret_key_info)?;
             }
 
             CtlMsg::SetAddressSecretKey(AddressSecretKey::Monero {
                 address,
-                view,
-                spend,
+                secret_key_info,
             }) => {
                 self.database
-                    .set_monero_address(&address, &monero::KeyPair { view, spend })?;
+                    .set_monero_address(&address, &secret_key_info)?;
             }
 
             CtlMsg::SetOfferStatus(OfferStatusPair { offer, status }) => {
@@ -302,14 +301,13 @@ impl Runtime {
                             }),
                         )?;
                     }
-                    Ok(secret_key_pair) => {
+                    Ok(secret_key_info) => {
                         self.send_client_info(
                             endpoints,
                             source,
                             InfoMsg::AddressSecretKey(AddressSecretKey::Monero {
                                 address,
-                                view: secret_key_pair.view.as_bytes().try_into().unwrap(),
-                                spend: secret_key_pair.spend.as_bytes().try_into().unwrap(),
+                                secret_key_info,
                             }),
                         )?;
                     }
@@ -326,13 +324,13 @@ impl Runtime {
                             info: format!("Could not retrieve secret key for address {}", address),
                         }),
                     )?,
-                    Ok(secret_key) => {
+                    Ok(secret_key_info) => {
                         self.send_client_info(
                             endpoints,
                             source,
                             InfoMsg::AddressSecretKey(AddressSecretKey::Bitcoin {
                                 address,
-                                secret_key,
+                                secret_key_info,
                             }),
                         )?;
                     }
@@ -483,19 +481,16 @@ impl Database {
     fn set_bitcoin_address(
         &mut self,
         address: &bitcoin::Address,
-        secret_key: &SecretKey,
+        secret_key_info: &BitcoinSecretKeyInfo,
     ) -> Result<(), Error> {
         let db = self.0.open_db(Some(LMDB_BITCOIN_ADDRESSES))?;
         let mut tx = self.0.begin_rw_txn()?;
         let mut key = vec![];
         address.strict_encode(&mut key)?;
+        let mut val = vec![];
+        secret_key_info.strict_encode(&mut val)?;
         if tx.get(db, &key).is_err() {
-            tx.put(
-                db,
-                &key,
-                &secret_key.secret_bytes(),
-                lmdb::WriteFlags::empty(),
-            )?;
+            tx.put(db, &key, &val, lmdb::WriteFlags::empty())?;
         } else {
             warn!(
                 "address {} was already persisted with its secret key",
@@ -509,13 +504,12 @@ impl Database {
     fn get_bitcoin_address_secret_key(
         &mut self,
         address: &bitcoin::Address,
-    ) -> Result<SecretKey, Error> {
+    ) -> Result<BitcoinSecretKeyInfo, Error> {
         let db = self.0.open_db(Some(LMDB_BITCOIN_ADDRESSES))?;
         let tx = self.0.begin_ro_txn()?;
         let mut key = vec![];
         address.strict_encode(&mut key)?;
-        let val = SecretKey::from_slice(tx.get(db, &key)?)
-            .expect("we only insert private keys, so retrieving one should not fail");
+        let val = BitcoinSecretKeyInfo::strict_decode(tx.get(db, &key)?)?;
         tx.abort();
         Ok(val)
     }
@@ -538,13 +532,13 @@ impl Database {
     fn set_monero_address(
         &mut self,
         address: &monero::Address,
-        secret_keys: &monero::KeyPair,
-    ) -> Result<(), lmdb::Error> {
+        secret_key_info: &MoneroSecretKeyInfo,
+    ) -> Result<(), Error> {
         let db = self.0.open_db(Some(LMDB_BITCOIN_ADDRESSES))?;
         let mut tx = self.0.begin_rw_txn()?;
         let key = address.as_bytes();
-        let mut val = secret_keys.spend.as_bytes().to_vec();
-        val.append(&mut secret_keys.view.as_bytes().to_vec());
+        let mut val = vec![];
+        secret_key_info.strict_encode(&mut val)?;
         if tx.get(db, &key).is_err() {
             tx.put(db, &key, &val, lmdb::WriteFlags::empty())?;
         } else {
@@ -560,19 +554,13 @@ impl Database {
     fn get_monero_address_secret_key(
         &mut self,
         address: &monero::Address,
-    ) -> Result<monero::KeyPair, lmdb::Error> {
+    ) -> Result<MoneroSecretKeyInfo, Error> {
         let db = self.0.open_db(Some(LMDB_BITCOIN_ADDRESSES))?;
         let tx = self.0.begin_ro_txn()?;
         let key = address.as_bytes();
-        let val: [u8; 64] = tx
-            .get(db, &key)?
-            .try_into()
-            .expect("every monero address should have a keypair");
+        let val = MoneroSecretKeyInfo::strict_decode(tx.get(db, &key)?)?;
         tx.abort();
-        Ok(monero::KeyPair {
-            spend: val[0..32].try_into().expect("unable to decode spend key"),
-            view: val[32..64].try_into().expect("unable to decode view key"),
-        })
+        Ok(val)
     }
 
     fn get_all_monero_addresses(&mut self) -> Result<Vec<String>, lmdb::Error> {
@@ -660,6 +648,7 @@ impl Database {
 #[test]
 fn test_lmdb_state() {
     use crate::bus::Outcome;
+    use bitcoin::secp256k1::SecretKey;
     use std::str::FromStr;
 
     let val1 = vec![0, 1];
@@ -699,12 +688,15 @@ fn test_lmdb_state() {
         bitcoin::PrivateKey::from_slice(&sk.secret_bytes(), bitcoin::Network::Testnet).unwrap();
     let pk = bitcoin::PublicKey::from_private_key(bitcoin::secp256k1::SECP256K1, &private_key);
     let addr = bitcoin::Address::p2wpkh(&pk, bitcoin::Network::Testnet).unwrap();
-    database.set_bitcoin_address(&addr, &sk).unwrap();
+    let addr_info = BitcoinSecretKeyInfo {
+        swap_id: None,
+        secret_key: sk,
+    };
+    database.set_bitcoin_address(&addr, &addr_info).unwrap();
     let val_retrieved = database.get_bitcoin_address_secret_key(&addr).unwrap();
-    assert_eq!(sk, val_retrieved);
+    assert_eq!(addr_info, val_retrieved);
     let addrs = database.get_all_bitcoin_addresses().unwrap();
     assert!(addrs.contains(&addr));
-
     let key_pair = monero::KeyPair {
         spend: monero::PrivateKey::from_str(
             "77916d0cd56ed1920aef6ca56d8a41bac915b68e4c46a589e0956e27a7b77404",
@@ -715,10 +707,17 @@ fn test_lmdb_state() {
         )
         .unwrap(),
     };
+    let addr_info = MoneroSecretKeyInfo {
+        swap_id: None,
+        creation_height: None,
+        view: key_pair.view,
+        spend: key_pair.spend,
+    };
+
     let addr = monero::Address::from_keypair(monero::Network::Stagenet, &key_pair);
-    database.set_monero_address(&addr, &key_pair).unwrap();
+    database.set_monero_address(&addr, &addr_info).unwrap();
     let val_retrieved = database.get_monero_address_secret_key(&addr).unwrap();
-    assert_eq!(key_pair, val_retrieved);
+    assert_eq!(addr_info, val_retrieved);
     let addrs = database.get_all_monero_addresses().unwrap();
     assert!(addrs.contains(&addr.to_string()));
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -100,6 +100,10 @@ pub enum Error {
 
     /// BitcoinSecp256k1
     BitcoinSecp256k1(bitcoin::secp256k1::Error),
+
+    /// StrictEncoding
+    #[from(strict_encoding::Error)]
+    StrictEncoding(strict_encoding::Error),
 }
 
 #[derive(Debug, Display)]

--- a/src/grpcd/runtime.rs
+++ b/src/grpcd/runtime.rs
@@ -805,7 +805,7 @@ impl Farcaster for FarcasterService {
                 .await?;
             match oneshot_rx.await {
                 Ok(BusMsg::Info(InfoMsg::AddressSecretKey(AddressSecretKey::Bitcoin {
-                    secret_key,
+                    secret_key_info,
                     address: _,
                 }))) => {
                     let oneshot_rx = self
@@ -813,7 +813,7 @@ impl Farcaster for FarcasterService {
                             request: CtlMsg::SweepAddress(SweepAddressAddendum::Bitcoin(
                                 SweepBitcoinAddress {
                                     source_address,
-                                    source_secret_key: secret_key,
+                                    source_secret_key: secret_key_info.secret_key,
                                     destination_address,
                                 },
                             )),
@@ -842,16 +842,15 @@ impl Farcaster for FarcasterService {
                 .await?;
             match oneshot_rx.await {
                 Ok(BusMsg::Info(InfoMsg::AddressSecretKey(AddressSecretKey::Monero {
-                    view,
-                    spend,
+                    secret_key_info,
                     address: _,
                 }))) => {
                     let oneshot_rx = self
                         .process_request(BusMsg::Bridge(BridgeMsg::Ctl {
                             request: CtlMsg::SweepAddress(SweepAddressAddendum::Monero(
                                 SweepMoneroAddress {
-                                    source_spend_key: spend,
-                                    source_view_key: view,
+                                    source_spend_key: secret_key_info.spend,
+                                    source_view_key: secret_key_info.view,
                                     destination_address,
                                     minimum_balance: monero::Amount::from_pico(0),
                                 },

--- a/src/walletd/runtime.rs
+++ b/src/walletd/runtime.rs
@@ -4,7 +4,7 @@ use crate::bus::{
         TakerCommitted, Token, Tx,
     },
     p2p::{Commit, PeerMsg, Reveal, TakerCommit},
-    AddressSecretKey, BusMsg, Outcome, ServiceBus,
+    AddressSecretKey, BitcoinSecretKeyInfo, BusMsg, MoneroSecretKeyInfo, Outcome, ServiceBus,
 };
 use crate::databased::checkpoint_send;
 use crate::service::Endpoints;
@@ -852,8 +852,11 @@ impl Runtime {
                             ServiceId::Database,
                             BusMsg::Ctl(CtlMsg::SetAddressSecretKey(AddressSecretKey::Bitcoin {
                                 address: funding_addr.clone(),
-                                secret_key: key_manager
-                                    .get_or_derive_bitcoin_key(ArbitratingKeyId::Lock)?,
+                                secret_key_info: BitcoinSecretKeyInfo {
+                                    swap_id: Some(swap_id),
+                                    secret_key: key_manager
+                                        .get_or_derive_bitcoin_key(ArbitratingKeyId::Lock)?,
+                                },
                             })),
                         )?;
                         info!("{} | Loading {}", swap_id.swap_id(), "Wallet::Bob".label());
@@ -990,8 +993,12 @@ impl Runtime {
                                 BusMsg::Ctl(CtlMsg::SetAddressSecretKey(
                                     AddressSecretKey::Bitcoin {
                                         address: funding_addr.clone(),
-                                        secret_key: key_manager
-                                            .get_or_derive_bitcoin_key(ArbitratingKeyId::Lock)?,
+                                        secret_key_info: BitcoinSecretKeyInfo {
+                                            swap_id: Some(swap_id),
+                                            secret_key: key_manager.get_or_derive_bitcoin_key(
+                                                ArbitratingKeyId::Lock,
+                                            )?,
+                                        },
                                     },
                                 )),
                             )?;
@@ -1186,8 +1193,12 @@ impl Runtime {
                         ServiceId::Database,
                         BusMsg::Ctl(CtlMsg::SetAddressSecretKey(AddressSecretKey::Monero {
                             address: corresponding_address,
-                            spend: keypair.spend.as_bytes().try_into().unwrap(),
-                            view: keypair.view.as_bytes().try_into().unwrap(),
+                            secret_key_info: MoneroSecretKeyInfo {
+                                swap_id: Some(swap_id),
+                                spend: keypair.spend.as_bytes().try_into().unwrap(),
+                                view: keypair.view.as_bytes().try_into().unwrap(),
+                                creation_height: None,
+                            },
                         })),
                     )?;
 
@@ -1284,8 +1295,12 @@ impl Runtime {
                         ServiceId::Database,
                         BusMsg::Ctl(CtlMsg::SetAddressSecretKey(AddressSecretKey::Monero {
                             address: corresponding_address,
-                            spend: keypair.spend.as_bytes().try_into().unwrap(),
-                            view: keypair.view.as_bytes().try_into().unwrap(),
+                            secret_key_info: MoneroSecretKeyInfo {
+                                swap_id: Some(swap_id),
+                                spend: keypair.spend.as_bytes().try_into().unwrap(),
+                                view: keypair.view.as_bytes().try_into().unwrap(),
+                                creation_height: None,
+                            },
                         })),
                     )?;
 


### PR DESCRIPTION
Bitcoin addresses now additionally store an optional swap_id.

Monero addresses additionally store an optional swap_id and optional
creation height.

Also add cleaner database encoding error handling.

This allows us to know from which height to sweep the Monero funding address and to which swap the funding addresses belong when cleaning up dangling swap data.