### PR TITLE
Farcaster: Handle take offer failure

### DIFF
--- a/src/bus/p2p.rs
+++ b/src/bus/p2p.rs
@@ -23,6 +23,10 @@ pub enum PeerMsg {
     #[display("{0} taker commit")]
     TakerCommit(TakerCommit),
 
+    #[api(type = 33703)]
+    #[display("{0} offer not found")]
+    OfferNotFound(SwapId),
+
     #[api(type = 33704)]
     #[display("reveal {0}")]
     Reveal(Reveal),
@@ -73,6 +77,7 @@ impl PeerMsg {
         match self {
             PeerMsg::MakerCommit(c) => c.swap_id(),
             PeerMsg::TakerCommit(c) => c.swap_id(),
+            PeerMsg::OfferNotFound(swap_id) => *swap_id,
             PeerMsg::Reveal(r) => r.swap_id(),
             PeerMsg::RefundProcedureSignatures(RefundProcedureSignatures { swap_id, .. }) => {
                 *swap_id
@@ -105,6 +110,7 @@ impl PeerMsg {
                 | PeerMsg::Ping(_)
                 | PeerMsg::Pong(_)
                 | PeerMsg::MsgReceipt(_)
+                | PeerMsg::OfferNotFound(_)
         )
     }
 
@@ -117,6 +123,7 @@ impl PeerMsg {
                 | PeerMsg::RefundProcedureSignatures(_)
                 | PeerMsg::CoreArbitratingSetup(_)
                 | PeerMsg::BuyProcedureSignature(_)
+                | PeerMsg::OfferNotFound(_)
         )
     }
 }

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -826,8 +826,8 @@ impl Runtime {
 
     fn match_request_to_syncer_state_machine(
         &mut self,
-        req: BusMsg,
-        source: ServiceId,
+        req: &BusMsg,
+        source: &ServiceId,
     ) -> Result<Option<SyncerStateMachine>, Error> {
         match (req, source) {
             (BusMsg::Ctl(CtlMsg::SweepAddress(..)), _) => Ok(Some(SyncerStateMachine::Start)),
@@ -836,15 +836,15 @@ impl Runtime {
                     id, ..
                 }))),
                 _,
-            ) => Ok(self.syncer_state_machines.remove(&id)),
+            ) => Ok(self.syncer_state_machines.remove(id)),
             _ => Ok(None),
         }
     }
 
     fn match_request_to_trade_state_machine(
         &mut self,
-        req: BusMsg,
-        source: ServiceId,
+        req: &BusMsg,
+        source: &ServiceId,
     ) -> Result<Option<TradeStateMachine>, Error> {
         match (req, source) {
             (BusMsg::Ctl(CtlMsg::RestoreCheckpoint(..)), _) => {
@@ -858,7 +858,7 @@ impl Runtime {
                 .iter()
                 .position(|tsm| {
                     if let Some(tsm_public_offer) = tsm.open_offer() {
-                        tsm_public_offer == public_offer
+                        tsm_public_offer == *public_offer
                     } else {
                         false
                     }
@@ -869,7 +869,7 @@ impl Runtime {
                 .iter()
                 .position(|tsm| {
                     if let Some(tsm_public_offer) = tsm.consumed_offer() {
-                        tsm_public_offer == public_offer
+                        tsm_public_offer == *public_offer
                     } else {
                         false
                     }
@@ -881,7 +881,7 @@ impl Runtime {
                 .iter()
                 .position(|tsm| {
                     if let Some(tsm_addr) = tsm.awaiting_connect_from() {
-                        addr == tsm_addr
+                        tsm_addr == *addr
                     } else {
                         false
                     }
@@ -897,7 +897,7 @@ impl Runtime {
                 .iter()
                 .position(|tsm| {
                     if let Some(tsm_swap_id) = tsm.swap_id() {
-                        tsm_swap_id == swap_id
+                        tsm_swap_id == *swap_id
                     } else {
                         false
                     }
@@ -913,18 +913,14 @@ impl Runtime {
         source: ServiceId,
         endpoints: &mut Endpoints,
     ) -> Result<(), Error> {
-        if let Some(tsm) =
-            self.match_request_to_trade_state_machine(request.clone(), source.clone())?
-        {
+        if let Some(tsm) = self.match_request_to_trade_state_machine(&request, &source)? {
             if let Some(new_tsm) =
                 TradeStateMachineExecutor::execute(self, endpoints, source, request, tsm)?
             {
                 self.trade_state_machines.push(new_tsm);
             }
             Ok(())
-        } else if let Some(ssm) =
-            self.match_request_to_syncer_state_machine(request.clone(), source.clone())?
-        {
+        } else if let Some(ssm) = self.match_request_to_syncer_state_machine(&request, &source)? {
             if let Some(new_ssm) =
                 SyncerStateMachineExecutor::execute(self, endpoints, source, request, ssm)?
             {
@@ -958,6 +954,16 @@ impl Runtime {
                             code: FailureCode::Unknown,
                             info: "Swap to connect not found.".to_string(),
                         })),
+                    )?;
+                    Ok(())
+                }
+                BusMsg::P2p(PeerMsg::TakerCommit(TakerCommit { commit, .. })) => {
+                    debug!("{} | Offer already taken or aborted, replying with offer not found to the counterparty", commit.swap_id());
+                    endpoints.send_to(
+                        ServiceBus::Msg,
+                        self.identity(),
+                        source,
+                        BusMsg::P2p(PeerMsg::OfferNotFound(commit.swap_id())),
                     )?;
                     Ok(())
                 }

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -1037,8 +1037,15 @@ impl Runtime {
                     )?;
                     Ok(())
                 }
-                BusMsg::P2p(PeerMsg::TakerCommit(TakerCommit { commit, .. })) => {
-                    debug!("{} | Offer already taken or aborted, replying with offer not found to the counterparty", commit.swap_id());
+                BusMsg::P2p(PeerMsg::TakerCommit(TakerCommit {
+                    commit,
+                    public_offer,
+                })) => {
+                    debug!(
+                        "{} | Offer {} already taken or aborted, replying with offer not found to the counterparty",
+                        commit.swap_id(),
+                        public_offer.id(),
+                    );
                     endpoints.send_to(
                         ServiceBus::Msg,
                         self.identity(),

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -561,6 +561,9 @@ impl Runtime {
         }
 
         match request {
+            // Trade role: Taker, target of this message
+            // Potentially the first and only message receive from maker if the offer is not found
+            // on maker side.
             PeerMsg::OfferNotFound(swap_id)
                 if self.state.commit() && self.state.trade_role() == Some(TradeRole::Taker) =>
             {

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -667,6 +667,17 @@ impl Runtime {
         }
 
         match request {
+            PeerMsg::OfferNotFound(swap_id)
+                if self.state.commit() && self.state.trade_role() == Some(TradeRole::Taker) =>
+            {
+                error!(
+                    "{} | Taken offer was not found by the maker, aborting this swap.",
+                    swap_id
+                );
+                // just cancel the swap, no additional logic required
+                self.state_update(endpoints, State::Alice(AliceState::FinishA(Outcome::Abort)))?;
+                self.abort_swap(endpoints)?;
+            }
             // Trade role: Taker, target of this message
             // Message #2 received after Take Swap control message
             //

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -568,8 +568,9 @@ impl Runtime {
                 if self.state.commit() && self.state.trade_role() == Some(TradeRole::Taker) =>
             {
                 error!(
-                    "{} | Taken offer was not found by the maker, aborting this swap.",
-                    swap_id
+                    "{} | Taken offer {} was not found by the maker, aborting this swap.",
+                    swap_id.swap_id(),
+                    self.public_offer.id().swap_id(),
                 );
                 // just cancel the swap, no additional logic required
                 self.state_update(State::Alice(AliceState::FinishA(Outcome::FailureAbort)))?;


### PR DESCRIPTION
The maker now replies to the taker with  the `OfferNotFound` message in case the offer is no longer available. The taker, on receipt, then aborts the already spawned swap.