### PR TITLE
Syncer: Some Refactors for better logging and ergonomics

### DIFF
--- a/src/farcasterd/syncer_state_machine.rs
+++ b/src/farcasterd/syncer_state_machine.rs
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-use bitcoin::hashes::{hex::ToHex, Hash};
 use farcaster_core::blockchain::{Blockchain, Network};
 
 use crate::{
@@ -334,16 +333,12 @@ fn attempt_transition_to_end(
         (BusMsg::Sync(SyncMsg::Event(SyncerEvent::SweepSuccess(mut success))), syncer_id)
             if syncer == syncer_id && success.id == syncer_task_id =>
         {
-            if let Some(Some(txid)) = success
-                .txids
-                .pop()
-                .map(|txid| bitcoin::Txid::from_slice(&txid).ok())
-            {
+            if let Some(txid) = success.txids.pop() {
                 event.send_client_info(
                     source,
                     InfoMsg::String(format!(
                         "Successfully sweeped address. Transaction Id: {}.",
-                        txid.to_hex()
+                        txid
                     )),
                 )?;
             } else {

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -443,12 +443,12 @@ impl Runtime {
 
                 if let Some(XmrAddressAddendum {
                     view_key,
-                    spend_key,
+                    address,
                     from_height,
                 }) = xmr_addr_addendum
                 {
                     let task = self.syncer_state.watch_addr_xmr(
-                        spend_key,
+                        address,
                         view_key,
                         TxLabel::AccLock,
                         Some(from_height),

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -17,7 +17,7 @@ use strict_encoding::{StrictDecode, StrictEncode};
 
 use crate::{
     bus::ctl::{MoneroFundingInfo, Params},
-    syncerd::{AddressTransaction, Txid},
+    syncerd::{AddressTransaction},
 };
 use crate::{
     bus::{
@@ -941,7 +941,7 @@ fn try_bob_fee_estimated_to_bob_funded(
             log_tx_seen(
                 runtime.swap_id,
                 &TxLabel::Funding,
-                &Txid::Bitcoin(tx.txid()),
+                &tx.txid().into(),
             );
             runtime.syncer_state.awaiting_funding = false;
             // If the bitcoin amount does not match the expected funding amount, abort the swap
@@ -1224,7 +1224,7 @@ fn try_bob_accordant_lock_final_to_bob_buy_final(
                 .unwrap();
             let task = runtime
                 .syncer_state
-                .retrieve_tx_btc(Txid::Bitcoin(txid), txlabel);
+                .retrieve_tx_btc(txid.into(), txlabel);
             event.send_sync_service(runtime.syncer_state.bitcoin_syncer(), SyncMsg::Task(task))?;
             Ok(Some(SwapStateMachine::BobAccordantLockFinal(
                 BobAccordantLockFinal {
@@ -1242,7 +1242,7 @@ fn try_bob_accordant_lock_final_to_bob_buy_final(
             Some((TxLabel::Buy, _))
         ) =>
         {
-            log_tx_seen(runtime.swap_id, &TxLabel::Buy, &Txid::Bitcoin(tx.txid()));
+            log_tx_seen(runtime.swap_id, &TxLabel::Buy, &tx.txid().into());
             let sweep_xmr = wallet.process_buy_tx(
                 tx,
                 event.endpoints,
@@ -1812,7 +1812,7 @@ fn try_alice_canceled_to_alice_refund_or_alice_punish(
                         .unwrap();
                     let task = runtime
                         .syncer_state
-                        .retrieve_tx_btc(Txid::Bitcoin(txid), txlabel);
+                        .retrieve_tx_btc(txid.into(), txlabel);
                     event.send_sync_service(
                         runtime.syncer_state.bitcoin_syncer(),
                         SyncMsg::Task(task),
@@ -1902,7 +1902,7 @@ fn try_alice_canceled_to_alice_refund_or_alice_punish(
                 .retrieving_txs
                 .remove(&id)
                 .unwrap();
-            log_tx_seen(runtime.swap_id, &txlabel, &Txid::Bitcoin(tx.txid()));
+            log_tx_seen(runtime.swap_id, &txlabel, &tx.txid().into());
             let sweep_xmr = wallet.process_refund_tx(
                 event.endpoints,
                 tx.clone(),

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -17,7 +17,7 @@ use strict_encoding::{StrictDecode, StrictEncode};
 
 use crate::{
     bus::ctl::{MoneroFundingInfo, Params},
-    syncerd::{AddressTransaction},
+    syncerd::AddressTransaction,
 };
 use crate::{
     bus::{
@@ -938,11 +938,7 @@ fn try_bob_fee_estimated_to_bob_funded(
                 "Received AddressTransaction, processing tx {}",
                 &tx.txid().tx_hash()
             ));
-            log_tx_seen(
-                runtime.swap_id,
-                &TxLabel::Funding,
-                &tx.txid().into(),
-            );
+            log_tx_seen(runtime.swap_id, &TxLabel::Funding, &tx.txid().into());
             runtime.syncer_state.awaiting_funding = false;
             // If the bitcoin amount does not match the expected funding amount, abort the swap
             let amount = bitcoin::Amount::from_sat(*amount);
@@ -1218,9 +1214,7 @@ fn try_bob_accordant_lock_final_to_bob_buy_final(
                 .txids
                 .remove_entry(&TxLabel::Buy)
                 .unwrap();
-            let task = runtime
-                .syncer_state
-                .retrieve_tx_btc(txid.into(), txlabel);
+            let task = runtime.syncer_state.retrieve_tx_btc(txid.into(), txlabel);
             event.send_sync_service(runtime.syncer_state.bitcoin_syncer(), SyncMsg::Task(task))?;
             Ok(Some(SwapStateMachine::BobAccordantLockFinal(
                 BobAccordantLockFinal {
@@ -1788,9 +1782,7 @@ fn try_alice_canceled_to_alice_refund_or_alice_punish(
                         .txids
                         .remove_entry(&TxLabel::Refund)
                         .unwrap();
-                    let task = runtime
-                        .syncer_state
-                        .retrieve_tx_btc(txid.into(), txlabel);
+                    let task = runtime.syncer_state.retrieve_tx_btc(txid.into(), txlabel);
                     event.send_sync_service(
                         runtime.syncer_state.bitcoin_syncer(),
                         SyncMsg::Task(task),

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -1123,7 +1123,7 @@ fn try_bob_refund_procedure_signatures_to_bob_accordant_lock(
             }
             if let Some(tx_label) = runtime.syncer_state.tasks.watched_addrs.remove(id) {
                 let abort_task = runtime.syncer_state.abort_task(*id);
-                let watch_tx = runtime.syncer_state.watch_tx_xmr(hash.clone(), tx_label);
+                let watch_tx = runtime.syncer_state.watch_tx_xmr(*hash, tx_label);
                 event.send_sync_service(
                     runtime.syncer_state.monero_syncer(),
                     SyncMsg::Task(watch_tx),
@@ -1615,7 +1615,7 @@ fn try_alice_arbitrating_lock_final_to_alice_accordant_lock(
                 id, hash, amount, block, tx
             ));
             let txlabel = TxLabel::AccLock;
-            let task = runtime.syncer_state.watch_tx_xmr(hash.clone(), txlabel);
+            let task = runtime.syncer_state.watch_tx_xmr(*hash, txlabel);
             if runtime.syncer_state.awaiting_funding {
                 event.send_ctl_service(
                     ServiceId::Farcasterd,

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -132,7 +132,7 @@ impl SyncerState {
         let task = Task::WatchTransaction(WatchTransaction {
             id,
             lifetime: self.task_lifetime(Blockchain::Bitcoin),
-            hash: Txid::Bitcoin(txid),
+            hash: txid.into(),
             confirmation_bound: self.confirmation_bound,
         });
         self.tasks.tasks.insert(id, task.clone());

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -171,9 +171,7 @@ impl SyncerState {
     pub fn retrieve_tx_btc(&mut self, txid: Txid, tx_label: TxLabel) -> Task {
         let id = self.tasks.new_taskid();
         let task = Task::GetTx(GetTx { id, hash: txid });
-        self.tasks
-            .retrieving_txs
-            .insert(id, tx_label);
+        self.tasks.retrieving_txs.insert(id, tx_label);
         self.tasks.tasks.insert(id, task.clone());
         task
     }

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -231,35 +231,29 @@ impl SyncerState {
     /// Watches an xmr address. If no `from_height` is provided, it will be set to current_height - 20.
     pub fn watch_addr_xmr(
         &mut self,
-        spend: monero::PublicKey,
+        address: monero::Address,
         view: monero::PrivateKey,
         tx_label: TxLabel,
         from_height: Option<u64>,
     ) -> Task {
         if self.is_watched_addr(&tx_label) {
             warn!(
-                "{} | Address already watched for {} - notifications will be repeated",
+                "{} | Address {} already watched for {} - notifications will be repeated",
+                address,
                 self.swap_id.swap_id(),
                 tx_label.label()
             );
         }
         debug!(
-            "{} | Address's secret view key for {}: {}",
+            "{} | Address {} secret view key for {}: {}",
+            address,
             self.swap_id.bright_blue_italic(),
             tx_label.bright_white_bold(),
             view.bright_white_italic()
         );
-        debug!(
-            "{} | Address's public spend key for {}: {}",
-            self.swap_id.bright_blue_italic(),
-            tx_label.bright_white_bold(),
-            spend.bright_white_italic()
-        );
-        let viewpair = monero::ViewPair { spend, view };
-        let address = monero::Address::from_viewpair(self.network.into(), &viewpair);
         let from_height = from_height.unwrap_or_else(|| self.from_height(Blockchain::Monero, 20));
         let addendum = XmrAddressAddendum {
-            spend_key: spend,
+            address,
             view_key: view,
             from_height,
         };

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -161,7 +161,7 @@ impl SyncerState {
         let task = Task::WatchTransaction(WatchTransaction {
             id,
             lifetime: self.task_lifetime(Blockchain::Monero),
-            hash: hash,
+            hash,
             confirmation_bound: self.confirmation_bound,
         });
         self.tasks.tasks.insert(id, task.clone());

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -261,7 +261,7 @@ impl ElectrumRpc {
                             let mut state_guard = state.lock().await;
                             state_guard
                                 .change_transaction(
-                                    Txid::Bitcoin(*tx_id),
+                                    (*tx_id).into(),
                                     None,
                                     Some(0),
                                     bitcoin::consensus::serialize(&tx),
@@ -289,7 +289,7 @@ impl ElectrumRpc {
                                     let mut state_guard = state.lock().await;
                                     state_guard
                                         .change_transaction(
-                                            Txid::Bitcoin(*tx_id),
+                                            (*tx_id).into(),
                                             None,
                                             Some(0),
                                             bitcoin::consensus::serialize(&tx),
@@ -316,7 +316,7 @@ impl ElectrumRpc {
                             let mut state_guard = state.lock().await;
                             state_guard
                                 .change_transaction(
-                                    Txid::Bitcoin(*tx_id),
+                                    (*tx_id).into(),
                                     None,
                                     Some(0),
                                     bitcoin::consensus::serialize(&tx),
@@ -336,7 +336,7 @@ impl ElectrumRpc {
                     let mut state_guard = state.lock().await;
                     state_guard
                         .change_transaction(
-                            Txid::Bitcoin(tx.txid()),
+                            tx.txid().into(),
                             blockhash,
                             Some(confs),
                             bitcoin::consensus::serialize(&tx),
@@ -348,7 +348,7 @@ impl ElectrumRpc {
                     trace!("error getting transaction, treating as not found: {}", err);
                     let mut state_guard = state.lock().await;
                     state_guard
-                        .change_transaction(Txid::Bitcoin(*tx_id), None, None, vec![])
+                        .change_transaction((*tx_id).into(), None, None, vec![])
                         .await;
                     drop(state_guard);
                 }
@@ -450,7 +450,7 @@ fn query_addr_history(
         };
         addr_txs.push(AddressTx {
             amount,
-            tx_id: Txid::Bitcoin(txid),
+            tx_id: txid.into(),
             tx: bitcoin::consensus::serialize(&tx),
             incoming: output_found && !input_found,
         })
@@ -582,7 +582,7 @@ fn sweep_address(
     let tx_hash =
         client.transaction_broadcast_raw(&bitcoin::consensus::serialize(&finalized_signed_tx))?;
 
-    Ok(vec![Txid::Bitcoin(tx_hash)])
+    Ok(vec![tx_hash.into()])
 }
 
 async fn run_syncerd_bridge_event_sender(

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -213,13 +213,13 @@ impl ElectrumRpc {
             state_guard
                 .unseen_transactions
                 .iter()
-                .map(|task_id| state_guard.transactions[task_id].task.hash.clone())
+                .map(|task_id| state_guard.transactions[task_id].task.hash)
                 .collect()
         } else {
             state_guard
                 .transactions
                 .values()
-                .map(|watched_tx| watched_tx.task.hash.clone())
+                .map(|watched_tx| watched_tx.task.hash)
                 .collect()
         };
         drop(state_guard);

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -216,7 +216,7 @@ impl MoneroRpc {
             .await
         {
             Err(err) => {
-                debug!("wallet doesn't exist, generating a new wallet: {:?}", err);
+                debug!("wallet doesn't exist, generating a new wallet: {}", err);
                 wallet
                     .generate_from_keys(GenerateFromKeysArgs {
                         restore_height: Some(address_addendum.from_height),
@@ -336,7 +336,7 @@ async fn sweep_address(
         .await
     {
         debug!(
-            "error opening to be sweeped wallet: {:?}, falling back to generating a new wallet",
+            "error opening to be sweeped wallet: {}, falling back to generating a new wallet",
             err,
         );
         wallet
@@ -429,7 +429,7 @@ async fn sweep_address(
         Ok(tx_ids)
     } else {
         debug!(
-            "retrying sweep, balance not unlocked yet. Unlocked balance {:?}. Total balance {:?}. Expected balance {:?}.",
+            "retrying sweep, balance not unlocked yet. Unlocked balance {}. Total balance {}. Expected balance {}.",
             balance.unlocked_balance, balance.balance, minimum_balance
         );
         trace!("releasing sweep wallet lock");
@@ -511,7 +511,7 @@ async fn run_syncerd_task_receiver(
                         }
                         Task::WatchAddress(task) => match task.addendum.clone() {
                             AddressAddendum::Monero(_) => {
-                                debug!("received new task: {:?}", task);
+                                debug!("received new watch address task for address: {}", task);
                                 let mut state_guard = state.lock().await;
                                 state_guard.watch_address(task, syncerd_task.source);
                             }
@@ -528,7 +528,7 @@ async fn run_syncerd_task_receiver(
                             state_guard.watch_height(task, syncerd_task.source).await;
                         }
                         Task::WatchTransaction(task) => {
-                            debug!("received new task: {:?}", task);
+                            debug!("received new watch tx task: {}", hex::encode(&task.hash));
                             let mut state_guard = state.lock().await;
                             state_guard.watch_transaction(task, syncerd_task.source);
                         }
@@ -592,19 +592,19 @@ async fn subscribe_address_lws(
     };
     let address = monero::Address::from_viewpair(network, &keypair);
     let daemon_client = monero_lws::LwsRpcClient::new(monero_lws_url);
-    debug!("subscribing monero address: {}, {:?}", address, address);
+    trace!("subscribing monero address: {}, {}", address, address);
     let res = daemon_client
         .login(address, keypair.view, true, true)
         .await?;
-    debug!("account created: {:?}", res);
+    trace!("account created: {:?}", res);
     let res = daemon_client
         .login(address, keypair.view, false, false)
         .await?;
-    debug!("logged in to lws: {:?}", res);
+    trace!("logged in to lws: {:?}", res);
     let res = daemon_client
         .import_request(address, keypair.view, Some(address_addendum.from_height))
         .await?;
-    debug!("import request to lws: {:?}", res);
+    trace!("import request to lws: {:?}", res);
     Ok(())
 }
 
@@ -649,7 +649,7 @@ fn address_polling(
                                     true
                                 }
                                 Err(err) => {
-                                    warn!("error subscribing address to monero lws: {:?}", err);
+                                    warn!("error subscribing address to monero lws: {}", err);
                                     false
                                 }
                             };
@@ -671,7 +671,7 @@ fn address_polling(
                             Err(err) => {
                                 // an error might indicate that the remote server shutdown, so we should re-subscribe everything on re-connect
                                 needs_resubscribe = true;
-                                error!("error polling addresses: {:?}", err);
+                                error!("error polling addresses: {}", err);
                                 // the remote server may have disconnected, set the subscribed addresses to none
                                 None
                             }
@@ -691,7 +691,7 @@ fn address_polling(
                         {
                             Ok(address_transactions) => Some(address_transactions),
                             Err(err) => {
-                                error!("error polling addresses: {:?}", err);
+                                error!("error polling addresses: {}", err);
                                 None
                             }
                         }
@@ -744,7 +744,7 @@ fn height_polling(
                             polled_transactions = txs;
                         }
                         Err(err) => {
-                            error!("polling transactions error: {:?}", err);
+                            error!("polling transactions error: {}", err);
                         }
                     }
                     let mut state_guard = state.lock().await;
@@ -787,7 +787,7 @@ fn sweep_polling(
                     .await
                     .unwrap_or_else(|err| {
                         warn!(
-                            "error polling sweep address {:?}, retrying: {}",
+                            "error polling sweep address {}, retrying: {}",
                             err, sweep_address_task.retry
                         );
                         vec![]
@@ -833,7 +833,7 @@ fn unseen_transaction_polling(
                         polled_transactions = txs;
                     }
                     Err(err) => {
-                        error!("polling unseen transactions error: {:?}", err);
+                        error!("polling unseen transactions error: {}", err);
                     }
                 }
                 let mut state_guard = state.lock().await;
@@ -857,7 +857,7 @@ async fn run_syncerd_bridge_event_sender(
         let mut session = LocalSession::with_zmq_socket(ZmqSocketType::Push, tx);
         while let Some(event) = event_rx.recv().await {
             let request = BusMsg::Sync(SyncMsg::BridgeEvent(event));
-            trace!("sending request over syncerd bridge: {:?}", request);
+            trace!("sending request over syncerd bridge: {}", request);
             session
                 .send_routed_message(
                     &syncer_address,
@@ -888,7 +888,7 @@ async fn fetch_balance(
         .await
     {
         debug!(
-            "error opening to be sweeped wallet: {:?}, falling back to generating a new wallet",
+            "error opening to be sweeped wallet: {}, falling back to generating a new wallet",
             err,
         );
         wallet

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -173,7 +173,7 @@ impl MoneroRpc {
                 };
                 AddressTx {
                     amount,
-                    tx_id: Txid::Monero(tx.hash.0),
+                    tx_id: tx.hash.0.into(),
                     tx: vec![],
                     incoming,
                 }
@@ -291,7 +291,7 @@ impl MoneroRpc {
                 // FIXME: tx set to vec![0]
                 address_txs.push(AddressTx {
                     amount: tx.amount.as_pico(),
-                    tx_id: Txid::Monero(monero::Hash::from_slice(&tx.txid.0)),
+                    tx_id: monero::Hash::from_slice(&tx.txid.0).into(),
                     tx: vec![0],
                     incoming,
                 });
@@ -375,7 +375,7 @@ async fn sweep_address(
             .map(|hash| {
                 let hash_str = hash.to_string();
                 info!("Sweep transaction hash: {}", hash_str.tx_hash());
-                Txid::Monero(hash.0)
+                hash.0.into()
             })
             .collect();
 
@@ -740,7 +740,7 @@ fn height_polling(
                     for tx in polled_transactions.drain(..) {
                         state_guard
                             .change_transaction(
-                                Txid::Monero(tx.tx_id),
+                                tx.tx_id.into(),
                                 tx.block_hash,
                                 tx.confirmations,
                                 vec![],
@@ -838,7 +838,7 @@ fn unseen_transaction_polling(
                 for tx in polled_transactions.drain(..) {
                     state_guard
                         .change_transaction(
-                            Txid::Monero(tx.tx_id),
+                            tx.tx_id.into(),
                             tx.block_hash,
                             tx.confirmations,
                             vec![],

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -816,7 +816,7 @@ fn unseen_transaction_polling(
                     .iter()
                     .filter_map(|id| {
                         let tx = transactions.get(id).expect("attempted fetching a monero syncer state transaction that does not exist");
-                        if let Txid::Monero(txid) = tx.task.hash.clone() {
+                        if let Txid::Monero(txid) = tx.task.hash {
                             Some(txid)
                         } else {
                             None

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -854,12 +854,7 @@ async fn syncer_state_transaction() {
     assert!(event_rx.try_recv().is_err());
 
     state
-        .change_transaction(
-            monero::Hash::new(vec![0]).into(),
-            none!(),
-            none!(),
-            none!(),
-        )
+        .change_transaction(monero::Hash::new(vec![0]).into(), none!(), none!(), none!())
         .await;
     assert_eq!(state.lifetimes.len(), 3);
     assert_eq!(state.transactions.len(), 2);
@@ -868,12 +863,7 @@ async fn syncer_state_transaction() {
     assert!(event_rx.try_recv().is_ok());
 
     state
-        .change_transaction(
-            monero::Hash::new(vec![0]).into(),
-            none!(),
-            Some(0),
-            none!(),
-        )
+        .change_transaction(monero::Hash::new(vec![0]).into(), none!(), Some(0), none!())
         .await;
     assert_eq!(state.lifetimes.len(), 3);
     assert_eq!(state.transactions.len(), 2);
@@ -882,12 +872,7 @@ async fn syncer_state_transaction() {
     assert!(event_rx.try_recv().is_ok());
 
     state
-        .change_transaction(
-            monero::Hash::new(vec![0]).into(),
-            none!(),
-            Some(0),
-            none!(),
-        )
+        .change_transaction(monero::Hash::new(vec![0]).into(), none!(), Some(0), none!())
         .await;
     assert_eq!(state.lifetimes.len(), 3);
     assert_eq!(state.transactions.len(), 2);
@@ -924,12 +909,7 @@ async fn syncer_state_transaction() {
     assert!(event_rx.try_recv().is_err());
 
     state
-        .change_transaction(
-            monero::Hash::new(vec![0]).into(),
-            none!(),
-            none!(),
-            none!(),
-        )
+        .change_transaction(monero::Hash::new(vec![0]).into(), none!(), none!(), none!())
         .await;
     assert_eq!(state.lifetimes.len(), 3);
     assert_eq!(state.transactions.len(), 2);
@@ -1177,10 +1157,7 @@ async fn syncer_state_sweep_addresses() {
     assert_eq!(state.tasks_sources.len(), 1);
     assert_eq!(state.sweep_addresses.len(), 1);
     state
-        .success_sweep(
-            &InternalId(2),
-            vec![monero::Hash::new(vec![0]).into()],
-        )
+        .success_sweep(&InternalId(2), vec![monero::Hash::new(vec![0]).into()])
         .await;
     assert_eq!(state.lifetimes.len(), 0);
     assert_eq!(state.tasks_sources.len(), 0);

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -493,7 +493,7 @@ impl SyncerState {
                         debug!("new tx seen: {}", new_tx.tx_id);
                         let address_transaction = AddressTransaction {
                             id: addr.task.id,
-                            hash: new_tx.tx_id.clone(),
+                            hash: new_tx.tx_id,
                             amount: new_tx.amount,
                             block: vec![], // eventually this should be removed from the event
                             tx: new_tx

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -823,13 +823,13 @@ async fn syncer_state_transaction() {
     let transaction_task_one = WatchTransaction {
         id: TaskId(0),
         lifetime: 1,
-        hash: Txid::Monero(monero::Hash::new(vec![0])),
+        hash: monero::Hash::new(vec![0]).into(),
         confirmation_bound: 4,
     };
     let transaction_task_two = WatchTransaction {
         id: TaskId(0),
         lifetime: 3,
-        hash: Txid::Monero(monero::Hash::new(vec![1])),
+        hash: monero::Hash::new(vec![1]).into(),
         confirmation_bound: 4,
     };
     let height_task = WatchHeight {
@@ -855,7 +855,7 @@ async fn syncer_state_transaction() {
 
     state
         .change_transaction(
-            Txid::Monero(monero::Hash::new(vec![0])),
+            monero::Hash::new(vec![0]).into(),
             none!(),
             none!(),
             none!(),
@@ -869,7 +869,7 @@ async fn syncer_state_transaction() {
 
     state
         .change_transaction(
-            Txid::Monero(monero::Hash::new(vec![0])),
+            monero::Hash::new(vec![0]).into(),
             none!(),
             Some(0),
             none!(),
@@ -883,7 +883,7 @@ async fn syncer_state_transaction() {
 
     state
         .change_transaction(
-            Txid::Monero(monero::Hash::new(vec![0])),
+            monero::Hash::new(vec![0]).into(),
             none!(),
             Some(0),
             none!(),
@@ -897,7 +897,7 @@ async fn syncer_state_transaction() {
 
     state
         .change_transaction(
-            Txid::Monero(monero::Hash::new(vec![0])),
+            monero::Hash::new(vec![0]).into(),
             Some(vec![1]),
             Some(1),
             none!(),
@@ -911,7 +911,7 @@ async fn syncer_state_transaction() {
 
     state
         .change_transaction(
-            Txid::Monero(monero::Hash::new(vec![0])),
+            monero::Hash::new(vec![0]).into(),
             Some(vec![1]),
             Some(1),
             none!(),
@@ -925,7 +925,7 @@ async fn syncer_state_transaction() {
 
     state
         .change_transaction(
-            Txid::Monero(monero::Hash::new(vec![0])),
+            monero::Hash::new(vec![0]).into(),
             none!(),
             none!(),
             none!(),
@@ -1011,25 +1011,25 @@ async fn syncer_state_addresses() {
     assert_eq!(state.addresses.len(), 1);
     let address_tx_one = AddressTx {
         amount: 1,
-        tx_id: Txid::Monero(monero::Hash::new(vec![0])),
+        tx_id: monero::Hash::new(vec![0]).into(),
         tx: vec![0],
         incoming: true,
     };
     let address_tx_two = AddressTx {
         amount: 1,
-        tx_id: Txid::Monero(monero::Hash::new(vec![1])),
+        tx_id: monero::Hash::new(vec![1]).into(),
         tx: vec![0],
         incoming: true,
     };
     let address_tx_three = AddressTx {
         amount: 1,
-        tx_id: Txid::Monero(monero::Hash::new(vec![2])),
+        tx_id: monero::Hash::new(vec![2]).into(),
         tx: vec![0],
         incoming: true,
     };
     let address_tx_four = AddressTx {
         amount: 1,
-        tx_id: Txid::Monero(monero::Hash::new(vec![3])),
+        tx_id: monero::Hash::new(vec![3]).into(),
         tx: vec![0],
         incoming: true,
     };
@@ -1179,7 +1179,7 @@ async fn syncer_state_sweep_addresses() {
     state
         .success_sweep(
             &InternalId(2),
-            vec![Txid::Monero(monero::Hash::new(vec![0]))],
+            vec![monero::Hash::new(vec![0]).into()],
         )
         .await;
     assert_eq!(state.lifetimes.len(), 0);

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -72,7 +72,7 @@ pub struct AddressTransactions {
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
 pub struct AddressTx {
     pub amount: u64,
-    pub tx_id: Vec<u8>,
+    pub tx_id: Txid,
     pub tx: Vec<u8>,
     pub incoming: bool,
 }
@@ -490,7 +490,7 @@ impl SyncerState {
                     }
                     // create events for new transactions
                     for new_tx in txs_diff {
-                        debug!("new tx seen: {}", hex::encode(&new_tx.tx_id));
+                        debug!("new tx seen: {}", new_tx.tx_id);
                         let address_transaction = AddressTransaction {
                             id: addr.task.id,
                             hash: new_tx.tx_id.clone(),
@@ -533,7 +533,7 @@ impl SyncerState {
 
     pub async fn change_transaction(
         &mut self,
-        tx_id: Vec<u8>,
+        tx_id: Txid,
         block_hash: Option<Vec<u8>>,
         confirmations: Option<u32>,
         tx: Vec<u8>,
@@ -557,7 +557,7 @@ impl SyncerState {
             unseen_transactions: &mut HashSet<InternalId>,
             events: &mut Vec<(Event, ServiceId)>,
             tasks_sources: &mut HashMap<InternalId, ServiceId>,
-            tx_id: Vec<u8>,
+            tx_id: Txid,
             block_hash: Option<Vec<u8>>,
             confirmations: Option<u32>,
             tx: Vec<u8>,
@@ -620,7 +620,7 @@ impl SyncerState {
         send_event(&self.tx_event, &mut events).await;
     }
 
-    pub async fn success_sweep(&mut self, id: &InternalId, txids: Vec<Vec<u8>>) {
+    pub async fn success_sweep(&mut self, id: &InternalId, txids: Vec<Txid>) {
         if let Some(sweep_address) = self.sweep_addresses.get(id) {
             send_event(
                 &self.tx_event,
@@ -823,13 +823,13 @@ async fn syncer_state_transaction() {
     let transaction_task_one = WatchTransaction {
         id: TaskId(0),
         lifetime: 1,
-        hash: vec![0],
+        hash: Txid::Monero(monero::Hash::new(vec![0])),
         confirmation_bound: 4,
     };
     let transaction_task_two = WatchTransaction {
         id: TaskId(0),
         lifetime: 3,
-        hash: vec![1],
+        hash: Txid::Monero(monero::Hash::new(vec![1])),
         confirmation_bound: 4,
     };
     let height_task = WatchHeight {
@@ -854,7 +854,12 @@ async fn syncer_state_transaction() {
     assert!(event_rx.try_recv().is_err());
 
     state
-        .change_transaction(vec![0], none!(), none!(), none!())
+        .change_transaction(
+            Txid::Monero(monero::Hash::new(vec![0])),
+            none!(),
+            none!(),
+            none!(),
+        )
         .await;
     assert_eq!(state.lifetimes.len(), 3);
     assert_eq!(state.transactions.len(), 2);
@@ -863,7 +868,12 @@ async fn syncer_state_transaction() {
     assert!(event_rx.try_recv().is_ok());
 
     state
-        .change_transaction(vec![0], none!(), Some(0), none!())
+        .change_transaction(
+            Txid::Monero(monero::Hash::new(vec![0])),
+            none!(),
+            Some(0),
+            none!(),
+        )
         .await;
     assert_eq!(state.lifetimes.len(), 3);
     assert_eq!(state.transactions.len(), 2);
@@ -872,7 +882,12 @@ async fn syncer_state_transaction() {
     assert!(event_rx.try_recv().is_ok());
 
     state
-        .change_transaction(vec![0], none!(), Some(0), none!())
+        .change_transaction(
+            Txid::Monero(monero::Hash::new(vec![0])),
+            none!(),
+            Some(0),
+            none!(),
+        )
         .await;
     assert_eq!(state.lifetimes.len(), 3);
     assert_eq!(state.transactions.len(), 2);
@@ -881,7 +896,12 @@ async fn syncer_state_transaction() {
     assert!(event_rx.try_recv().is_err());
 
     state
-        .change_transaction(vec![0], Some(vec![1]), Some(1), none!())
+        .change_transaction(
+            Txid::Monero(monero::Hash::new(vec![0])),
+            Some(vec![1]),
+            Some(1),
+            none!(),
+        )
         .await;
     assert_eq!(state.lifetimes.len(), 3);
     assert_eq!(state.transactions.len(), 2);
@@ -890,7 +910,12 @@ async fn syncer_state_transaction() {
     assert!(event_rx.try_recv().is_ok());
 
     state
-        .change_transaction(vec![0], Some(vec![1]), Some(1), none!())
+        .change_transaction(
+            Txid::Monero(monero::Hash::new(vec![0])),
+            Some(vec![1]),
+            Some(1),
+            none!(),
+        )
         .await;
     assert_eq!(state.lifetimes.len(), 3);
     assert_eq!(state.transactions.len(), 2);
@@ -899,7 +924,12 @@ async fn syncer_state_transaction() {
     assert!(event_rx.try_recv().is_err());
 
     state
-        .change_transaction(vec![0], none!(), none!(), none!())
+        .change_transaction(
+            Txid::Monero(monero::Hash::new(vec![0])),
+            none!(),
+            none!(),
+            none!(),
+        )
         .await;
     assert_eq!(state.lifetimes.len(), 3);
     assert_eq!(state.transactions.len(), 2);
@@ -981,25 +1011,25 @@ async fn syncer_state_addresses() {
     assert_eq!(state.addresses.len(), 1);
     let address_tx_one = AddressTx {
         amount: 1,
-        tx_id: vec![0; 32],
+        tx_id: Txid::Monero(monero::Hash::new(vec![0])),
         tx: vec![0],
         incoming: true,
     };
     let address_tx_two = AddressTx {
         amount: 1,
-        tx_id: vec![1; 32],
+        tx_id: Txid::Monero(monero::Hash::new(vec![1])),
         tx: vec![0],
         incoming: true,
     };
     let address_tx_three = AddressTx {
         amount: 1,
-        tx_id: vec![2; 32],
+        tx_id: Txid::Monero(monero::Hash::new(vec![2])),
         tx: vec![0],
         incoming: true,
     };
     let address_tx_four = AddressTx {
         amount: 1,
-        tx_id: vec![3; 32],
+        tx_id: Txid::Monero(monero::Hash::new(vec![3])),
         tx: vec![0],
         incoming: true,
     };
@@ -1146,7 +1176,12 @@ async fn syncer_state_sweep_addresses() {
     assert_eq!(state.lifetimes.len(), 1);
     assert_eq!(state.tasks_sources.len(), 1);
     assert_eq!(state.sweep_addresses.len(), 1);
-    state.success_sweep(&InternalId(2), vec![vec![0]]).await;
+    state
+        .success_sweep(
+            &InternalId(2),
+            vec![Txid::Monero(monero::Hash::new(vec![0]))],
+        )
+        .await;
     assert_eq!(state.lifetimes.len(), 0);
     assert_eq!(state.tasks_sources.len(), 0);
     assert_eq!(state.sweep_addresses.len(), 0);

--- a/src/syncerd/types.rs
+++ b/src/syncerd/types.rs
@@ -254,7 +254,7 @@ impl fmt::Display for BroadcastTransaction {
         let bitcoin_tx_id =
             bitcoin::Transaction::consensus_decode(std::io::Cursor::new(self.tx.clone()))
                 .map(|tx| tx.txid().to_string())
-                .unwrap_or("".to_string());
+                .unwrap_or_default();
 
         write!(
             f,
@@ -447,7 +447,7 @@ impl fmt::Display for TransactionBroadcasted {
         let bitcoin_tx_id =
             bitcoin::Transaction::consensus_decode(std::io::Cursor::new(self.tx.clone()))
                 .map(|tx| tx.txid().to_string())
-                .unwrap_or("".to_string());
+                .unwrap_or_default();
         write!(
             f,
             "TransactionBroadcasted(id: {}, tx_id: {}, error: {:?})",

--- a/src/syncerd/types.rs
+++ b/src/syncerd/types.rs
@@ -361,7 +361,7 @@ impl fmt::Display for HeightChanged {
     }
 }
 
-#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),

--- a/src/syncerd/types.rs
+++ b/src/syncerd/types.rs
@@ -59,8 +59,7 @@ pub struct BtcAddressAddendum {
 )]
 #[display(Debug)]
 pub struct XmrAddressAddendum {
-    #[serde_as(as = "DisplayFromStr")]
-    pub spend_key: monero::PublicKey,
+    pub address: monero::Address,
     #[serde_as(as = "DisplayFromStr")]
     pub view_key: monero::PrivateKey,
     /// The blockchain height where to start the query (not inclusive).

--- a/src/syncerd/types.rs
+++ b/src/syncerd/types.rs
@@ -4,6 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+use std::fmt;
+
+use bitcoin::consensus::Decodable;
 #[cfg(feature = "serde")]
 use serde_with::DisplayFromStr;
 use strict_encoding::{StrictDecode, StrictEncode};
@@ -30,9 +33,10 @@ pub struct TaskId(pub u32);
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[display(Debug)]
 pub enum AddressAddendum {
+    #[display("Monero Address {0}")]
     Monero(XmrAddressAddendum),
+    #[display("Bitcoin Address {0}")]
     Bitcoin(BtcAddressAddendum),
 }
 
@@ -57,7 +61,7 @@ pub struct BtcAddressAddendum {
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[display(Debug)]
+#[display("address: {address}, from_height: {from_height}")]
 pub struct XmrAddressAddendum {
     pub address: monero::Address,
     #[serde_as(as = "DisplayFromStr")]
@@ -72,7 +76,7 @@ pub struct XmrAddressAddendum {
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[display(Debug)]
+#[display("SweepAddress({addendum}, retry: {retry}, id: {id}, lifetime: {lifetime})")]
 pub struct SweepAddress {
     pub retry: bool,
     pub id: TaskId,
@@ -86,9 +90,10 @@ pub struct SweepAddress {
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[display(Debug)]
 pub enum SweepAddressAddendum {
+    #[display("SweepMoneroAddress({0})")]
     Monero(SweepMoneroAddress),
+    #[display("SweepBitcoinAddress({0})")]
     Bitcoin(SweepBitcoinAddress),
 }
 
@@ -99,7 +104,7 @@ pub enum SweepAddressAddendum {
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[display(Debug)]
+#[display("Sweep destination: {destination_address}, Min balance: {minimum_balance}")]
 pub struct SweepMoneroAddress {
     #[serde_as(as = "DisplayFromStr")]
     pub source_spend_key: monero::PrivateKey,
@@ -117,7 +122,7 @@ pub struct SweepMoneroAddress {
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[display(Debug)]
+#[display("Source address: {source_address}, destination_address: {destination_address}")]
 pub struct SweepBitcoinAddress {
     pub source_secret_key: bitcoin::secp256k1::SecretKey,
     pub source_address: bitcoin::Address,
@@ -165,7 +170,7 @@ pub struct WatchHeight {
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[display(Debug)]
+#[display("WatchAddress({addendum}, id: {id}, lifetime: {lifetime}, include_tx: {include_tx})")]
 pub struct WatchAddress {
     pub id: TaskId,
     pub lifetime: u64,
@@ -208,28 +213,35 @@ impl From<Boolean> for bool {
     }
 }
 
-#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[display(Debug)]
 pub struct WatchTransaction {
     pub id: TaskId,
     pub lifetime: u64,
-    #[serde(with = "hex")]
-    pub hash: Vec<u8>,
+    pub hash: Txid,
     pub confirmation_bound: u32,
 }
 
-#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+impl fmt::Display for WatchTransaction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "WatchTransaction(id: {}, lifetime: {}, hash: {}, confirmations_bound: {})",
+            self.id, self.lifetime, self.hash, self.confirmation_bound
+        )
+    }
+}
+
+#[derive(Clone, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[display(Debug)]
 pub struct BroadcastTransaction {
     pub id: TaskId,
     #[serde(with = "hex")]
@@ -237,17 +249,36 @@ pub struct BroadcastTransaction {
     pub broadcast_after_height: Option<u64>,
 }
 
-#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+impl fmt::Display for BroadcastTransaction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let bitcoin_tx_id =
+            bitcoin::Transaction::consensus_decode(std::io::Cursor::new(self.tx.clone()))
+                .map(|tx| tx.txid().to_string())
+                .unwrap_or("".to_string());
+
+        write!(
+            f,
+            "BroadcastTransaction(id: {}, broadcast_after_height: {:?}, tx_id: {})",
+            self.id, self.broadcast_after_height, bitcoin_tx_id
+        )
+    }
+}
+
+#[derive(Clone, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[display(Debug)]
 pub struct GetTx {
     pub id: TaskId,
-    #[serde(with = "hex")]
-    pub hash: Vec<u8>,
+    pub hash: Txid,
+}
+
+impl fmt::Display for GetTx {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "GetTx(id: {}, hash: {})", self.id, self.hash,)
+    }
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
@@ -293,18 +324,28 @@ pub struct GetAddressBalance {
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[display(Debug)]
 pub enum Task {
+    #[display("{0}")]
     Abort(Abort),
+    #[display("{0}")]
     WatchHeight(WatchHeight),
+    #[display("{0}")]
     WatchAddress(WatchAddress),
+    #[display("{0}")]
     WatchTransaction(WatchTransaction),
+    #[display("{0}")]
     BroadcastTransaction(BroadcastTransaction),
+    #[display("{0}")]
     SweepAddress(SweepAddress),
+    #[display("{0}")]
     GetTx(GetTx),
+    #[display("{0}")]
     GetAddressBalance(GetAddressBalance),
+    #[display("{0}")]
     WatchEstimateFee(WatchEstimateFee),
+    #[display("{0}")]
     HealthCheck(HealthCheck),
+    #[display("Terminate")]
     Terminate,
 }
 
@@ -315,20 +356,43 @@ pub struct TaskAborted {
     pub error: Option<String>,
 }
 
-#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[display(Debug)]
+#[derive(Clone, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
 pub struct HeightChanged {
     pub id: TaskId,
     pub block: Vec<u8>,
     pub height: u64,
 }
 
+impl fmt::Display for HeightChanged {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "HeightChanged(id: {}, block: {}, height: {})",
+            self.id,
+            hex::encode(&self.block),
+            self.height,
+        )
+    }
+}
+
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[display(Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
+pub enum Txid {
+    #[display("{0}")]
+    Monero(monero::Hash),
+    #[display("{0}")]
+    Bitcoin(bitcoin::Txid),
+}
+
+#[derive(Clone, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
 pub struct AddressTransaction {
     pub id: TaskId,
-    pub hash: Vec<u8>,
-    pub amount: u64, // Only calculated for incoming transactions
+    pub hash: Txid,
+    pub amount: u64,
     pub block: Vec<u8>,
     // for bitcoin with bitcoin::consensus encoding, chunked into chunks with
     // length < 2^16 as a workaround for the strict encoding length limit
@@ -336,8 +400,20 @@ pub struct AddressTransaction {
     pub incoming: bool,
 }
 
-#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[display(Debug)]
+impl fmt::Display for AddressTransaction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "AddressTransaction(id: {}, hash: {}, amount: {}, block: {})",
+            self.id,
+            self.hash,
+            self.amount,
+            hex::encode(&self.block),
+        )
+    }
+}
+
+#[derive(Clone, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
 pub struct TransactionConfirmations {
     pub id: TaskId,
     pub block: Vec<u8>,
@@ -347,26 +423,63 @@ pub struct TransactionConfirmations {
     pub tx: Vec<Vec<u8>>,
 }
 
-#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[display(Debug)]
+impl fmt::Display for TransactionConfirmations {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "TransactionConfirmations(id: {}, block: {}, confirmations: {:?})",
+            self.id,
+            hex::encode(&self.block),
+            self.confirmations,
+        )
+    }
+}
+
+#[derive(Clone, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
 pub struct TransactionBroadcasted {
     pub id: TaskId,
     pub tx: Vec<u8>,
     pub error: Option<String>,
 }
 
-#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[display(Debug)]
+impl fmt::Display for TransactionBroadcasted {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let bitcoin_tx_id =
+            bitcoin::Transaction::consensus_decode(std::io::Cursor::new(self.tx.clone()))
+                .map(|tx| tx.txid().to_string())
+                .unwrap_or("".to_string());
+        write!(
+            f,
+            "TransactionBroadcasted(id: {}, tx_id: {}, error: {:?})",
+            self.id, bitcoin_tx_id, self.error,
+        )
+    }
+}
+
+#[derive(Clone, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
 pub struct SweepSuccess {
     pub id: TaskId,
-    pub txids: Vec<Vec<u8>>,
+    pub txids: Vec<Txid>,
+}
+
+impl fmt::Display for SweepSuccess {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "SweepSuccess(id: {}, txids: {:?})",
+            self.id,
+            self.txids
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<Vec<String>>(),
+        )
+    }
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
 #[display(Debug)]
 pub struct TransactionRetrieved {
     pub id: TaskId,
-    // for bitcoin with bitcoin::consensus encoding
     pub tx: Option<bitcoin::Transaction>,
 }
 
@@ -423,21 +536,32 @@ pub struct AddressBalance {
 /// Events are identified with a unique 32-bits integer that match the [`Task`]
 /// id.
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[display(Debug)]
 pub enum Event {
     /// Notify the daemon the blockchain height changed.
+    #[display("{0}")]
     HeightChanged(HeightChanged),
+    #[display("{0}")]
     AddressTransaction(AddressTransaction),
+    #[display("{0}")]
     TransactionConfirmations(TransactionConfirmations),
+    #[display("{0}")]
     TransactionBroadcasted(TransactionBroadcasted),
+    #[display("{0}")]
     SweepSuccess(SweepSuccess),
+    #[display("{0}")]
     /// Notify the daemon the task has been aborted with success or failure.
     /// Carries the status for the task abortion.
+    #[display("{0}")]
     TaskAborted(TaskAborted),
+    #[display("{0}")]
     TransactionRetrieved(TransactionRetrieved),
+    #[display("{0}")]
     FeeEstimation(FeeEstimation),
     /// Empty event to signify that a task with a certain id has not produced an initial result
+    #[display("{0}")]
     Empty(TaskId),
+    #[display("{0}")]
     HealthResult(HealthResult),
+    #[display("{0}")]
     AddressBalance(AddressBalance),
 }

--- a/src/syncerd/types.rs
+++ b/src/syncerd/types.rs
@@ -374,6 +374,18 @@ pub enum Txid {
     Bitcoin(bitcoin::Txid),
 }
 
+impl From<monero::Hash> for Txid {
+    fn from(t: monero::Hash) -> Txid {
+        Txid::Monero(t)
+    }
+}
+
+impl From<bitcoin::Txid> for Txid {
+    fn from(t: bitcoin::Txid) -> Txid {
+        Txid::Bitcoin(t)
+    }
+}
+
 #[derive(Clone, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
 pub struct AddressTransaction {
     pub id: TaskId,

--- a/src/syncerd/types.rs
+++ b/src/syncerd/types.rs
@@ -452,12 +452,13 @@ impl fmt::Display for SweepSuccess {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "SweepSuccess(id: {}, txids: {:?})",
+            "SweepSuccess(id: {}, txids: {})",
             self.id,
             self.txids
                 .iter()
                 .map(|t| t.to_string())
-                .collect::<Vec<String>>(),
+                .collect::<Vec<String>>()
+                .join(", ")
         )
     }
 }

--- a/src/syncerd/types.rs
+++ b/src/syncerd/types.rs
@@ -213,27 +213,18 @@ impl From<Boolean> for bool {
     }
 }
 
-#[derive(Clone, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[derive(Clone, Display, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
+#[display("WatchTransaction(id: {id}, lifetime: {lifetime}, hash: {hash}, confirmation_bound: {confirmation_bound})")]
 pub struct WatchTransaction {
     pub id: TaskId,
     pub lifetime: u64,
     pub hash: Txid,
     pub confirmation_bound: u32,
-}
-
-impl fmt::Display for WatchTransaction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "WatchTransaction(id: {}, lifetime: {}, hash: {}, confirmations_bound: {})",
-            self.id, self.lifetime, self.hash, self.confirmation_bound
-        )
-    }
 }
 
 #[derive(Clone, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
@@ -264,21 +255,16 @@ impl fmt::Display for BroadcastTransaction {
     }
 }
 
-#[derive(Clone, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
+#[display("GetTx(id: {id}, hash: {hash})")]
 pub struct GetTx {
     pub id: TaskId,
     pub hash: Txid,
-}
-
-impl fmt::Display for GetTx {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "GetTx(id: {}, hash: {})", self.id, self.hash,)
-    }
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -12,7 +12,7 @@ use farcaster_node::syncerd::types::{
     SweepAddressAddendum, Task, WatchAddress, WatchEstimateFee, WatchHeight, WatchTransaction,
 };
 use farcaster_node::syncerd::{runtime::Synclet, TaskId, TaskTarget};
-use farcaster_node::syncerd::{GetAddressBalance, SweepBitcoinAddress, TxFilter, Txid};
+use farcaster_node::syncerd::{GetAddressBalance, SweepBitcoinAddress, TxFilter};
 use farcaster_node::ServiceId;
 use microservices::ZMQ_CONTEXT;
 use ntest::timeout;
@@ -70,7 +70,7 @@ fn bitcoin_syncer_retrieve_transaction_test() {
     let task = SyncerdTask {
         task: Task::GetTx(GetTx {
             id: TaskId(1),
-            hash: Txid::Bitcoin(txid),
+            hash: txid.into(),
         }),
         source: SOURCE1.clone(),
     };
@@ -284,7 +284,7 @@ fn bitcoin_syncer_address_test() {
     let message = rx_event.recv_multipart(0).unwrap();
     info!("received address transaction message");
     let request = misc::get_request_from_message(message);
-    assert::address_transaction(request, amount.as_sat(), vec![Txid::Bitcoin(txid)]);
+    assert::address_transaction(request, amount.as_sat(), vec![txid.into()]);
 
     // now generate a block for address1, then wait for the response and test it
     let block_hash = bitcoin_rpc.generate_to_address(1, &address1).unwrap();
@@ -298,7 +298,7 @@ fn bitcoin_syncer_address_test() {
     assert::address_transaction(
         request,
         address_transaction_amount,
-        vec![Txid::Bitcoin(address_txid)],
+        vec![address_txid.into()],
     );
 
     // then send a transaction to the other address we are watching
@@ -315,7 +315,7 @@ fn bitcoin_syncer_address_test() {
     assert::address_transaction(
         request,
         amount.as_sat(),
-        vec![Txid::Bitcoin(txid_1.clone()), Txid::Bitcoin(txid_2)],
+        vec![txid_1.into(), txid_2.into()],
     );
 
     info!("waiting for address transaction message");
@@ -325,7 +325,7 @@ fn bitcoin_syncer_address_test() {
     assert::address_transaction(
         request,
         amount.as_sat(),
-        vec![Txid::Bitcoin(txid_1.clone()), Txid::Bitcoin(txid_2.clone())],
+        vec![txid_1.into(), txid_2.into()],
     );
 
     // watch for the same address, it should already contain transactions
@@ -347,7 +347,7 @@ fn bitcoin_syncer_address_test() {
     assert::address_transaction(
         request,
         amount.as_sat(),
-        vec![Txid::Bitcoin(txid_1.clone()), Txid::Bitcoin(txid_2.clone())],
+        vec![txid_1.into(), txid_2.into()],
     );
     info!("waiting for address transaction message");
     let message = rx_event.recv_multipart(0).unwrap();
@@ -356,7 +356,7 @@ fn bitcoin_syncer_address_test() {
     assert::address_transaction(
         request,
         amount.as_sat(),
-        vec![Txid::Bitcoin(txid_1.clone()), Txid::Bitcoin(txid_2.clone())],
+        vec![txid_1.into(), txid_2.into()],
     );
 
     let address4 = bitcoin_rpc.get_new_address(None, None).unwrap();
@@ -395,7 +395,7 @@ fn bitcoin_syncer_address_test() {
         let message = rx_event.recv_multipart(0).unwrap();
         info!("received repeated address transaction message");
         let request = misc::get_request_from_message(message);
-        assert::address_transaction(request, amount.as_sat(), vec![Txid::Bitcoin(txid)]);
+        assert::address_transaction(request, amount.as_sat(), vec![txid.into()]);
     }
 
     let address5 = bitcoin_rpc.get_new_address(None, None).unwrap();
@@ -435,7 +435,7 @@ fn bitcoin_syncer_address_test() {
     let message = rx_event.recv_multipart(0).unwrap();
     info!("received address transaction message");
     let request = misc::get_request_from_message(message);
-    assert::address_transaction(request, amount.as_sat(), vec![Txid::Bitcoin(txid)]);
+    assert::address_transaction(request, amount.as_sat(), vec![txid.into()]);
 
     tx.send(SyncerdTask {
         task: Task::Terminate,
@@ -491,7 +491,7 @@ fn bitcoin_syncer_transaction_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 5,
-            hash: Txid::Bitcoin(txid_1.clone()),
+            hash: txid_1.into(),
             confirmation_bound: 0,
         }),
         source: SOURCE1.clone(),
@@ -507,7 +507,7 @@ fn bitcoin_syncer_transaction_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 5,
-            hash: Txid::Bitcoin(txid_1.clone()),
+            hash: txid_1.into(),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -549,7 +549,7 @@ fn bitcoin_syncer_transaction_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 5,
-            hash: Txid::Bitcoin(address_txid),
+            hash: address_txid.into(),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -585,7 +585,7 @@ fn bitcoin_syncer_transaction_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 5,
-            hash: Txid::Bitcoin(txid_2.clone()),
+            hash: txid_2.into(),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -595,7 +595,7 @@ fn bitcoin_syncer_transaction_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 5,
-            hash: Txid::Bitcoin(txid_3.clone()),
+            hash: txid_3.into(),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -650,7 +650,7 @@ fn bitcoin_syncer_transaction_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 5,
-            hash: Txid::Bitcoin(txid),
+            hash: txid.into(),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -708,7 +708,7 @@ fn bitcoin_syncer_abort_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(0),
             lifetime: blocks + 10,
-            hash: Txid::Bitcoin(bitcoin::Txid::from_slice(&vec![0; 32]).unwrap()),
+            hash: bitcoin::Txid::from_slice(&vec![0; 32]).unwrap().into(),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -756,7 +756,7 @@ fn bitcoin_syncer_abort_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(0),
             lifetime: blocks + 10,
-            hash: Txid::Bitcoin(bitcoin::Txid::from_slice(&vec![0; 32]).unwrap()),
+            hash: bitcoin::Txid::from_slice(&vec![0; 32]).unwrap().into(),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -771,7 +771,7 @@ fn bitcoin_syncer_abort_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 10,
-            hash: Txid::Bitcoin(bitcoin::Txid::from_slice(&vec![0; 32]).unwrap()),
+            hash: bitcoin::Txid::from_slice(&vec![0; 32]).unwrap().into(),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -12,7 +12,7 @@ use farcaster_node::syncerd::types::{
     SweepAddressAddendum, Task, WatchAddress, WatchEstimateFee, WatchHeight, WatchTransaction,
 };
 use farcaster_node::syncerd::{runtime::Synclet, TaskId, TaskTarget};
-use farcaster_node::syncerd::{GetAddressBalance, SweepBitcoinAddress, TxFilter};
+use farcaster_node::syncerd::{GetAddressBalance, SweepBitcoinAddress, TxFilter, Txid};
 use farcaster_node::ServiceId;
 use microservices::ZMQ_CONTEXT;
 use ntest::timeout;
@@ -70,7 +70,7 @@ fn bitcoin_syncer_retrieve_transaction_test() {
     let task = SyncerdTask {
         task: Task::GetTx(GetTx {
             id: TaskId(1),
-            hash: txid.to_vec(),
+            hash: Txid::Bitcoin(txid),
         }),
         source: SOURCE1.clone(),
     };
@@ -284,7 +284,7 @@ fn bitcoin_syncer_address_test() {
     let message = rx_event.recv_multipart(0).unwrap();
     info!("received address transaction message");
     let request = misc::get_request_from_message(message);
-    assert::address_transaction(request, amount.as_sat(), vec![txid.to_vec()]);
+    assert::address_transaction(request, amount.as_sat(), vec![Txid::Bitcoin(txid)]);
 
     // now generate a block for address1, then wait for the response and test it
     let block_hash = bitcoin_rpc.generate_to_address(1, &address1).unwrap();
@@ -298,7 +298,7 @@ fn bitcoin_syncer_address_test() {
     assert::address_transaction(
         request,
         address_transaction_amount,
-        vec![address_txid.to_vec()],
+        vec![Txid::Bitcoin(address_txid)],
     );
 
     // then send a transaction to the other address we are watching
@@ -315,7 +315,7 @@ fn bitcoin_syncer_address_test() {
     assert::address_transaction(
         request,
         amount.as_sat(),
-        vec![txid_1.to_vec(), txid_2.to_vec()],
+        vec![Txid::Bitcoin(txid_1.clone()), Txid::Bitcoin(txid_2)],
     );
 
     info!("waiting for address transaction message");
@@ -325,7 +325,7 @@ fn bitcoin_syncer_address_test() {
     assert::address_transaction(
         request,
         amount.as_sat(),
-        vec![txid_1.to_vec(), txid_2.to_vec()],
+        vec![Txid::Bitcoin(txid_1.clone()), Txid::Bitcoin(txid_2.clone())],
     );
 
     // watch for the same address, it should already contain transactions
@@ -347,7 +347,7 @@ fn bitcoin_syncer_address_test() {
     assert::address_transaction(
         request,
         amount.as_sat(),
-        vec![txid_1.to_vec(), txid_2.to_vec()],
+        vec![Txid::Bitcoin(txid_1.clone()), Txid::Bitcoin(txid_2.clone())],
     );
     info!("waiting for address transaction message");
     let message = rx_event.recv_multipart(0).unwrap();
@@ -356,7 +356,7 @@ fn bitcoin_syncer_address_test() {
     assert::address_transaction(
         request,
         amount.as_sat(),
-        vec![txid_1.to_vec(), txid_2.to_vec()],
+        vec![Txid::Bitcoin(txid_1.clone()), Txid::Bitcoin(txid_2.clone())],
     );
 
     let address4 = bitcoin_rpc.get_new_address(None, None).unwrap();
@@ -395,7 +395,7 @@ fn bitcoin_syncer_address_test() {
         let message = rx_event.recv_multipart(0).unwrap();
         info!("received repeated address transaction message");
         let request = misc::get_request_from_message(message);
-        assert::address_transaction(request, amount.as_sat(), vec![txid.to_vec()]);
+        assert::address_transaction(request, amount.as_sat(), vec![Txid::Bitcoin(txid)]);
     }
 
     let address5 = bitcoin_rpc.get_new_address(None, None).unwrap();
@@ -435,7 +435,7 @@ fn bitcoin_syncer_address_test() {
     let message = rx_event.recv_multipart(0).unwrap();
     info!("received address transaction message");
     let request = misc::get_request_from_message(message);
-    assert::address_transaction(request, amount.as_sat(), vec![txid.to_vec()]);
+    assert::address_transaction(request, amount.as_sat(), vec![Txid::Bitcoin(txid)]);
 
     tx.send(SyncerdTask {
         task: Task::Terminate,
@@ -491,7 +491,7 @@ fn bitcoin_syncer_transaction_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 5,
-            hash: txid_1.to_vec(),
+            hash: Txid::Bitcoin(txid_1.clone()),
             confirmation_bound: 0,
         }),
         source: SOURCE1.clone(),
@@ -507,7 +507,7 @@ fn bitcoin_syncer_transaction_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 5,
-            hash: txid_1.to_vec(),
+            hash: Txid::Bitcoin(txid_1.clone()),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -549,7 +549,7 @@ fn bitcoin_syncer_transaction_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 5,
-            hash: address_txid.to_vec(),
+            hash: Txid::Bitcoin(address_txid),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -585,7 +585,7 @@ fn bitcoin_syncer_transaction_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 5,
-            hash: txid_2.to_vec(),
+            hash: Txid::Bitcoin(txid_2.clone()),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -595,7 +595,7 @@ fn bitcoin_syncer_transaction_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 5,
-            hash: txid_3.to_vec(),
+            hash: Txid::Bitcoin(txid_3.clone()),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -650,7 +650,7 @@ fn bitcoin_syncer_transaction_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 5,
-            hash: txid.to_vec(),
+            hash: Txid::Bitcoin(txid),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -708,7 +708,7 @@ fn bitcoin_syncer_abort_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(0),
             lifetime: blocks + 10,
-            hash: vec![0; 32],
+            hash: Txid::Bitcoin(bitcoin::Txid::from_slice(&vec![0; 32]).unwrap()),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -756,7 +756,7 @@ fn bitcoin_syncer_abort_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(0),
             lifetime: blocks + 10,
-            hash: vec![0; 32],
+            hash: Txid::Bitcoin(bitcoin::Txid::from_slice(&vec![0; 32]).unwrap()),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -771,7 +771,7 @@ fn bitcoin_syncer_abort_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 10,
-            hash: vec![0; 32],
+            hash: Txid::Bitcoin(bitcoin::Txid::from_slice(&vec![0; 32]).unwrap()),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -312,21 +312,13 @@ fn bitcoin_syncer_address_test() {
     let message = rx_event.recv_multipart(0).unwrap();
     info!("received address transaction message");
     let request = misc::get_request_from_message(message);
-    assert::address_transaction(
-        request,
-        amount.as_sat(),
-        vec![txid_1.into(), txid_2.into()],
-    );
+    assert::address_transaction(request, amount.as_sat(), vec![txid_1.into(), txid_2.into()]);
 
     info!("waiting for address transaction message");
     let message = rx_event.recv_multipart(0).unwrap();
     info!("received address transaction message");
     let request = misc::get_request_from_message(message);
-    assert::address_transaction(
-        request,
-        amount.as_sat(),
-        vec![txid_1.into(), txid_2.into()],
-    );
+    assert::address_transaction(request, amount.as_sat(), vec![txid_1.into(), txid_2.into()]);
 
     // watch for the same address, it should already contain transactions
     let watch_address_task_3 = SyncerdTask {
@@ -344,20 +336,12 @@ fn bitcoin_syncer_address_test() {
     let message = rx_event.recv_multipart(0).unwrap();
     info!("received address transaction message");
     let request = misc::get_request_from_message(message);
-    assert::address_transaction(
-        request,
-        amount.as_sat(),
-        vec![txid_1.into(), txid_2.into()],
-    );
+    assert::address_transaction(request, amount.as_sat(), vec![txid_1.into(), txid_2.into()]);
     info!("waiting for address transaction message");
     let message = rx_event.recv_multipart(0).unwrap();
     info!("received address transaction message");
     let request = misc::get_request_from_message(message);
-    assert::address_transaction(
-        request,
-        amount.as_sat(),
-        vec![txid_1.into(), txid_2.into()],
-    );
+    assert::address_transaction(request, amount.as_sat(), vec![txid_1.into(), txid_2.into()]);
 
     let address4 = bitcoin_rpc.get_new_address(None, None).unwrap();
     let addendum_4 = AddressAddendum::Bitcoin(BtcAddressAddendum {

--- a/tests/monero.rs
+++ b/tests/monero.rs
@@ -723,7 +723,7 @@ async fn monero_syncer_transaction_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 5,
-            hash: Txid::Monero(transaction.tx_hash.0),
+            hash: transaction.tx_hash.0.into(),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -779,13 +779,13 @@ async fn monero_syncer_abort_test() {
         .unwrap()
         .height;
 
-    let zero_txid_hash = Txid::Monero(monero::Hash::new(vec![0]));
+    let zero_txid_hash: Txid = monero::Hash::new(vec![0]).into();
 
     let task = SyncerdTask {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(0),
             lifetime: blocks + 2,
-            hash: zero_txid_hash.clone(),
+            hash: zero_txid_hash,
             confirmation_bound: 2,
         }),
         source: SOURCE2.clone(),
@@ -831,7 +831,7 @@ async fn monero_syncer_abort_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(0),
             lifetime: blocks + 10,
-            hash: zero_txid_hash.clone(),
+            hash: zero_txid_hash,
             confirmation_bound: 2,
         }),
         source: SOURCE2.clone(),
@@ -1044,7 +1044,7 @@ async fn send_monero(
         )
         .await
         .unwrap();
-    Txid::Monero(transaction.tx_hash.0)
+    transaction.tx_hash.0.into()
 }
 
 async fn get_block_hash_from_height(

--- a/tests/monero.rs
+++ b/tests/monero.rs
@@ -324,7 +324,7 @@ async fn monero_syncer_address_test() {
         std::thread::sleep(duration);
 
         let addendum_1 = AddressAddendum::Monero(XmrAddressAddendum {
-            spend_key: address1.public_spend,
+            address: address1,
             view_key: view_key1,
             from_height: if lws_bool { 0 } else { 10 },
         });
@@ -367,7 +367,7 @@ async fn monero_syncer_address_test() {
         };
 
         let addendum_2 = AddressAddendum::Monero(XmrAddressAddendum {
-            spend_key: address2.public_spend,
+            address: address2,
             view_key: view_key2,
             from_height: 0,
         });
@@ -396,7 +396,7 @@ async fn monero_syncer_address_test() {
         assert::address_transaction(request, 1, vec![tx_id2_1.clone(), tx_id2_2.clone()]);
 
         let addendum_3 = AddressAddendum::Monero(XmrAddressAddendum {
-            spend_key: address2.public_spend,
+            address: address2,
             view_key: view_key2,
             from_height: 0,
         });
@@ -437,7 +437,7 @@ async fn monero_syncer_address_test() {
         };
 
         let addendum_4 = AddressAddendum::Monero(XmrAddressAddendum {
-            spend_key: address4.public_spend,
+            address: address4,
             view_key: view_key4,
             from_height: 0,
         });
@@ -477,7 +477,7 @@ async fn monero_syncer_address_test() {
         send_monero(&wallet, address4, 1).await;
 
         let addendum_5 = AddressAddendum::Monero(XmrAddressAddendum {
-            spend_key: address5.public_spend,
+            address: address5,
             view_key: view_key5,
             from_height: blocks,
         });
@@ -520,7 +520,7 @@ async fn monero_syncer_address_test() {
 
         let (address6, view_key6) = new_address(&wallet).await;
         let addendum_6 = AddressAddendum::Monero(XmrAddressAddendum {
-            spend_key: address6.public_spend,
+            address: address6,
             view_key: view_key6,
             from_height: blocks,
         });

--- a/tests/utils/assert.rs
+++ b/tests/utils/assert.rs
@@ -3,10 +3,10 @@
 use farcaster_node::bus::sync::{BridgeEvent, SyncMsg};
 use farcaster_node::bus::BusMsg;
 use farcaster_node::syncerd::types::Event;
-use farcaster_node::syncerd::TaskId;
 use farcaster_node::syncerd::{FeeEstimation, FeeEstimations};
+use farcaster_node::syncerd::{TaskId, Txid};
 
-pub fn address_transaction(request: BusMsg, expected_amount: u64, possible_txids: Vec<Vec<u8>>) {
+pub fn address_transaction(request: BusMsg, expected_amount: u64, possible_txids: Vec<Txid>) {
     match request {
         BusMsg::Sync(SyncMsg::BridgeEvent(event)) => match event.event {
             Event::AddressTransaction(address_transaction) => {


### PR DESCRIPTION
Add a dedicated address field in the Monero watch address addendum for the address instead of the public spend key.

Refactors a bunch of log lines towards using the default formatter.

Lastly, implements a dedicated Txid type for encoding txids. The syncer Txid type wraps either a bitcoin Txid, or a Monero tx hash