### PR TITLE
remove swapd.runtime.syncer_state.{bitcoin,monero}_amount

### DIFF
--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -60,8 +60,6 @@ pub fn run(config: ServiceConfig, opts: Opts) -> Result<(), Error> {
         punish_timelock,
         maker_role, // SwapRole of maker (Alice or Bob)
         network,
-        accordant_amount: monero_amount,
-        arbitrating_amount: bitcoin_amount,
         ..
     } = public_offer.offer;
 
@@ -116,8 +114,6 @@ pub fn run(config: ServiceConfig, opts: Opts) -> Result<(), Error> {
         network,
         bitcoin_syncer: ServiceId::Syncer(Blockchain::Bitcoin, network),
         monero_syncer: ServiceId::Syncer(Blockchain::Monero, network),
-        monero_amount,
-        bitcoin_amount,
         awaiting_funding: false,
         xmr_addr_addendum: None,
         btc_fee_estimate_sat_per_kvb: None,
@@ -785,7 +781,7 @@ impl Runtime {
         let nr_inputs = 1;
         let total_fees =
             bitcoin::Amount::from_sat(p2wpkh_signed_tx_fee(sat_per_kvb, vsize, nr_inputs));
-        let amount = self.syncer_state.bitcoin_amount + total_fees;
+        let amount = self.public_offer.offer.arbitrating_amount + total_fees;
         self.log_info(format!(
             "Send {} to {}, this includes {} for the Lock transaction network fees",
             amount.bright_green_bold(),

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -1123,10 +1123,10 @@ fn try_bob_refund_procedure_signatures_to_bob_accordant_lock(
             && runtime.syncer_state.tasks.watched_addrs.get(&id) == Some(&TxLabel::AccLock) =>
         {
             let amount = monero::Amount::from_pico(amount.clone());
-            if amount < runtime.syncer_state.monero_amount {
+            if amount < runtime.public_offer.offer.accordant_amount {
                 runtime.log_warn(format!(
                     "Not enough monero locked: expected {}, found {}",
-                    runtime.syncer_state.monero_amount, amount
+                    runtime.public_offer.offer.accordant_amount, amount
                 ));
                 return Ok(None);
             }
@@ -1541,7 +1541,7 @@ fn try_alice_core_arbitrating_setup_to_alice_arbitrating_lock_final(
                 let address =
                     monero::Address::from_viewpair(runtime.syncer_state.network.into(), &viewpair);
                 let swap_id = runtime.swap_id();
-                let amount = runtime.syncer_state.monero_amount;
+                let amount = runtime.public_offer.offer.accordant_amount;
                 let funding_info = MoneroFundingInfo {
                     swap_id,
                     address,

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -58,8 +58,6 @@ pub struct SyncerState {
     pub network: farcaster_core::blockchain::Network,
     pub bitcoin_syncer: ServiceId,
     pub monero_syncer: ServiceId,
-    pub monero_amount: monero::Amount,
-    pub bitcoin_amount: bitcoin::Amount,
     pub xmr_addr_addendum: Option<XmrAddressAddendum>,
     pub confirmations: HashMap<TxLabel, Option<u32>>,
     pub awaiting_funding: bool,


### PR DESCRIPTION
There's no reason to keep this within the syncer state since it's only
read from within the swap state machine. Instead, read it from `swapd.runtime.public_offer.offer.{arbitrating,according}_amount_`. Closes #837 and closes the more loosely phrased #271.