### PR TITLE
Errors: Wrap error types in Error enum instead of converting to Farcaster::Error

### DIFF
--- a/src/bus/info.rs
+++ b/src/bus/info.rs
@@ -380,11 +380,11 @@ impl FromStr for Address {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         bitcoin::Address::from_str(s)
             .map(Address::Bitcoin)
-            .map_err(|e| Error::Farcaster(e.to_string()))
+            .map_err(Error::from)
             .or_else(|_| {
                 monero::Address::from_str(s)
                     .map(Address::Monero)
-                    .map_err(|e| Error::Farcaster(e.to_string()))
+                    .map_err(Error::from)
             })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,7 +127,7 @@ impl Config {
         } else {
             format!("{}:{}", FARCASTER_BIND_IP, FARCASTER_BIND_PORT)
         };
-        InetSocketAddr::from_str(&addr).map_err(|e| Error::Farcaster(e.to_string()))
+        Ok(InetSocketAddr::from_str(&addr)?)
     }
 
     /// Returns a syncer configuration, if found in config, for the specified network

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,20 +19,21 @@ use crate::service::ServiceId;
 #[display(doc_comments)]
 #[non_exhaustive]
 pub enum Error {
-    /// Farcaster core errors: {0}
-    FarcasterCore(farcaster_core::Error),
+    /// Farcaster core errors, related to low level cryptography or protocol
+    #[display(inner)]
+    Core(farcaster_core::Error),
 
-    /// Farcaster node errors: {0}
+    /// Generic Farcaster node errors
+    #[display(inner)]
     Farcaster(String),
 
-    /// Wallet node errors: {0}
-    Wallet(String),
-
-    /// Config errors: {0}
-    #[from(config::ConfigError)]
+    /// Node configuration errors, when parsing and manipulating `farcasterd.toml` conf
+    #[display("Configuration error: {0}")]
+    #[from]
     Config(config::ConfigError),
 
-    /// I/O error: {0:?}
+    /// Generic I/O errors
+    #[display(inner)]
     #[from(io::Error)]
     Io(IoError),
 
@@ -53,15 +54,16 @@ pub enum Error {
 
     /// Provided RPC request is not supported for the used type of endpoint
     #[cfg(feature = "_rpc")]
+    #[display("RPC request error, not supported on {0}: {1}")]
     NotSupported(ServiceBus, String),
 
     /// Peer does not respond to ping messages
     NotResponding,
 
-    /// Peer has misbehaved LN peer protocol rules
+    /// Peer has misbehaved peer protocol rules
     Misbehaving,
 
-    /// unrecoverable error "{0}"
+    /// Unrecoverable error: {0}
     Terminate(String),
 
     /// Other error type with string explanation
@@ -72,100 +74,101 @@ pub enum Error {
     /// Invalid walletd token error
     InvalidToken,
 
-    /// Syncer
+    /// Syncer microservice errors
     #[display(inner)]
     #[from]
     Syncer(SyncerError),
 
-    /// BitcoinHashes
+    /// Bitcoin hashes manipulation errors
     #[display(inner)]
     #[from]
     BitcoinHashes(bitcoin::hashes::Error),
 
-    /// LMDB
+    /// Checkpoint database errors
     #[display(inner)]
     #[from]
     Checkpoint(lmdb::Error),
 
-    /// BitcoinKey
+    /// Bitcoin key errors
     #[display(inner)]
     #[from]
     BitcoinKey(bitcoin::util::key::Error),
 
-    /// BitcoinSecp256k1
+    /// Bitcoin secp256k1 curve errors
     #[display(inner)]
     #[from]
     BitcoinSecp256k1(bitcoin::secp256k1::Error),
 
+    /// Bitcoin address errors
     #[display(inner)]
     #[from]
     BitcoinAddress(bitcoin::util::address::Error),
 
+    /// Bitcoin consensus errors
     #[display(inner)]
     #[from]
     BitcoinConsensus(bitcoin::consensus::encode::Error),
 
+    /// Bitcoin amount errors
     #[display(inner)]
     #[from]
     BitcoinAmount(bitcoin::util::amount::ParseAmountError),
 
+    /// Monero address errors
     #[display(inner)]
     #[from]
     MoneroAddress(monero::util::address::Error),
 
+    /// Monero amount errors
     #[display(inner)]
     #[from]
     MoneroAmount(monero::util::amount::ParsingError),
 
-    #[display(inner)]
-    #[from]
-    RustHex(rustc_hex::FromHexError),
-
-    /// StrictEncoding
+    /// Strict encoding and decoding errors
     #[display(inner)]
     #[from]
     StrictEncoding(strict_encoding::Error),
 
-    /// Uuid
+    /// Deals and swaps identifiers errors
     #[display(inner)]
     #[from]
     Uuid(uuid::Error),
 
-    /// Inet2AddrParseError
+    /// Internet2 address parsing errors
     #[display(inner)]
     #[from]
     Inet2AddrParseError(internet2::addr::AddrParseError),
 
-    /// TonicTransportError
+    /// Tonic gRPC deamon transport errors
     #[display(inner)]
     #[from]
     TonicTransportError(tonic::transport::Error),
 }
 
-#[derive(Debug, Display)]
+#[derive(Debug, Display, From, Error)]
+#[display(doc_comments)]
+#[non_exhaustive]
 pub enum SyncerError {
+    /// Generic Electrum client errors
+    #[from]
     #[display(inner)]
     Electrum(electrum_client::Error),
 
-    #[display(inner)]
-    NoTxsOnAddress,
-
-    #[display(inner)]
-    ScriptAlreadyRegistered,
-
-    #[display("syncer creating error")]
-    UnknownNetwork,
-
+    /// Generic Monero RPC errors
+    #[from]
     #[display(inner)]
     MoneroRpc(anyhow::Error),
 
-    #[display("Invalid configuration. Missing or malformed")]
+    /// Invalid configuration, missing or malformed
     InvalidConfig,
-    #[display("height did not increment")]
+
+    /// Height did not increment
     NoIncrementToHeight,
-    #[display("could not construct psbt")]
+
+    /// Invalid PSBT, could not construct
     InvalidPsbt,
-    #[display("Transaction should be found in the history if we successfully queried `transaction_get` for it")]
+
+    /// Transaction should be found in the history if we successfully queried `transaction_get`
     TxNotInHistory,
 }
 
@@ -203,24 +206,24 @@ impl From<electrum_client::Error> for Error {
 
 impl From<farcaster_core::Error> for Error {
     fn from(err: farcaster_core::Error) -> Self {
-        Error::FarcasterCore(err)
+        Error::Core(err)
     }
 }
 
 impl From<farcaster_core::transaction::Error> for Error {
     fn from(err: farcaster_core::transaction::Error) -> Self {
-        Error::FarcasterCore(err.into())
+        Error::Core(err.into())
     }
 }
 
 impl From<farcaster_core::crypto::Error> for Error {
     fn from(err: farcaster_core::crypto::Error) -> Self {
-        Error::FarcasterCore(err.into())
+        Error::Core(err.into())
     }
 }
 
 impl From<farcaster_core::consensus::Error> for Error {
     fn from(err: farcaster_core::consensus::Error) -> Self {
-        Error::FarcasterCore(err.into())
+        Error::Core(err.into())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,32 +74,72 @@ pub enum Error {
 
     /// Syncer
     #[display(inner)]
-    #[from(SyncerError)]
+    #[from]
     Syncer(SyncerError),
 
     /// BitcoinHashes
     #[display(inner)]
+    #[from]
     BitcoinHashes(bitcoin::hashes::Error),
 
-    /// Checkpoint
-    #[from(lmdb::Error)]
+    /// LMDB
+    #[display(inner)]
+    #[from]
     Checkpoint(lmdb::Error),
 
     /// BitcoinKey
     #[display(inner)]
-    #[from(bitcoin::util::key::Error)]
+    #[from]
     BitcoinKey(bitcoin::util::key::Error),
 
     /// BitcoinSecp256k1
+    #[display(inner)]
+    #[from]
     BitcoinSecp256k1(bitcoin::secp256k1::Error),
 
+    #[display(inner)]
+    #[from]
+    BitcoinAddress(bitcoin::util::address::Error),
+
+    #[display(inner)]
+    #[from]
+    BitcoinConsensus(bitcoin::consensus::encode::Error),
+
+    #[display(inner)]
+    #[from]
+    BitcoinAmount(bitcoin::util::amount::ParseAmountError),
+
+    #[display(inner)]
+    #[from]
+    MoneroAddress(monero::util::address::Error),
+
+    #[display(inner)]
+    #[from]
+    MoneroAmount(monero::util::amount::ParsingError),
+
+    #[display(inner)]
+    #[from]
+    RustHex(rustc_hex::FromHexError),
+
     /// StrictEncoding
-    #[from(strict_encoding::Error)]
+    #[display(inner)]
+    #[from]
     StrictEncoding(strict_encoding::Error),
 
     /// Uuid
-    #[from(uuid::Error)]
+    #[display(inner)]
+    #[from]
     Uuid(uuid::Error),
+
+    /// Inet2AddrParseError
+    #[display(inner)]
+    #[from]
+    Inet2AddrParseError(internet2::addr::AddrParseError),
+
+    /// TonicTransportError
+    #[display(inner)]
+    #[from]
+    TonicTransportError(tonic::transport::Error),
 }
 
 #[derive(Debug, Display)]
@@ -153,57 +193,9 @@ impl From<farcaster_core::Error> for Error {
     }
 }
 
-impl From<bitcoin::consensus::encode::Error> for Error {
-    fn from(err: bitcoin::consensus::encode::Error) -> Self {
-        Error::Farcaster(err.to_string())
-    }
-}
-
-impl From<monero::util::address::Error> for Error {
-    fn from(err: monero::util::address::Error) -> Self {
-        Error::Farcaster(err.to_string())
-    }
-}
-
-impl From<bitcoin::util::address::Error> for Error {
-    fn from(err: bitcoin::util::address::Error) -> Self {
-        Error::Farcaster(err.to_string())
-    }
-}
-
-impl From<monero::util::amount::ParsingError> for Error {
-    fn from(err: monero::util::amount::ParsingError) -> Self {
-        Error::Farcaster(err.to_string())
-    }
-}
-
-impl From<bitcoin::util::amount::ParseAmountError> for Error {
-    fn from(err: bitcoin::util::amount::ParseAmountError) -> Self {
-        Error::Farcaster(err.to_string())
-    }
-}
-
 impl From<electrum_client::Error> for Error {
     fn from(err: electrum_client::Error) -> Self {
         Error::Syncer(SyncerError::Electrum(err))
-    }
-}
-
-impl From<rustc_hex::FromHexError> for Error {
-    fn from(err: rustc_hex::FromHexError) -> Self {
-        Error::Farcaster(err.to_string())
-    }
-}
-
-impl From<bitcoin::hashes::Error> for Error {
-    fn from(err: bitcoin::hashes::Error) -> Self {
-        Error::BitcoinHashes(err)
-    }
-}
-
-impl From<bitcoin::secp256k1::Error> for Error {
-    fn from(err: bitcoin::secp256k1::Error) -> Self {
-        Error::BitcoinSecp256k1(err)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -181,21 +181,29 @@ impl From<Error> for esb::Error<ServiceId> {
     }
 }
 
+//
+// Custom Syncer error transformation
+//
+
 impl From<anyhow::Error> for Error {
     fn from(err: anyhow::Error) -> Self {
         Error::Syncer(SyncerError::MoneroRpc(err))
     }
 }
 
-impl From<farcaster_core::Error> for Error {
-    fn from(err: farcaster_core::Error) -> Self {
-        Error::FarcasterCore(err)
-    }
-}
-
 impl From<electrum_client::Error> for Error {
     fn from(err: electrum_client::Error) -> Self {
         Error::Syncer(SyncerError::Electrum(err))
+    }
+}
+
+//
+// Custom Core error transformation
+//
+
+impl From<farcaster_core::Error> for Error {
+    fn from(err: farcaster_core::Error) -> Self {
+        Error::FarcasterCore(err)
     }
 }
 

--- a/src/grpcd/runtime.rs
+++ b/src/grpcd/runtime.rs
@@ -1332,7 +1332,7 @@ fn request_loop(
                     "Error encountered while sending request to GRPC runtime: {}",
                     err
                 );
-                return Err(Error::Farcaster(err.to_string()));
+                return Err(err.into());
             }
         }
         Ok(())
@@ -1391,7 +1391,7 @@ fn server_loop(
             .await
         {
             error!("Error encountered while running grpc server: {}", err);
-            Err(Error::Farcaster(err.to_string()))
+            Err(err.into())
         } else {
             Ok(())
         }

--- a/src/swapd/wallet.rs
+++ b/src/swapd/wallet.rs
@@ -846,7 +846,7 @@ impl Wallet {
                     // CoreArbitratingSetup to proceed
                 } else {
                     error!("{} | only Some(Wallet::Alice)", swap_id.swap_id(),);
-                    Err(Error::Farcaster("Needs to be a n Alice wallet".to_string()))
+                    Err(Error::Farcaster("Needs to be an Alice wallet".to_string()))
                 }
             }
             _ => Err(Error::Farcaster(

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -232,7 +232,7 @@ impl ElectrumRpc {
                     let height = match self
                         .client
                         .script_get_history(&tx.output[0].script_pubkey)
-                        .map_err(|err| SyncerError::Electrum(err))
+                        .map_err(SyncerError::Electrum)
                         .and_then(|mut history| {
                             history
                                 .iter()


### PR DESCRIPTION
Create a bunch of new error types and allign existing errors with common formatting.