### PR TITLE
Swap state: Don't emit Bob aborted swap message twice

### DIFF
--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -1422,7 +1422,8 @@ fn try_awaiting_sweep_to_swap_end(
                 ServiceId::Farcasterd,
                 CtlMsg::FundingCanceled(Blockchain::Bitcoin),
             )?;
-            handle_abort_swap(event, runtime)
+            runtime.log_info("Aborted swap.");
+            Ok(Some(SwapStateMachine::SwapEnd(Outcome::FailureAbort)))
         }
 
         BusMsg::Sync(SyncMsg::Event(SyncEvent::SweepSuccess(SweepSuccess { id, .. })))
@@ -1432,7 +1433,8 @@ fn try_awaiting_sweep_to_swap_end(
                 ServiceId::Farcasterd,
                 CtlMsg::FundingCanceled(Blockchain::Bitcoin),
             )?;
-            handle_abort_swap(event, runtime)
+            runtime.log_info("Aborted swap.");
+            Ok(Some(SwapStateMachine::SwapEnd(Outcome::FailureAbort)))
         }
         _ => Ok(None),
     }


### PR DESCRIPTION
The message is already emitted when the AbortSwap is coming in.