### PR TITLE
Feat: new grpc config options

### DIFF
--- a/farcasterd.toml
+++ b/farcasterd.toml
@@ -29,8 +29,8 @@ monero_rpc_wallet = "http://localhost:38084"
 # Define grpc
 [farcasterd.grpc]
 # Set this to true to enable the grpc daemon
-use_grpc = true
-# If use_grpc=true, also requires a port for grpc clients to connect to
+enable = true
+# If enabled, also requires a port for grpc clients to connect to
 port = 50051
 
 # Syncers configuration

--- a/farcasterd.toml
+++ b/farcasterd.toml
@@ -31,7 +31,7 @@ monero_rpc_wallet = "http://localhost:38084"
 # Set this to true to enable the grpc daemon
 enable = true
 # If enabled, also requires a port for grpc clients to connect to
-port = 50051
+bind_port = 50051
 
 # Syncers configuration
 # configures the Bitcoin and Monero syncers for the three

--- a/farcasterd.toml
+++ b/farcasterd.toml
@@ -32,6 +32,10 @@ monero_rpc_wallet = "http://localhost:38084"
 enable = true
 # If enabled, also requires a port for grpc clients to connect to
 bind_port = 50051
+# If enabled, where to bind the grpc service. Defaults to 127.0.0.1
+# The grpc interface allow full management of the node, you probably want to
+# keep it only accessible on your local network
+bind_ip = "127.0.0.1"
 
 # Syncers configuration
 # configures the Bitcoin and Monero syncers for the three

--- a/farcasterd.toml
+++ b/farcasterd.toml
@@ -26,8 +26,8 @@ bitcoin_cookie_path = "~/.bitcoin/testnet3/.cookie"
 # the wallet should have spendable funds
 monero_rpc_wallet = "http://localhost:38084"
 
-# Define grpc
-[farcasterd.grpc]
+# Defines grpc options
+[grpc]
 # Set this to true to enable the grpc daemon
 enable = true
 # If enabled, also requires a port for grpc clients to connect to

--- a/farcasterd.toml
+++ b/farcasterd.toml
@@ -6,7 +6,7 @@
 # Set this to true if you want to enable auto-funding, default to false
 # if set to true you need to register the parameter for the networks you
 # want to support: mainnet, testnet, or local
-auto_fund = false
+enable = false
 
 # Auto-funding testnet parameters
 [farcasterd.auto_funding.testnet]

