### PR TITLE
Feat: log errors outside of farcaster too

### DIFF
--- a/src/opts.rs
+++ b/src/opts.rs
@@ -141,7 +141,7 @@ impl FromStr for TokenString {
 
 impl Opts {
     pub fn process(&mut self) {
-        let env = env_logger::Env::new().default_filter_or("farcaster_node=info");
+        let env = env_logger::Env::new().default_filter_or("error,farcaster_node=info");
         // standard environment variable set to "true" when running in CI environments
         let is_test = matches!(std::env::var("CI"), Ok(v) if v == "true");
         env_logger::from_env(env)


### PR DESCRIPTION
With our current default filter with exclude everything outside of `farcaster_node`, with this patch errors from e.g. microservices are displayed by default.