### PR TITLE
Syncer: Support Incoming and Outgoing AddressTransaction events

### DIFF
--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -1124,9 +1124,11 @@ fn try_bob_refund_procedure_signatures_to_bob_accordant_lock(
             amount,
             block: _,
             tx: _,
+            incoming,
         }))) if runtime.syncer_state.tasks.watched_addrs.contains_key(&id)
             && runtime.syncer_state.is_watched_addr(&TxLabel::AccLock)
-            && runtime.syncer_state.tasks.watched_addrs.get(&id) == Some(&TxLabel::AccLock) =>
+            && runtime.syncer_state.tasks.watched_addrs.get(&id) == Some(&TxLabel::AccLock)
+            && *incoming =>
         {
             let amount = monero::Amount::from_pico(amount.clone());
             if amount < runtime.deal.parameters.accordant_amount {
@@ -1649,7 +1651,10 @@ fn try_alice_arbitrating_lock_final_to_alice_accordant_lock(
             amount,
             ref block,
             ref tx,
-        }))) if runtime.syncer_state.tasks.watched_addrs.get(&id) == Some(&TxLabel::AccLock) => {
+            incoming,
+        }))) if runtime.syncer_state.tasks.watched_addrs.get(&id) == Some(&TxLabel::AccLock)
+            && incoming =>
+        {
             runtime.log_debug(format!(
                 "Event details: {} {:?} {} {:?} {:?}",
                 id, hash, amount, block, tx

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -10,8 +10,8 @@ use crate::{
     syncerd::{
         Abort, AddressAddendum, Boolean, BroadcastTransaction, BtcAddressAddendum, GetTx,
         SweepAddress, SweepAddressAddendum, SweepBitcoinAddress, SweepMoneroAddress, TaskTarget,
-        TransactionBroadcasted, WatchAddress, WatchEstimateFee, WatchHeight, WatchTransaction,
-        XmrAddressAddendum,
+        TransactionBroadcasted, TxFilter, WatchAddress, WatchEstimateFee, WatchHeight,
+        WatchTransaction, XmrAddressAddendum,
     },
     Error,
 };
@@ -201,11 +201,18 @@ impl SyncerState {
             from_height,
             address,
         };
+        let filter = if TxLabel::Cancel == tx_label {
+            // If this is the cancel transaction, only look for outgoing transactions
+            TxFilter::Outgoing
+        } else {
+            TxFilter::Incoming
+        };
         let task = Task::WatchAddress(WatchAddress {
             id,
             lifetime: self.task_lifetime(Blockchain::Bitcoin),
             addendum: AddressAddendum::Bitcoin(addendum),
             include_tx: Boolean::True,
+            filter,
         });
         self.tasks.tasks.insert(id, task.clone());
         task
@@ -273,6 +280,7 @@ impl SyncerState {
             lifetime: self.task_lifetime(Blockchain::Monero),
             addendum: AddressAddendum::Monero(addendum),
             include_tx: Boolean::False,
+            filter: TxFilter::Incoming,
         };
         let task = Task::WatchAddress(watch_addr);
         self.tasks.tasks.insert(id, task.clone());

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -241,6 +241,24 @@ impl MoneroRpc {
             wallet.refresh(None).await?;
         }
 
+        // transaction filtering in monero-rpc is not documented well,
+        // and the implementation within monero::wallet2 is a mess,
+        // so here's an overview of how transactions are filtered:
+        // - GetTransfersCategory::In:
+        //  incoming transfers to the address
+        //   wallet2::get_payments->payments
+        // - GetTransfersCategory::Out:
+        //  outgoing transfers from the address
+        //  wallet2::get_payments_out->confirmed_txs
+        // - GetTransfersCategory::{Pending|Failed}:
+        //  outgoing transfers from the address that are not confirmed yet or have failed
+        //  wallet2::get_unconfirmed_payments_out->unconfirmed_txs
+        //  GetTransfersCategory::Pool:
+        //  incoming transfers that are not confirmed yet (i.e. just on mempool)
+        //  wallet2::get_unconfirmed_payments->unconfirmed_payments
+        //  GetTransfersCategory::Block:
+        //  incoming transfers that are coinbase transactions
+        //  seems deprecated: not used in wallet2, so removed here too
         let mut category_selector: HashMap<GetTransfersCategory, bool> = HashMap::new();
         match filter {
             TxFilter::All => {
@@ -248,12 +266,10 @@ impl MoneroRpc {
                 category_selector.insert(GetTransfersCategory::Out, true);
                 category_selector.insert(GetTransfersCategory::Pending, true);
                 category_selector.insert(GetTransfersCategory::Pool, true);
-                category_selector.insert(GetTransfersCategory::Block, true);
             }
             TxFilter::Incoming => {
                 category_selector.insert(GetTransfersCategory::In, true);
                 category_selector.insert(GetTransfersCategory::Pool, true);
-                category_selector.insert(GetTransfersCategory::Block, true);
             }
             TxFilter::Outgoing => {
                 category_selector.insert(GetTransfersCategory::Out, true);
@@ -278,9 +294,7 @@ impl MoneroRpc {
         let mut address_txs: Vec<AddressTx> = vec![];
         for (category, mut txs) in transfers.drain() {
             let incoming = match category {
-                GetTransfersCategory::In
-                | GetTransfersCategory::Block
-                | GetTransfersCategory::Pool => true,
+                GetTransfersCategory::In | GetTransfersCategory::Pool => true,
                 GetTransfersCategory::Out | GetTransfersCategory::Pending => false,
                 _ => continue,
             };

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -71,9 +71,10 @@ pub struct AddressTransactions {
 
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
 pub struct AddressTx {
-    pub our_amount: u64,
+    pub amount: u64,
     pub tx_id: Vec<u8>,
     pub tx: Vec<u8>,
+    pub incoming: bool,
 }
 
 pub fn create_set<T: std::hash::Hash + Eq>(xs: Vec<T>) -> HashSet<T> {
@@ -493,7 +494,7 @@ impl SyncerState {
                         let address_transaction = AddressTransaction {
                             id: addr.task.id,
                             hash: new_tx.tx_id.clone(),
-                            amount: new_tx.our_amount,
+                            amount: new_tx.amount,
                             block: vec![], // eventually this should be removed from the event
                             tx: new_tx
                                 .tx
@@ -501,6 +502,7 @@ impl SyncerState {
                                 .chunks(STRICT_ENCODE_MAX_ITEMS.into())
                                 .map(|c| c.to_vec())
                                 .collect(), // chunk as a workaround for the strict encoding length limit
+                            incoming: new_tx.incoming,
                         };
                         events.push((
                             Event::AddressTransaction(address_transaction),
@@ -943,12 +945,14 @@ async fn syncer_state_addresses() {
         lifetime: 1,
         addendum: addendum.clone(),
         include_tx: Boolean::False,
+        filter: TxFilter::All,
     };
     let address_task_two = WatchAddress {
         id: TaskId(0),
         lifetime: 1,
         addendum: addendum.clone(),
         include_tx: Boolean::False,
+        filter: TxFilter::All,
     };
     let source1 = ServiceId::Syncer(Blockchain::Bitcoin, Network::Mainnet);
 
@@ -976,24 +980,28 @@ async fn syncer_state_addresses() {
     assert_eq!(state.tasks_sources.len(), 1);
     assert_eq!(state.addresses.len(), 1);
     let address_tx_one = AddressTx {
-        our_amount: 1,
+        amount: 1,
         tx_id: vec![0; 32],
         tx: vec![0],
+        incoming: true,
     };
     let address_tx_two = AddressTx {
-        our_amount: 1,
+        amount: 1,
         tx_id: vec![1; 32],
         tx: vec![0],
+        incoming: true,
     };
     let address_tx_three = AddressTx {
-        our_amount: 1,
+        amount: 1,
         tx_id: vec![2; 32],
         tx: vec![0],
+        incoming: true,
     };
     let address_tx_four = AddressTx {
-        our_amount: 1,
+        amount: 1,
         tx_id: vec![3; 32],
         tx: vec![0],
+        incoming: true,
     };
 
     state

--- a/src/syncerd/types.rs
+++ b/src/syncerd/types.rs
@@ -172,6 +172,20 @@ pub struct WatchAddress {
     pub lifetime: u64,
     pub addendum: AddressAddendum,
     pub include_tx: Boolean,
+    pub filter: TxFilter,
+}
+
+#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
+#[display(Debug)]
+pub enum TxFilter {
+    Incoming,
+    Outgoing,
+    All,
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
@@ -315,11 +329,12 @@ pub struct HeightChanged {
 pub struct AddressTransaction {
     pub id: TaskId,
     pub hash: Vec<u8>,
-    pub amount: u64,
+    pub amount: u64, // Only calculated for incoming transactions
     pub block: Vec<u8>,
     // for bitcoin with bitcoin::consensus encoding, chunked into chunks with
     // length < 2^16 as a workaround for the strict encoding length limit
     pub tx: Vec<Vec<u8>>,
+    pub incoming: bool,
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -12,7 +12,7 @@ use farcaster_node::syncerd::types::{
     SweepAddressAddendum, Task, WatchAddress, WatchEstimateFee, WatchHeight, WatchTransaction,
 };
 use farcaster_node::syncerd::{runtime::Synclet, TaskId, TaskTarget};
-use farcaster_node::syncerd::{GetAddressBalance, SweepBitcoinAddress};
+use farcaster_node::syncerd::{GetAddressBalance, SweepBitcoinAddress, TxFilter};
 use farcaster_node::ServiceId;
 use microservices::ZMQ_CONTEXT;
 use ntest::timeout;
@@ -249,6 +249,7 @@ fn bitcoin_syncer_address_test() {
             lifetime: blocks + 1,
             addendum: addendum_1,
             include_tx: Boolean::True,
+            filter: TxFilter::All,
         }),
         source: SOURCE1.clone(),
     };
@@ -264,6 +265,7 @@ fn bitcoin_syncer_address_test() {
             lifetime: blocks + 2,
             addendum: addendum_2.clone(),
             include_tx: Boolean::True,
+            filter: TxFilter::All,
         }),
         source: SOURCE1.clone(),
     };
@@ -333,6 +335,7 @@ fn bitcoin_syncer_address_test() {
             lifetime: blocks + 2,
             addendum: addendum_2,
             include_tx: Boolean::True,
+            filter: TxFilter::All,
         }),
         source: SOURCE1.clone(),
     };
@@ -368,6 +371,7 @@ fn bitcoin_syncer_address_test() {
                 lifetime: blocks + 5,
                 addendum: addendum_4.clone(),
                 include_tx: Boolean::True,
+                filter: TxFilter::All,
             }),
             source: SOURCE1.clone(),
         })
@@ -411,6 +415,7 @@ fn bitcoin_syncer_address_test() {
             lifetime: blocks + 5,
             addendum: addendum_5,
             include_tx: Boolean::False,
+            filter: TxFilter::All,
         }),
         source: SOURCE1.clone(),
     })

--- a/tests/monero.rs
+++ b/tests/monero.rs
@@ -8,11 +8,11 @@ use farcaster_node::syncerd::types::{
     Abort, AddressAddendum, Boolean, BroadcastTransaction, Task, WatchAddress, WatchHeight,
     WatchTransaction,
 };
-use farcaster_node::syncerd::GetAddressBalance;
 use farcaster_node::syncerd::{
     runtime::Synclet, SweepAddress, SweepAddressAddendum, SweepMoneroAddress, TaskId, TaskTarget,
     XmrAddressAddendum,
 };
+use farcaster_node::syncerd::{GetAddressBalance, TxFilter};
 use farcaster_node::ServiceId;
 use microservices::ZMQ_CONTEXT;
 use monero_rpc::GetBlockHeaderSelector;
@@ -334,6 +334,7 @@ async fn monero_syncer_address_test() {
                 lifetime: blocks + 1,
                 addendum: addendum_1.clone(),
                 include_tx: Boolean::True,
+                filter: TxFilter::Incoming,
             }),
             source: SOURCE1.clone(),
         };
@@ -376,6 +377,7 @@ async fn monero_syncer_address_test() {
                 lifetime: blocks + 1,
                 addendum: addendum_2,
                 include_tx: Boolean::True,
+                filter: TxFilter::Incoming,
             }),
             source: SOURCE1.clone(),
         };
@@ -404,6 +406,7 @@ async fn monero_syncer_address_test() {
                 lifetime: blocks + 1,
                 addendum: addendum_3,
                 include_tx: Boolean::True,
+                filter: TxFilter::Incoming,
             }),
             source: SOURCE1.clone(),
         };