--- a/src/bin/grpcd.rs
+++ b/src/bin/grpcd.rs
@@ -46,7 +46,7 @@ fn main() {
     debug!("CTL RPC socket {}", &service_config.ctl_endpoint);
 
     debug!("Starting runtime ...");
-    grpcd::run(service_config, opts.grpc_port).expect("Error running grpcd runtime");
+    grpcd::run(service_config, opts.grpc_port, opts.grpc_ip).expect("Error running grpcd runtime");
 
     unreachable!()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,8 @@ pub const FARCASTER_TESTNET_ELECTRUM_SERVER: &str = "ssl://blockstream.info:993"
 pub const FARCASTER_TESTNET_MONERO_DAEMON: &str = "http://stagenet.community.rino.io:38081";
 pub const FARCASTER_TESTNET_MONERO_RPC_WALLET: &str = "http://localhost:38083";
 
+pub const GRPC_BIND_IP_ADDRESS: &str = "127.0.0.1";
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(crate = "serde_crate")]
 pub struct Config {
@@ -56,6 +58,17 @@ impl Config {
         match &self.grpc {
             Some(GrpcConfig { enable, .. }) => *enable,
             _ => false,
+        }
+    }
+
+    /// Returns the Grcp bind ip address, if not set return the default value
+    pub fn grpc_bind_ip(&self) -> String {
+        match &self.grpc {
+            Some(GrpcConfig {
+                bind_ip: Some(bind_ip),
+                ..
+            }) => bind_ip.clone(),
+            _ => String::from(GRPC_BIND_IP_ADDRESS),
         }
     }
 
@@ -114,6 +127,8 @@ pub struct GrpcConfig {
     pub enable: bool,
     /// Grpc port configuration
     pub bind_port: u16,
+    /// Grpc listening ip address
+    pub bind_ip: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,7 +113,7 @@ pub struct GrpcConfig {
     /// Use grpc functionality
     pub enable: bool,
     /// Grpc port configuration
-    pub port: u64,
+    pub bind_port: u16,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,9 +53,9 @@ impl Config {
     pub fn is_grpc_enable(&self) -> bool {
         match &self.farcasterd {
             Some(FarcasterdConfig {
-                grpc: Some(GrpcConfig { use_grpc, .. }),
+                grpc: Some(GrpcConfig { enable, .. }),
                 ..
-            }) => *use_grpc,
+            }) => *enable,
             _ => false,
         }
     }
@@ -113,7 +113,7 @@ pub struct FarcasterdConfig {
 #[serde(crate = "serde_crate")]
 pub struct GrpcConfig {
     /// Use grpc functionality
-    pub use_grpc: bool,
+    pub enable: bool,
     /// Grpc port configuration
     pub port: u64,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,9 +42,9 @@ impl Config {
     pub fn is_auto_funding_enable(&self) -> bool {
         match &self.farcasterd {
             Some(FarcasterdConfig {
-                auto_funding: Some(AutoFundingConfig { auto_fund, .. }),
-                grpc: _,
-            }) => *auto_fund,
+                auto_funding: Some(AutoFundingConfig { enable, .. }),
+                ..
+            }) => *enable,
             _ => false,
         }
     }
@@ -53,8 +53,8 @@ impl Config {
     pub fn is_grpc_enable(&self) -> bool {
         match &self.farcasterd {
             Some(FarcasterdConfig {
-                auto_funding: _,
                 grpc: Some(GrpcConfig { use_grpc, .. }),
+                ..
             }) => *use_grpc,
             _ => false,
         }
@@ -67,13 +67,13 @@ impl Config {
             Some(FarcasterdConfig {
                 auto_funding:
                     Some(AutoFundingConfig {
-                        auto_fund,
+                        enable,
                         mainnet,
                         testnet,
                         local,
                     }),
-                grpc: _,
-            }) if *auto_fund => match network {
+                ..
+            }) if *enable => match network {
                 Network::Mainnet => mainnet.clone(),
                 Network::Testnet => testnet.clone(),
                 Network::Local => local.clone(),
@@ -122,7 +122,7 @@ pub struct GrpcConfig {
 #[serde(crate = "serde_crate")]
 pub struct AutoFundingConfig {
     /// Use auto-funding functionality
-    pub auto_fund: bool,
+    pub enable: bool,
     /// Mainnet auto-funding configuration
     pub mainnet: Option<AutoFundingServers>,
     /// Testnet auto-funding configuration

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,12 +33,14 @@ pub const FARCASTER_TESTNET_MONERO_RPC_WALLET: &str = "http://localhost:38083";
 pub struct Config {
     /// Farcasterd configuration
     pub farcasterd: Option<FarcasterdConfig>,
+    /// Sets the grpc server port, if none is given, no grpc server is run
+    pub grpc: Option<GrpcConfig>,
     /// Syncer configuration
     pub syncers: Option<SyncersConfig>,
 }
 
 impl Config {
-    /// Returns if auto-funding functionality is enable
+    /// Returns if auto-funding functionality is enabled
     pub fn is_auto_funding_enable(&self) -> bool {
         match &self.farcasterd {
             Some(FarcasterdConfig {
@@ -49,13 +51,10 @@ impl Config {
         }
     }
 
-    /// Returns if grpc port is set
+    /// Returns if grpc is enabled
     pub fn is_grpc_enable(&self) -> bool {
-        match &self.farcasterd {
-            Some(FarcasterdConfig {
-                grpc: Some(GrpcConfig { enable, .. }),
-                ..
-            }) => *enable,
+        match &self.grpc {
+            Some(GrpcConfig { enable, .. }) => *enable,
             _ => false,
         }
     }
@@ -95,6 +94,7 @@ impl Default for Config {
     fn default() -> Self {
         Config {
             farcasterd: None,
+            grpc: None,
             syncers: Some(SyncersConfig::default()),
         }
     }
@@ -105,8 +105,6 @@ impl Default for Config {
 pub struct FarcasterdConfig {
     /// Sets the auto-funding parameters, default to no auto-fund
     pub auto_funding: Option<AutoFundingConfig>,
-    /// Sets the grpc server port, if none is given, no grpc server is run
-    pub grpc: Option<GrpcConfig>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -65,12 +65,9 @@ pub fn run(
             "grpcd",
             &[
                 "--grpc-port",
-                &config
-                    .grpc
-                    .clone()
-                    .unwrap()
-                    .bind_port
-                    .to_string(),
+                &config.grpc.clone().unwrap().bind_port.to_string(),
+                "--grpc-ip",
+                &config.grpc_bind_ip(),
             ],
         )?;
     }

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -69,7 +69,7 @@ pub fn run(
                     .grpc
                     .clone()
                     .unwrap()
-                    .port
+                    .bind_port
                     .to_string(),
             ],
         )?;

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -66,10 +66,8 @@ pub fn run(
             &[
                 "--grpc-port",
                 &config
-                    .farcasterd
-                    .clone()
-                    .unwrap()
                     .grpc
+                    .clone()
                     .unwrap()
                     .port
                     .to_string(),

--- a/src/grpcd/opts.rs
+++ b/src/grpcd/opts.rs
@@ -10,6 +10,10 @@ pub struct Opts {
     /// Port number that the grpc server is accepting connections on
     #[clap(long)]
     pub grpc_port: u16,
+
+    /// Ip that the grpc server is accepting connections on
+    #[clap(long)]
+    pub grpc_ip: String,
 }
 
 impl Opts {

--- a/src/grpcd/opts.rs
+++ b/src/grpcd/opts.rs
@@ -9,7 +9,7 @@ pub struct Opts {
 
     /// Port number that the grpc server is accepting connections on
     #[clap(long)]
-    pub grpc_port: u64,
+    pub grpc_port: u16,
 }
 
 impl Opts {

--- a/src/grpcd/runtime.rs
+++ b/src/grpcd/runtime.rs
@@ -150,7 +150,7 @@ impl IdCounter {
     }
 }
 
-pub fn run(config: ServiceConfig, grpc_port: u16) -> Result<(), Error> {
+pub fn run(config: ServiceConfig, grpc_port: u16, grpc_ip: String) -> Result<(), Error> {
     let (tx_response, rx_response): (Sender<(u64, BusMsg)>, Receiver<(u64, BusMsg)>) =
         std::sync::mpsc::channel();
 
@@ -159,7 +159,7 @@ pub fn run(config: ServiceConfig, grpc_port: u16) -> Result<(), Error> {
     tx_request.connect("inproc://grpcdbridge")?;
     rx_request.bind("inproc://grpcdbridge")?;
 
-    let mut server = GrpcServer { grpc_port };
+    let mut server = GrpcServer { grpc_port, grpc_ip };
     server.run(rx_response, tx_request)?;
 
     let runtime = Runtime {
@@ -868,6 +868,7 @@ impl Farcaster for FarcasterService {
 
 pub struct GrpcServer {
     grpc_port: u16,
+    grpc_ip: String,
 }
 
 fn request_loop(
@@ -939,7 +940,7 @@ impl GrpcServer {
         rx_response: Receiver<(u64, BusMsg)>,
         tx_request: zmq::Socket,
     ) -> Result<(), Error> {
-        let addr = format!("0.0.0.0:{}", self.grpc_port)
+        let addr = format!("{}:{}", self.grpc_ip, self.grpc_port)
             .parse()
             .expect("invalid grpc server bind address");
         info!("Binding grpc to address: {}", addr);

--- a/src/grpcd/runtime.rs
+++ b/src/grpcd/runtime.rs
@@ -150,7 +150,7 @@ impl IdCounter {
     }
 }
 
-pub fn run(config: ServiceConfig, grpc_port: u64) -> Result<(), Error> {
+pub fn run(config: ServiceConfig, grpc_port: u16) -> Result<(), Error> {
     let (tx_response, rx_response): (Sender<(u64, BusMsg)>, Receiver<(u64, BusMsg)>) =
         std::sync::mpsc::channel();
 
@@ -867,7 +867,7 @@ impl Farcaster for FarcasterService {
 }
 
 pub struct GrpcServer {
-    grpc_port: u64,
+    grpc_port: u16,
 }
 
 fn request_loop(

--- a/tests/cfg/config.yml
+++ b/tests/cfg/config.yml
@@ -35,6 +35,14 @@ ci:
       port: 38884
       protocol: "http"
 
+  grpc:
+    fc1:
+      host: "0.0.0.0"
+      port: 23432
+    fc2:
+      host: "0.0.0.0"
+      port: 23433
+
 # Top level configuration for (docker-)compose setup, used if no `CI`
 # environment variable is found.
 compose:
@@ -71,3 +79,11 @@ compose:
       host: "localhost"
       port: 38884
       protocol: "http"
+
+  grpc:
+    fc1:
+      host: "0.0.0.0"
+      port: 23432
+    fc2:
+      host: "0.0.0.0"
+      port: 23433

--- a/tests/cfg/fc1.ci.toml
+++ b/tests/cfg/fc1.ci.toml
@@ -1,6 +1,6 @@
 [grpc]
 enable = true
-port = 23432
+bind_port = 23432
 
 [syncers.local]
 electrum_server = "tcp://electrs:60401"

--- a/tests/cfg/fc1.ci.toml
+++ b/tests/cfg/fc1.ci.toml
@@ -1,6 +1,7 @@
 [grpc]
 enable = true
 bind_port = 23432
+bind_ip = "0.0.0.0"
 
 [syncers.local]
 electrum_server = "tcp://electrs:60401"

--- a/tests/cfg/fc1.ci.toml
+++ b/tests/cfg/fc1.ci.toml
@@ -1,5 +1,5 @@
 [farcasterd.grpc]
-use_grpc = true
+enable = true
 port = 23432
 
 [syncers.local]

--- a/tests/cfg/fc1.ci.toml
+++ b/tests/cfg/fc1.ci.toml
@@ -1,4 +1,4 @@
-[farcasterd.grpc]
+[grpc]
 enable = true
 port = 23432
 

--- a/tests/cfg/fc1.toml
+++ b/tests/cfg/fc1.toml
@@ -1,6 +1,6 @@
 [grpc]
 enable = true
-port = 23432
+bind_port = 23432
 
 [syncers.local]
 electrum_server = "tcp://localhost:60401"

--- a/tests/cfg/fc1.toml
+++ b/tests/cfg/fc1.toml
@@ -1,6 +1,7 @@
 [grpc]
 enable = true
 bind_port = 23432
+bind_ip = "0.0.0.0"
 
 [syncers.local]
 electrum_server = "tcp://localhost:60401"

--- a/tests/cfg/fc1.toml
+++ b/tests/cfg/fc1.toml
@@ -1,5 +1,5 @@
 [farcasterd.grpc]
-use_grpc = true
+enable = true
 port = 23432
 
 [syncers.local]

--- a/tests/cfg/fc1.toml
+++ b/tests/cfg/fc1.toml
@@ -1,4 +1,4 @@
-[farcasterd.grpc]
+[grpc]
 enable = true
 port = 23432
 

--- a/tests/cfg/fc2.ci.toml
+++ b/tests/cfg/fc2.ci.toml
@@ -1,6 +1,6 @@
 [grpc]
 enable = true
-port = 23433
+bind_port = 23433
 
 [syncers.local]
 electrum_server = "tcp://electrs:60401"

--- a/tests/cfg/fc2.ci.toml
+++ b/tests/cfg/fc2.ci.toml
@@ -1,5 +1,5 @@
 [farcasterd.grpc]
-use_grpc = true
+enable = true
 port = 23433
 
 [syncers.local]

--- a/tests/cfg/fc2.ci.toml
+++ b/tests/cfg/fc2.ci.toml
@@ -1,4 +1,4 @@
-[farcasterd.grpc]
+[grpc]
 enable = true
 port = 23433
 

--- a/tests/cfg/fc2.ci.toml
+++ b/tests/cfg/fc2.ci.toml
@@ -1,6 +1,7 @@
 [grpc]
 enable = true
 bind_port = 23433
+bind_ip = "0.0.0.0"
 
 [syncers.local]
 electrum_server = "tcp://electrs:60401"

--- a/tests/cfg/fc2.toml
+++ b/tests/cfg/fc2.toml
@@ -1,6 +1,7 @@
 [grpc]
 enable = true
 bind_port = 23433
+bind_ip = "0.0.0.0"
 
 [syncers.local]
 electrum_server = "tcp://localhost:60401"

--- a/tests/cfg/fc2.toml
+++ b/tests/cfg/fc2.toml
@@ -1,6 +1,6 @@
 [grpc]
 enable = true
-port = 23433
+bind_port = 23433
 
 [syncers.local]
 electrum_server = "tcp://localhost:60401"

--- a/tests/cfg/fc2.toml
+++ b/tests/cfg/fc2.toml
@@ -1,5 +1,5 @@
 [farcasterd.grpc]
-use_grpc = true
+enable = true
 port = 23433
 
 [syncers.local]

--- a/tests/cfg/fc2.toml
+++ b/tests/cfg/fc2.toml
@@ -1,4 +1,4 @@
-[farcasterd.grpc]
+[grpc]
 enable = true
 port = 23433
 

--- a/tests/grpc.rs
+++ b/tests/grpc.rs
@@ -12,7 +12,7 @@ use farcaster::{InfoRequest, MakeResponse, NeedsFundingResponse};
 use farcaster_node::bus::ctl::BitcoinFundingInfo;
 use std::{str::FromStr, sync::Arc, time};
 use tonic::transport::Endpoint;
-use utils::fc::*;
+use utils::{config, fc::*};
 
 mod utils;
 
@@ -23,18 +23,22 @@ pub mod farcaster {
 #[tokio::test]
 #[ignore]
 async fn grpc_server_functional_test() {
+    let conf = config::TestConfig::parse();
     let _ = setup_clients().await;
 
     // Allow some time for the microservices to start and register each other
     tokio::time::sleep(time::Duration::from_secs(10)).await;
 
-    let channel_1 = Endpoint::from_static("http://0.0.0.0:23432")
+    let grpc_1 = conf.grpc.fc1.to_string();
+    let channel_1 = Endpoint::from_str(&grpc_1)
+        .unwrap()
         .connect()
         .await
         .unwrap();
     let mut farcaster_client_1 = FarcasterClient::new(channel_1);
 
-    let channel_2 = Endpoint::from_static("http://0.0.0.0:23433")
+    let channel_2 = Endpoint::from_str(&conf.grpc.fc2.to_string())
+        .unwrap()
         .connect()
         .await
         .unwrap();
@@ -177,7 +181,8 @@ async fn grpc_server_functional_test() {
 
     // Test sweep address on re-launch
     let btc_address = bitcoin_rpc.get_new_address(None, None).unwrap();
-    let channel_1 = Endpoint::from_static("http://0.0.0.0:23432")
+    let channel_1 = Endpoint::from_str(&grpc_1)
+        .unwrap()
         .connect()
         .await
         .unwrap();
@@ -246,7 +251,8 @@ async fn grpc_server_functional_test() {
     kill_all();
     let _ = setup_clients().await;
     tokio::time::sleep(time::Duration::from_secs(5)).await;
-    let channel_1 = Endpoint::from_static("http://0.0.0.0:23432")
+    let channel_1 = Endpoint::from_str(&grpc_1)
+        .unwrap()
         .connect()
         .await
         .unwrap();

--- a/tests/utils/config.rs
+++ b/tests/utils/config.rs
@@ -26,6 +26,7 @@ pub struct TestConfig {
     pub bitcoin: BitcoinConfig,
     pub electrs: NodeConfig,
     pub monero: MoneroConfig,
+    pub grpc: GrpcConfig,
 }
 
 impl TestConfig {
@@ -138,5 +139,25 @@ impl From<WalletIndex> for usize {
             WalletIndex::Secondary => 1,
             WalletIndex::Tertiary => 2,
         }
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(crate = "serde_crate")]
+pub struct GrpcConfig {
+    pub fc1: GrpcNode,
+    pub fc2: GrpcNode,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(crate = "serde_crate")]
+pub struct GrpcNode {
+    pub host: String,
+    pub port: u16,
+}
+
+impl fmt::Display for GrpcNode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "http://{}:{}", self.host, self.port)
     }
 }


### PR DESCRIPTION
Fix #468, fix #466, fix #467

This PR is a rework of the gRPC configuration in `farcasterd.toml` config file. It updates the previous config and add a new flag to control the bind ip address.

**This PR also rename the `auto_fund = true` option into `enable = true` for auto-funding**