### PR TITLE
Database: Improve error handling

### DIFF
--- a/src/databased/runtime.rs
+++ b/src/databased/runtime.rs
@@ -223,22 +223,28 @@ impl Runtime {
                 )?;
             }
 
-            InfoMsg::RetrieveAllCheckpointInfo => match self.database.get_all_checkpoint_info() {
-                Ok(list) => {
-                    self.send_client_info(endpoints, source, InfoMsg::CheckpointList(list.into()))?;
-                }
-                Err(err) => {
-                    error!("Failed to retrieve checkpoint info list: {}", err);
-                    self.send_client_ctl(
-                        endpoints,
-                        source,
-                        CtlMsg::Failure(Failure {
-                            code: FailureCode::Unknown,
-                            info: "Failed to retrieve checkpoint list".to_string(),
-                        }),
-                    )?;
-                }
-            },
+            InfoMsg::RetrieveAllCheckpointInfo => {
+                match self.database.get_all_checkpoint_info() {
+                    Ok(list) => {
+                        self.send_client_info(
+                            endpoints,
+                            source,
+                            InfoMsg::CheckpointList(list.into()),
+                        )?;
+                    }
+                    Err(err) => {
+                        error!("Failed to retrieve checkpoint info list: {}", err);
+                        self.send_client_ctl(
+                            endpoints,
+                            source,
+                            CtlMsg::Failure(Failure {
+                                code: FailureCode::Unknown,
+                                info: "Failed to retrieve checkpoint list".to_string(),
+                            }),
+                        )?;
+                    }
+                };
+            }
 
             InfoMsg::GetCheckpointEntry(swap_id) => {
                 match self.database.get_checkpoint_info(&swap_id) {

--- a/src/databased/runtime.rs
+++ b/src/databased/runtime.rs
@@ -528,7 +528,7 @@ impl Database {
         address: &monero::Address,
         secret_key_info: &MoneroSecretKeyInfo,
     ) -> Result<(), Error> {
-        let db = self.0.open_db(Some(LMDB_BITCOIN_ADDRESSES))?;
+        let db = self.0.open_db(Some(LMDB_MONERO_ADDRESSES))?;
         let mut tx = self.0.begin_rw_txn()?;
         let key = address.as_bytes();
         let mut val = vec![];
@@ -549,7 +549,7 @@ impl Database {
         &mut self,
         address: &monero::Address,
     ) -> Result<MoneroSecretKeyInfo, Error> {
-        let db = self.0.open_db(Some(LMDB_BITCOIN_ADDRESSES))?;
+        let db = self.0.open_db(Some(LMDB_MONERO_ADDRESSES))?;
         let tx = self.0.begin_ro_txn()?;
         let key = address.as_bytes();
         let val = MoneroSecretKeyInfo::strict_decode(tx.get(db, &key)?)?;
@@ -559,8 +559,8 @@ impl Database {
 
     fn get_all_monero_addresses(
         &mut self,
-    ) -> Result<Vec<(monero::Address, Option<SwapId>)>, lmdb::Error> {
-        let db = self.0.open_db(Some(LMDB_BITCOIN_ADDRESSES))?;
+    ) -> Result<Vec<(monero::Address, Option<SwapId>)>, Error> {
+        let db = self.0.open_db(Some(LMDB_MONERO_ADDRESSES))?;
         let tx = self.0.begin_ro_txn()?;
         let mut cursor = tx.open_ro_cursor(db)?;
         let res = cursor

--- a/src/databased/runtime.rs
+++ b/src/databased/runtime.rs
@@ -226,7 +226,8 @@ impl Runtime {
                 Ok(list) => {
                     self.send_client_info(endpoints, source, InfoMsg::CheckpointList(list.into()))?;
                 }
-                Err(_) => {
+                Err(err) => {
+                    error!("Failed to retrieve checkpoint info list: {}", err);
                     self.send_client_ctl(
                         endpoints,
                         source,
@@ -241,9 +242,10 @@ impl Runtime {
             InfoMsg::GetCheckpointEntry(swap_id) => {
                 match self.database.get_checkpoint_info(&swap_id) {
                     Ok(entry) => {
-                        self.send_client_info(endpoints, source, InfoMsg::CheckpointEntry(entry))?
+                        self.send_client_info(endpoints, source, InfoMsg::CheckpointEntry(entry))?;
                     }
-                    Err(_) => {
+                    Err(err) => {
+                        warn!("Failed to retrieve checkpoint entry: {}", err);
                         self.send_client_ctl(
                             endpoints,
                             source,

--- a/src/databased/runtime.rs
+++ b/src/databased/runtime.rs
@@ -436,7 +436,7 @@ impl Database {
         let db = self.0.open_db(Some(LMDB_OFFER_HISTORY))?;
         let tx = self.0.begin_ro_txn()?;
         let mut cursor = tx.open_ro_cursor(db)?;
-        let res = cursor
+        cursor
             .iter()
             .filter_map(|(key, val)| {
                 let status = OfferStatus::strict_decode(IoCursor::new(val.to_vec()));
@@ -465,8 +465,7 @@ impl Database {
                         .map_err(|err| Error::from(err)),
                 )
             })
-            .collect();
-        res
+            .collect()
     }
 
     fn set_bitcoin_address(
@@ -516,8 +515,7 @@ impl Database {
             .map(|(key, val)| {
                 Ok((
                     bitcoin::Address::strict_decode(IoCursor::new(key.to_vec()))?,
-                    BitcoinSecretKeyInfo::strict_decode(IoCursor::new(val.to_vec()))?
-                        .swap_id,
+                    BitcoinSecretKeyInfo::strict_decode(IoCursor::new(val.to_vec()))?.swap_id,
                 ))
             })
             .collect();


### PR DESCRIPTION
Instead of swallowing some of the strict encode errors, transparently handle them at the database call site. 

Also fixes a bug, where the Monero addresses were written to the bitcoin address db.