### PR TITLE
Grpc: Handle handler drops (usually on client disconnect)

### DIFF
--- a/src/grpcd/runtime.rs
+++ b/src/grpcd/runtime.rs
@@ -1352,10 +1352,9 @@ fn response_loop(
                     if let Some(sender) = pending_requests.remove(&id) {
                         if let Err(err) = sender.send(request) {
                             error!(
-                                "Error encountered while sending response to Grpc server: {}",
+                                "Error {} encountered while sending response to Grpc server handle: The client probably disconnected.",
                                 err
                             );
-                            break;
                         }
                     } else {
                         error!("id {} not found in pending grpc requests", id);
@@ -1371,7 +1370,6 @@ fn response_loop(
                 }
             };
         }
-        Ok(())
     })
 }
 


### PR DESCRIPTION
When the client disconnects, its handler function is dropped. In this case, we should not error, but log a warning and continue the loop. Since we remove from the pending requests, no additional resources need to be dropped