### PR TITLE
Syncer(monero): Disregard unlock time transactions

### DIFF
--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -299,6 +299,14 @@ impl MoneroRpc {
                 _ => continue,
             };
             for tx in txs.drain(..) {
+                // Skip transactions with an unlock time set
+                if tx.unlock_time > 0 {
+                    warn!(
+                        "Address {} had transaction {} with an unlock time {}. Locked transactions are not supported. Skipping.",
+                        address, tx.txid, tx.unlock_time
+                    );
+                    continue;
+                }
                 // FIXME: tx set to vec![0]
                 address_txs.push(AddressTx {
                     amount: tx.amount.as_pico(),


### PR DESCRIPTION
These have the potential to burn the recipient's coins.