@@ -445,6 +448,7 @@ async fn monero_syncer_address_test() {
                     lifetime: blocks + 5,
                     addendum: addendum_4.clone(),
                     include_tx: Boolean::True,
+                    filter: TxFilter::Incoming,
                 }),
                 source: SOURCE2.clone(),
             })
@@ -484,6 +488,7 @@ async fn monero_syncer_address_test() {
                 lifetime: blocks + 5,
                 addendum: addendum_5.clone(),
                 include_tx: Boolean::True,
+                filter: TxFilter::Incoming,
             }),
             source: SOURCE2.clone(),
         })
@@ -525,6 +530,7 @@ async fn monero_syncer_address_test() {
                 lifetime: blocks + 2,
                 addendum: addendum_6.clone(),
                 include_tx: Boolean::True,
+                filter: TxFilter::Incoming,
             }),
             source: SOURCE1.clone(),
         };
@@ -549,6 +555,7 @@ async fn monero_syncer_address_test() {
                 lifetime: blocks + 2,
                 addendum: addendum_6,
                 include_tx: Boolean::True,
+                filter: TxFilter::Incoming,
             }),
             source: SOURCE1.clone(),
         };


### PR DESCRIPTION
Adds a filter to the WatchAddress Task in order for the user to select incoming or outgoing transactions. The returned AddressTransaction's amount is either the sum total incoming amount if the incoming bool is true, or the sum total outgoing amount if the incoming bool is false.