### PR TITLE
Swapd: Some patches and improvements

### DIFF
--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -737,7 +737,7 @@ impl Runtime {
             {
                 // checkpoint swap pre lock bob
                 debug!("{} | checkpointing bob pre lock state", self.swap_id);
-                // Set the monero address creation height for Bob to before setting the first checkpoint
+                // Set the monero address creation height for Bob before setting the first checkpoint
                 if self.monero_address_creation_height.is_none() {
                     self.monero_address_creation_height =
                         Some(self.syncer_state.height(Blockchain::Monero));

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -1351,14 +1351,14 @@ impl Runtime {
                         self.syncer_state.get_confs(TxLabel::AccLock).unwrap_or(0),
                     );
                     info!(
-                        "{} | {} reaches your address {} around block {}",
+                        "{} | {} reaches your address {} after block {}",
                         self.swap_id.swap_id(),
                         Blockchain::Monero.label(),
                         sweep_xmr.destination_address.addr(),
                         sweep_block.bright_blue_bold(),
                     );
                     warn!(
-                        "Peerd might crash, just ignore it, counterparty closed\
+                        "Peerd might crash, just ignore it, counterparty closed \
                                connection but you don't need it anymore!"
                     );
                     self.pending_requests.defer_request(

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -2309,11 +2309,16 @@ impl Runtime {
                             }
 
                             TxLabel::Cancel
-                                if self.temporal_safety.safe_refund(*confirmations)
+                                if self
+                                    .temporal_safety
+                                    .final_tx(*confirmations, Blockchain::Bitcoin)
                                     && (self.state.b_buy_sig() || self.state.b_core_arb())
                                     && self.txs.contains_key(&TxLabel::Refund) =>
                             {
                                 trace!("here Bob publishes refund tx");
+                                if !self.temporal_safety.safe_refund(*confirmations) {
+                                    warn!("Publishing refund tx, but we might already have been punished");
+                                }
                                 let (tx_label, refund_tx) =
                                     self.txs.remove_entry(&TxLabel::Refund).unwrap();
                                 self.broadcast(refund_tx, tx_label, endpoints)?;

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -202,7 +202,7 @@ impl MoneroRpc {
                 debug!("Watch wallet opened successfully");
             }
             Ok(_) => {
-                debug!("Watch wallet opened successfully")
+                debug!("Watch wallet opened successfully");
             }
         }
 
@@ -436,6 +436,7 @@ async fn run_syncerd_task_receiver(
                         }
                         Task::WatchAddress(task) => match task.addendum.clone() {
                             AddressAddendum::Monero(_) => {
+                                debug!("received new task: {:?}", task);
                                 let mut state_guard = state.lock().await;
                                 state_guard.watch_address(task, syncerd_task.source);
                             }
@@ -452,6 +453,7 @@ async fn run_syncerd_task_receiver(
                             state_guard.watch_height(task, syncerd_task.source).await;
                         }
                         Task::WatchTransaction(task) => {
+                            debug!("received new task: {:?}", task);
                             let mut state_guard = state.lock().await;
                             state_guard.watch_transaction(task, syncerd_task.source);
                         }


### PR DESCRIPTION
Based on #761

Correct log message for when monero reaches the buyer.
Log incoming monero syncer watch addr and tx tasks on debug.
Record and checkpoint the monero address creation height.
Improve formatting of two log messages.
Swapd: Safer behaviour around publishing transaction. Always publish the refund transaction if you can, inform the user if punish was possible in the meantime