### PR TITLE
TSM: Check if Hello is coming from peerd

### DIFF
--- a/src/farcasterd/trade_state_machine.rs
+++ b/src/farcasterd/trade_state_machine.rs
@@ -1240,7 +1240,8 @@ fn attempt_transition_to_end(
     } = swapd_running;
     match (event.request.clone(), event.source.clone()) {
         (BusMsg::Ctl(CtlMsg::Hello), source)
-            if source.node_addr() == peerd.as_ref().map(|p| p.node_addr()).flatten() =>
+            if matches!(source, ServiceId::Peer(..))
+                && source.node_addr() == peerd.as_ref().map(|p| p.node_addr()).flatten() =>
         {
             let swap_service_id = ServiceId::Swap(swap_id);
             debug!(


### PR DESCRIPTION
Fixes an issue where the reconnect message would be triggered by a Hello of an arbitrary peer.