### PR TITLE
Swapd: Refactor retrieving txs in syncer client

### DIFF
--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -567,10 +567,10 @@ impl Runtime {
 
                     // This re-triggers the tx fetch event in case the transaction was not detected yet
                     Event::TransactionRetrieved(TransactionRetrieved { id, tx: None })
-                        if self.syncer_state.tasks.retrieving_txs.contains_key(id) =>
+                        if self.syncer_state.tasks.retrieving_txs.contains_key(id)
+                            && self.syncer_state.tasks.tasks.contains_key(id) =>
                     {
-                        let (_tx_label, task) =
-                            self.syncer_state.tasks.retrieving_txs.get(id).unwrap();
+                        let task = self.syncer_state.tasks.tasks.get(id).unwrap();
                         std::thread::sleep(core::time::Duration::from_millis(500));
                         endpoints.send_to(
                             ServiceBus::Sync,

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -1224,7 +1224,7 @@ fn try_bob_accordant_lock_final_to_bob_buy_final(
             tx: Some(tx),
         }))) if matches!(
             runtime.syncer_state.tasks.retrieving_txs.remove(&id),
-            Some((TxLabel::Buy, _))
+            Some(TxLabel::Buy)
         ) =>
         {
             log_tx_seen(runtime.swap_id, &TxLabel::Buy, &tx.txid());
@@ -1858,10 +1858,10 @@ fn try_alice_canceled_to_alice_refund_or_alice_punish(
             tx: Some(ref tx),
         }))) if matches!(
             runtime.syncer_state.tasks.retrieving_txs.get(&id),
-            Some((TxLabel::Refund, _))
+            Some(TxLabel::Refund)
         ) =>
         {
-            let (txlabel, _) = runtime
+            let txlabel = runtime
                 .syncer_state
                 .tasks
                 .retrieving_txs

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -31,7 +31,7 @@ pub struct SyncerTasks {
     pub watched_txs: HashMap<TaskId, TxLabel>,
     pub final_txs: HashMap<TxLabel, bool>,
     pub watched_addrs: HashMap<TaskId, TxLabel>,
-    pub retrieving_txs: HashMap<TaskId, (TxLabel, Task)>,
+    pub retrieving_txs: HashMap<TaskId, TxLabel>,
     pub broadcasting_txs: HashMap<TaskId, TxLabel>,
     pub sweeping_addr: Option<TaskId>,
     // external address: needed to subscribe for buy (bob) or refund (alice) address_txs
@@ -174,9 +174,7 @@ impl SyncerState {
             id,
             hash: txid.to_vec(),
         });
-        self.tasks
-            .retrieving_txs
-            .insert(id, (tx_label, task.clone()));
+        self.tasks.retrieving_txs.insert(id, tx_label);
         self.tasks.tasks.insert(id, task.clone());
         task
     }


### PR DESCRIPTION
Storing the tasks within the same data structure is not really needed.