### PR TITLE
Syncer State Machine: Handle Task Aborted

### DIFF
--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -14,7 +14,7 @@ use crate::farcasterd::stats::Stats;
 use crate::farcasterd::syncer_state_machine::{SyncerStateMachine, SyncerStateMachineExecutor};
 use crate::farcasterd::trade_state_machine::{TradeStateMachine, TradeStateMachineExecutor};
 use crate::farcasterd::Opts;
-use crate::syncerd::AddressBalance;
+use crate::syncerd::{AddressBalance, TaskAborted};
 use crate::syncerd::{Event as SyncerEvent, HealthResult, SweepSuccess, TaskId};
 use crate::{
     bus::ctl::{Keys, ProgressStack, Token},
@@ -916,6 +916,14 @@ impl Runtime {
                 }))),
                 _,
             ) => Ok(self.syncer_state_machines.remove(id)),
+            (BusMsg::Sync(SyncMsg::Event(SyncerEvent::TaskAborted(TaskAborted { id, .. }))), _) => {
+                if let Some(id) = id.clone().pop() {
+                    Ok(self.syncer_state_machines.remove(&id))
+                } else {
+                    Ok(None)
+                }
+            }
+
             _ => Ok(None),
         }
     }

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -945,6 +945,11 @@ impl Runtime {
                 _,
             ) => Ok(self.syncer_state_machines.remove(id)),
             (BusMsg::Sync(SyncMsg::Event(SyncerEvent::TaskAborted(TaskAborted { id, .. }))), _) => {
+                // can only match to a syncer state machine if `id` vec is singleton, i.e. a single ssm.
+                // note that this limitation of the syncer state machine handling is not a problem in the
+                // *current* implementation since the `TaskAborted.id` vec is only non-singleton when the
+                // task target is `TaskTarget::AllTasks`, and this is only emitted when a swap ends normally
+                // without error, thus does not require any cleanup.
                 if let Some(id) = id.clone().pop() {
                     Ok(self.syncer_state_machines.remove(&id))
                 } else {

--- a/src/farcasterd/syncer_state_machine.rs
+++ b/src/farcasterd/syncer_state_machine.rs
@@ -350,26 +350,7 @@ fn attempt_transition_to_end(
             } else {
                 event.send_client_info(source, InfoMsg::String("Nothing to sweep.".to_string()))?;
             }
-
-            runtime.registered_services = runtime
-                .registered_services
-                .clone()
-                .drain()
-                .filter(|service| {
-                    if let ServiceId::Syncer(..) = service {
-                        if !runtime.syncer_has_client(service) {
-                            info!("Terminating {}", service);
-                            event
-                                .send_ctl_service(service.clone(), CtlMsg::Terminate)
-                                .is_err()
-                        } else {
-                            true
-                        }
-                    } else {
-                        true
-                    }
-                })
-                .collect();
+            runtime.clean_up_after_syncer_usage(event.endpoints)?;
             Ok(None)
         }
 
@@ -393,25 +374,7 @@ fn attempt_transition_to_end(
                     }),
                 )?;
             }
-            runtime.registered_services = runtime
-                .registered_services
-                .clone()
-                .drain()
-                .filter(|service| {
-                    if let ServiceId::Syncer(..) = service {
-                        if !runtime.syncer_has_client(service) {
-                            info!("Terminating {}", service);
-                            event
-                                .send_ctl_service(service.clone(), CtlMsg::Terminate)
-                                .is_err()
-                        } else {
-                            true
-                        }
-                    } else {
-                        true
-                    }
-                })
-                .collect();
+            runtime.clean_up_after_syncer_usage(event.endpoints)?;
             Ok(None)
         }
 
@@ -431,25 +394,7 @@ fn attempt_transition_to_end(
                     ),
                 }),
             )?;
-            runtime.registered_services = runtime
-                .registered_services
-                .clone()
-                .drain()
-                .filter(|service| {
-                    if let ServiceId::Syncer(..) = service {
-                        if !runtime.syncer_has_client(service) {
-                            info!("Terminating {}", service);
-                            event
-                                .send_ctl_service(service.clone(), CtlMsg::Terminate)
-                                .is_err()
-                        } else {
-                            true
-                        }
-                    } else {
-                        true
-                    }
-                })
-                .collect();
+            runtime.clean_up_after_syncer_usage(event.endpoints)?;
             Ok(None)
         }
 
@@ -457,25 +402,7 @@ fn attempt_transition_to_end(
             if syncer == syncer_id && res.id == syncer_task_id =>
         {
             event.send_ctl_service(source, CtlMsg::HealthResult(res.health))?;
-            runtime.registered_services = runtime
-                .registered_services
-                .clone()
-                .drain()
-                .filter(|service| {
-                    if let ServiceId::Syncer(..) = service {
-                        if !runtime.syncer_has_client(service) {
-                            info!("Terminating {}", service);
-                            event
-                                .send_ctl_service(service.clone(), CtlMsg::Terminate)
-                                .is_err()
-                        } else {
-                            true
-                        }
-                    } else {
-                        true
-                    }
-                })
-                .collect();
+            runtime.clean_up_after_syncer_usage(event.endpoints)?;
             Ok(None)
         }
         (req, source) => {

--- a/src/farcasterd/syncer_state_machine.rs
+++ b/src/farcasterd/syncer_state_machine.rs
@@ -389,8 +389,8 @@ fn attempt_transition_to_end(
                 CtlMsg::Failure(Failure {
                     code: FailureCode::Unknown,
                     info: format!(
-                        "Failure in chain query: {}",
-                        error.unwrap_or("".to_string())
+                        "Failure in chain query{}",
+                        error.map_or("".to_string(), |e| format!(": {}", e))
                     ),
                 }),
             )?;

--- a/src/farcasterd/syncer_state_machine.rs
+++ b/src/farcasterd/syncer_state_machine.rs
@@ -16,7 +16,7 @@ use crate::{
     event::{Event, StateMachine, StateMachineExecutor},
     syncerd::{
         Event as SyncerEvent, GetAddressBalance, Health, HealthCheck, SweepAddress,
-        SweepAddressAddendum, Task, TaskId,
+        SweepAddressAddendum, Task, TaskAborted, TaskId,
     },
     ServiceId,
 };
@@ -393,6 +393,44 @@ fn attempt_transition_to_end(
                     }),
                 )?;
             }
+            runtime.registered_services = runtime
+                .registered_services
+                .clone()
+                .drain()
+                .filter(|service| {
+                    if let ServiceId::Syncer(..) = service {
+                        if !runtime.syncer_has_client(service) {
+                            info!("Terminating {}", service);
+                            event
+                                .send_ctl_service(service.clone(), CtlMsg::Terminate)
+                                .is_err()
+                        } else {
+                            true
+                        }
+                    } else {
+                        true
+                    }
+                })
+                .collect();
+            Ok(None)
+        }
+
+        (
+            BusMsg::Sync(SyncMsg::Event(SyncerEvent::TaskAborted(TaskAborted {
+                id, error, ..
+            }))),
+            syncer_id,
+        ) if syncer == syncer_id && id.len() == 1 && id[0] == syncer_task_id => {
+            event.send_client_ctl(
+                source,
+                CtlMsg::Failure(Failure {
+                    code: FailureCode::Unknown,
+                    info: format!(
+                        "Failure in chain query: {}",
+                        error.unwrap_or("".to_string())
+                    ),
+                }),
+            )?;
             runtime.registered_services = runtime
                 .registered_services
                 .clone()


### PR DESCRIPTION
If a call to the syncer from Farcasterd fails, task aborted may be emitted. Handle this case gracefully.