### PR TITLE
Swapd: state refactors

### DIFF
--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -2066,8 +2066,14 @@ fn try_alice_punish_to_swap_end(
 ) -> Result<Option<SwapStateMachine>, Error> {
     match event.request {
         BusMsg::Sync(SyncMsg::Event(SyncEvent::TransactionConfirmations(
-            TransactionConfirmations { id, .. },
-        ))) if runtime.syncer_state.tasks.watched_txs.get(&id) == Some(&TxLabel::Punish) => {
+            TransactionConfirmations {
+                id,
+                confirmations: Some(confirmations),
+                ..
+            },
+        ))) if runtime.syncer_state.tasks.watched_txs.get(&id) == Some(&TxLabel::Punish)
+            && confirmations >= runtime.temporal_safety.btc_finality_thr =>
+        {
             let abort_all = Task::Abort(Abort {
                 task_target: TaskTarget::AllTasks,
                 respond: Boolean::False,

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -541,10 +541,7 @@ impl StateMachine<Runtime, Error> for SwapStateMachine {
             }
             SwapStateMachine::AlicePunish => try_alice_punish_to_swap_end(event, runtime),
 
-            SwapStateMachine::SwapEnd(_) => {
-                runtime.log_warn("Received event after swap end");
-                Ok(Some(self))
-            }
+            SwapStateMachine::SwapEnd(_) => Ok(None),
         }
     }
 

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -541,7 +541,10 @@ impl StateMachine<Runtime, Error> for SwapStateMachine {
             }
             SwapStateMachine::AlicePunish => try_alice_punish_to_swap_end(event, runtime),
 
-            _ => Ok(Some(self)),
+            SwapStateMachine::SwapEnd(_) => {
+                runtime.log_warn("Received event after swap end");
+                Ok(Some(self))
+            }
         }
     }
 

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -735,7 +735,7 @@ fn attempt_transition_to_init_maker(
                 }
                 _ => {
                     runtime.log_error(format!(
-                        "Invalid swap role {} for wallet {:?}",
+                        "Invalid swap role {} for wallet {}",
                         swap_role, wallet
                     ));
                     Ok(None)

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -720,7 +720,9 @@ fn attempt_transition_to_init_maker(
                     Ok(Some(SwapStateMachine::BobInitMaker(BobInitMaker {
                         local_commit,
                         local_params,
-                        funding_address: funding_tx.get_address().ok().unwrap(),
+                        funding_address: funding_tx
+                            .get_address()
+                            .expect("Funding address should be valid"),
                         remote_commit: commit,
                         wallet,
                         reveal: None,

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -114,6 +114,13 @@ impl SyncerState {
     }
 
     pub fn watch_tx_btc(&mut self, txid: Txid, tx_label: TxLabel) -> Task {
+        if self.is_watched_tx(&tx_label) {
+            warn!(
+                "{} | Already watching for tx with label {} - notifications will be repeated",
+                self.swap_id.swap_id(),
+                tx_label.label()
+            );
+        }
         let id = self.tasks.new_taskid();
         self.tasks.watched_txs.insert(id, tx_label);
         self.tasks.txids.insert(tx_label, txid);
@@ -136,6 +143,13 @@ impl SyncerState {
         self.tasks.watched_txs.values().any(|tx| tx == tx_label)
     }
     pub fn watch_tx_xmr(&mut self, hash: Vec<u8>, tx_label: TxLabel) -> Task {
+        if self.is_watched_tx(&tx_label) {
+            warn!(
+                "{} | Already watching for tx with label {} - notifications will be repeated",
+                self.swap_id.swap_id(),
+                tx_label.label()
+            );
+        }
         let id = self.tasks.new_taskid();
         self.tasks.watched_txs.insert(id, tx_label);
         info!(

--- a/src/swapd/wallet.rs
+++ b/src/swapd/wallet.rs
@@ -71,9 +71,9 @@ pub struct HandleBuyProcedureSignatureRes {
 
 #[derive(Clone, Display, Debug, StrictEncode, StrictDecode)]
 pub enum Wallet {
-    #[display("Wallet::Alice")]
+    #[display("Alice's wallet")]
     Alice(AliceState),
-    #[display("Wallet::Bob")]
+    #[display("Bob's wallet")]
     Bob(BobState),
 }
 
@@ -754,7 +754,7 @@ impl Wallet {
                     }
                 } else {
                     error!(
-                        "{} | Not correct wallet, should be Wallet::Bob: {}",
+                        "{} | Not correct wallet, should be Bob's wallet: {}",
                         swap_id.swap_id(),
                         self
                     );

--- a/src/swapd/wallet.rs
+++ b/src/swapd/wallet.rs
@@ -69,9 +69,11 @@ pub struct HandleBuyProcedureSignatureRes {
     pub buy_tx: bitcoin::Transaction,
 }
 
-#[derive(Clone, Debug, StrictEncode, StrictDecode)]
+#[derive(Clone, Display, Debug, StrictEncode, StrictDecode)]
 pub enum Wallet {
+    #[display("Wallet::Alice")]
     Alice(AliceState),
+    #[display("Wallet::Bob")]
     Bob(BobState),
 }
 
@@ -752,7 +754,7 @@ impl Wallet {
                     }
                 } else {
                     error!(
-                        "{} | Not correct wallet, should be Bob: {:?}",
+                        "{} | Not correct wallet, should be Wallet::Bob: {}",
                         swap_id.swap_id(),
                         self
                     );

--- a/src/swapd/wallet.rs
+++ b/src/swapd/wallet.rs
@@ -752,8 +752,9 @@ impl Wallet {
                     }
                 } else {
                     error!(
-                        "{} | Wallet not found or not on correct state",
+                        "{} | Not correct wallet, should be Bob: {:?}",
                         swap_id.swap_id(),
+                        self
                     );
                     return Err(Error::Farcaster(
                         "Needs to be a Bob wallet to process Alice Commit".to_string(),


### PR DESCRIPTION
A bunch of small independent refactors segregated by commits not tracked by open issues. 
The commit 09387540ecce3f9314396ddd29582781a28925b4 (*couple swap role and wallet role when initiating maker*) I'm unsure about, but would like to discuss stronger coupling of swap roles and wallet roles in handling.