### PR TITLE
Swapd: Handle re-orgs and possible mempool drops of broadcasted txs.

### DIFF
--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -116,6 +116,7 @@ pub fn run(config: ServiceConfig, opts: Opts) -> Result<(), Error> {
         awaiting_funding: false,
         xmr_addr_addendum: None,
         confirmations: none!(),
+        broadcasted_txs: none!(),
     };
 
     let state_report = StateReport::new("Start".to_string(), &temporal_safety, &syncer_state);
@@ -178,7 +179,7 @@ pub struct CheckpointSwapd {
     pub temporal_safety: TemporalSafety,
     pub txs: Vec<(TxLabel, bitcoin::Transaction)>,
     pub txids: Vec<(TxLabel, Txid)>,
-    pub pending_broadcasts: Vec<bitcoin::Transaction>,
+    pub pending_broadcasts: Vec<(bitcoin::Transaction, TxLabel)>,
     pub local_trade_role: TradeRole,
     pub connected_counterparty_node_id: Option<NodeId>,
     pub deal: Deal,
@@ -284,7 +285,7 @@ impl Runtime {
             tx_label.label(),
             tx.txid().tx_hash()
         ));
-        let task = self.syncer_state.broadcast(tx);
+        let task = self.syncer_state.broadcast(tx, tx_label);
         Ok(endpoints.send_to(
             ServiceBus::Sync,
             self.identity(),
@@ -393,8 +394,8 @@ impl Runtime {
                     enquirer,
                     temporal_safety,
                     mut txs,
-                    txids,
-                    pending_broadcasts,
+                    mut txids,
+                    mut pending_broadcasts,
                     xmr_addr_addendum,
                     local_trade_role,
                     monero_address_creation_height,
@@ -415,7 +416,7 @@ impl Runtime {
                     .watch_height(endpoints, Blockchain::Monero)?;
 
                 self.log_trace("Watching transactions");
-                for (tx_label, txid) in txids.iter() {
+                for (tx_label, txid) in txids.drain(..) {
                     let task = self
                         .syncer_state
                         .watch_tx_btc(txid.clone(), tx_label.clone());
@@ -428,8 +429,8 @@ impl Runtime {
                 }
 
                 self.log_trace("Broadcasting txs pending broadcast");
-                for tx in pending_broadcasts.iter() {
-                    let task = self.syncer_state.broadcast(tx.clone());
+                for (tx, label) in pending_broadcasts.drain(..) {
+                    let task = self.syncer_state.broadcast(tx.clone(), label);
                     endpoints.send_to(
                         ServiceBus::Sync,
                         self.identity(),
@@ -536,6 +537,7 @@ impl Runtime {
                             confirmations,
                             self.swap_id(),
                             self.temporal_safety.xmr_finality_thr,
+                            endpoints,
                         );
                     }
 
@@ -589,6 +591,7 @@ impl Runtime {
                             &Some(*confirmations),
                             self.swap_id(),
                             self.temporal_safety.btc_finality_thr,
+                            endpoints,
                         );
                         let txlabel = self.syncer_state.tasks.watched_txs.get(id);
                         // saving requests of interest for later replaying latest event
@@ -616,11 +619,12 @@ impl Runtime {
                             confirmations,
                             self.swap_id(),
                             self.temporal_safety.btc_finality_thr,
+                            endpoints,
                         );
                     }
 
                     Event::TransactionBroadcasted(event) => {
-                        self.syncer_state.transaction_broadcasted(event)
+                        self.syncer_state.transaction_broadcasted(event);
                     }
 
                     Event::AddressTransaction(_) => {}

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -1082,7 +1082,9 @@ fn try_bob_funded_to_bob_refund_procedure_signature(
                 });
             runtime.log_debug("Checkpointing bob refund signature swapd state.");
             // manually add lock_tx to pending broadcasts to ensure it's checkpointed
-            runtime.syncer_state.broadcast(lock_tx.clone());
+            runtime
+                .syncer_state
+                .broadcast(lock_tx.clone(), TxLabel::Lock);
             runtime.checkpoint_state(event.endpoints, None, new_ssm.clone())?;
             runtime.broadcast(lock_tx, TxLabel::Lock, event.endpoints)?;
             Ok(Some(new_ssm))
@@ -1212,6 +1214,7 @@ fn try_bob_accordant_lock_final_to_bob_buy_final(
                 &Some(confirmations),
                 runtime.swap_id(),
                 runtime.temporal_safety.btc_finality_thr,
+                event.endpoints,
             );
             runtime.log_warn(
                 "Peerd might crash, just ignore it, counterparty closed \
@@ -1307,6 +1310,7 @@ fn try_bob_cancel_final_to_swap_end(
                 &Some(confirmations),
                 runtime.swap_id(),
                 runtime.temporal_safety.btc_finality_thr,
+                event.endpoints,
             );
             let abort_all = Task::Abort(Abort {
                 task_target: TaskTarget::AllTasks,
@@ -1355,6 +1359,7 @@ fn try_bob_canceled_to_bob_cancel_final(
                 &Some(confirmations),
                 runtime.swap_id(),
                 runtime.temporal_safety.btc_finality_thr,
+                event.endpoints,
             );
             runtime.log_trace("Bob publishes refund tx");
             if !runtime.temporal_safety.safe_refund(confirmations) {
@@ -1752,6 +1757,7 @@ fn try_alice_buy_procedure_signature_to_swap_end(
                 &Some(confirmations),
                 runtime.swap_id(),
                 runtime.temporal_safety.btc_finality_thr,
+                event.endpoints,
             );
             let abort_all = Task::Abort(Abort {
                 task_target: TaskTarget::AllTasks,

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -1209,13 +1209,6 @@ fn try_bob_accordant_lock_final_to_bob_buy_final(
             && runtime.syncer_state.tasks.watched_txs.get(&id) == Some(&TxLabel::Buy)
             && runtime.syncer_state.tasks.txids.contains_key(&TxLabel::Buy) =>
         {
-            runtime.syncer_state.handle_tx_confs(
-                &id,
-                &Some(confirmations),
-                runtime.swap_id(),
-                runtime.temporal_safety.btc_finality_thr,
-                event.endpoints,
-            );
             runtime.log_warn(
                 "Peerd might crash, just ignore it, counterparty closed \
                     connection, because they are done with the swap, but you don't need it anymore either!"
@@ -1305,13 +1298,6 @@ fn try_bob_cancel_final_to_swap_end(
             .final_tx(confirmations, Blockchain::Bitcoin)
             && runtime.syncer_state.tasks.watched_txs.get(&id) == Some(&TxLabel::Refund) =>
         {
-            runtime.syncer_state.handle_tx_confs(
-                &id,
-                &Some(confirmations),
-                runtime.swap_id(),
-                runtime.temporal_safety.btc_finality_thr,
-                event.endpoints,
-            );
             let abort_all = Task::Abort(Abort {
                 task_target: TaskTarget::AllTasks,
                 respond: Boolean::False,
@@ -1354,13 +1340,6 @@ fn try_bob_canceled_to_bob_cancel_final(
             && runtime.syncer_state.tasks.watched_txs.get(&id) == Some(&TxLabel::Cancel)
             && runtime.txs.contains_key(&TxLabel::Refund) =>
         {
-            runtime.syncer_state.handle_tx_confs(
-                &id,
-                &Some(confirmations),
-                runtime.swap_id(),
-                runtime.temporal_safety.btc_finality_thr,
-                event.endpoints,
-            );
             runtime.log_trace("Bob publishes refund tx");
             if !runtime.temporal_safety.safe_refund(confirmations) {
                 runtime.log_warn("Publishing refund tx, but we might already have been punished");
@@ -1752,13 +1731,6 @@ fn try_alice_buy_procedure_signature_to_swap_end(
             .final_tx(confirmations, Blockchain::Bitcoin)
             && runtime.syncer_state.tasks.watched_txs.get(&id) == Some(&TxLabel::Buy) =>
         {
-            runtime.syncer_state.handle_tx_confs(
-                &id,
-                &Some(confirmations),
-                runtime.swap_id(),
-                runtime.temporal_safety.btc_finality_thr,
-                event.endpoints,
-            );
             let abort_all = Task::Abort(Abort {
                 task_target: TaskTarget::AllTasks,
                 respond: Boolean::False,

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use bitcoin::{consensus::Decodable, Txid};
 use farcaster_core::{blockchain::Blockchain, swap::SwapId, transaction::TxLabel};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use crate::{
     bus::sync::SyncMsg,
@@ -32,7 +32,7 @@ pub struct SyncerTasks {
     pub final_txs: HashMap<TxLabel, bool>,
     pub watched_addrs: HashMap<TaskId, TxLabel>,
     pub retrieving_txs: HashMap<TaskId, (TxLabel, Task)>,
-    pub broadcasting_txs: HashSet<TaskId>,
+    pub broadcasting_txs: HashMap<TaskId, TxLabel>,
     pub sweeping_addr: Option<TaskId>,
     // external address: needed to subscribe for buy (bob) or refund (alice) address_txs
     pub txids: HashMap<TxLabel, Txid>,
@@ -61,6 +61,7 @@ pub struct SyncerState {
     pub xmr_addr_addendum: Option<XmrAddressAddendum>,
     pub confirmations: HashMap<TxLabel, Option<u32>>,
     pub awaiting_funding: bool,
+    pub broadcasted_txs: HashMap<TxLabel, bitcoin::Transaction>,
 }
 impl SyncerState {
     pub fn task_lifetime(&self, blockchain: Blockchain) -> u64 {
@@ -333,7 +334,7 @@ impl SyncerState {
         task
     }
 
-    pub fn broadcast(&mut self, tx: bitcoin::Transaction) -> Task {
+    pub fn broadcast(&mut self, tx: bitcoin::Transaction, label: TxLabel) -> Task {
         let id = self.tasks.new_taskid();
         let task = Task::BroadcastTransaction(BroadcastTransaction {
             id,
@@ -341,25 +342,47 @@ impl SyncerState {
             broadcast_after_height: None,
         });
         self.tasks.tasks.insert(id, task.clone());
-        self.tasks.broadcasting_txs.insert(id);
+        self.tasks.broadcasting_txs.insert(id, label);
         task
     }
     pub fn transaction_broadcasted(&mut self, event: &TransactionBroadcasted) {
-        self.tasks.broadcasting_txs.remove(&event.id);
-        self.tasks.tasks.remove(&event.id);
+        if let Some(txlabel) = self.tasks.broadcasting_txs.remove(&event.id) {
+            self.tasks.tasks.remove(&event.id);
+            if let Some(ref err) = event.error {
+                warn!(
+                    "{} | Error broadcasting {} transaction: {}",
+                    self.swap_id, txlabel, err
+                );
+            } else {
+                let tx = match bitcoin::Transaction::consensus_decode(std::io::Cursor::new(
+                    event.tx.clone(),
+                )) {
+                    Ok(tx) => tx,
+                    Err(_) => {
+                        error!(
+                            "{} | Error while consensus decoding broadcasted {} transaction",
+                            self.swap_id, txlabel
+                        );
+                        return;
+                    }
+                };
+                self.broadcasted_txs.insert(txlabel, tx);
+            }
+        }
     }
-    pub fn pending_broadcast_txs(&self) -> Vec<bitcoin::Transaction> {
+    pub fn pending_broadcast_txs(&self) -> Vec<(bitcoin::Transaction, TxLabel)> {
         self.tasks
             .broadcasting_txs
             .iter()
-            .filter_map(|id| {
+            .filter_map(|(id, label)| {
                 if let Task::BroadcastTransaction(broadcast_tx) = self.tasks.tasks.get(id)? {
-                    Some(
+                    Some((
                         bitcoin::Transaction::consensus_decode(std::io::Cursor::new(
                             broadcast_tx.tx.clone(),
                         ))
                         .ok()?,
-                    )
+                        label.clone(),
+                    ))
                 } else {
                     None
                 }
@@ -379,9 +402,10 @@ impl SyncerState {
         confirmations: &Option<u32>,
         swapid: SwapId,
         finality_thr: u32,
+        endpoints: &mut Endpoints,
     ) {
-        if let Some(txlabel) = self.tasks.watched_txs.get(id) {
-            if !self.tasks.final_txs.contains_key(txlabel)
+        if let Some(txlabel) = self.tasks.watched_txs.get(id).cloned() {
+            if !self.tasks.final_txs.contains_key(&txlabel)
                 && confirmations.is_some()
                 && confirmations.unwrap() >= finality_thr
             {
@@ -393,8 +417,8 @@ impl SyncerState {
                     confirmations.unwrap().bright_green_bold(),
                     "confirmations".bright_green_bold()
                 );
-                self.tasks.final_txs.insert(*txlabel, true);
-            } else if let Some(finality) = self.tasks.final_txs.get(txlabel) {
+                self.tasks.final_txs.insert(txlabel, true);
+            } else if let Some(finality) = self.tasks.final_txs.get(&txlabel) {
                 info!(
                     "{} | Tx {} {}",
                     self.swap_id.swap_id(),
@@ -424,6 +448,21 @@ impl SyncerState {
                         )
                     }
                     None => {
+                        if let Some(tx) = self.broadcasted_txs.get(&txlabel) {
+                            warn!("{} | Tx {} was re-orged or dropped from the mempool. Re-broadcasting tx", swapid.swap_id(), txlabel.label());
+                            let task = self.broadcast(tx.clone(), txlabel.clone());
+                            if let Err(_) = endpoints.send_to(
+                                ServiceBus::Sync,
+                                ServiceId::Swap(self.swap_id),
+                                self.bitcoin_syncer(),
+                                BusMsg::Sync(SyncMsg::Task(task)),
+                            ) {
+                                error!(
+                                    "{} | failed to send task for re-broadcasting {} transaction",
+                                    swapid, txlabel
+                                );
+                            }
+                        }
                         info!(
                             "{} | Tx {} not on the mempool",
                             swapid.swap_id(),


### PR DESCRIPTION
Keep a list of broadcasted transactions and re-broadcast them when receiving a `None` confirmation event.

Also segregate the handling of syncer confirmations to the runtime and don't repeat the logic in the swap state machine.