### PR TITLE
Make clippy annoying again

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
 
 jobs:
   binaries:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
 
 jobs:
   rust_format:

--- a/src/config.rs
+++ b/src/config.rs
@@ -153,18 +153,22 @@ impl Config {
                         .bitcoin
                         .get_for_network(network)
                         .or_else(|| ArbConfig::get(arb, network))
-                        .ok_or(config::ConfigError::Message(
-                            "No configuration nor defaults founds!".to_string(),
-                        ))?,
+                        .ok_or_else(|| {
+                            config::ConfigError::Message(
+                                "No configuration nor defaults founds!".to_string(),
+                            )
+                        })?,
                 };
                 let accordant = match acc {
                     AccordantBlockchain::Monero => swap
                         .monero
                         .get_for_network(network)
                         .or_else(|| AccConfig::get(acc, network))
-                        .ok_or(config::ConfigError::Message(
-                            "No configuration nor defaults founds!".to_string(),
-                        ))?,
+                        .ok_or_else(|| {
+                            config::ConfigError::Message(
+                                "No configuration nor defaults founds!".to_string(),
+                            )
+                        })?,
                 };
                 Ok(ParsedSwapConfig {
                     arbitrating,
@@ -172,12 +176,12 @@ impl Config {
                 })
             }
             None => {
-                let arbitrating = ArbConfig::get(arb, network).ok_or(
-                    config::ConfigError::Message("No defaults founds!".to_string()),
-                )?;
-                let accordant = AccConfig::get(acc, network).ok_or(
-                    config::ConfigError::Message("No defaults founds!".to_string()),
-                )?;
+                let arbitrating = ArbConfig::get(arb, network).ok_or_else(|| {
+                    config::ConfigError::Message("No defaults founds!".to_string())
+                })?;
+                let accordant = AccConfig::get(acc, network).ok_or_else(|| {
+                    config::ConfigError::Message("No defaults founds!".to_string())
+                })?;
                 Ok(ParsedSwapConfig {
                     arbitrating,
                     accordant,

--- a/src/databased/runtime.rs
+++ b/src/databased/runtime.rs
@@ -697,7 +697,7 @@ fn test_lmdb_state() {
         service_id: ServiceId::Database,
     };
     let path = std::env::current_dir().unwrap();
-    let mut database = Database::new(path.to_path_buf()).unwrap();
+    let mut database = Database::new(path).unwrap();
     database.set_checkpoint_state(&key1, &val1).unwrap();
     let res = database.get_checkpoint_state(&key1).unwrap();
     assert_eq!(val1, res);
@@ -713,7 +713,7 @@ fn test_lmdb_state() {
 
     let key_info = SwapId(Uuid::new());
     let val_info = CheckpointEntry {
-        swap_id: key_info.clone(),
+        swap_id: key_info,
         trade_role: TradeRole::Maker,
         deal: Deal::from_str("Deal:Cke4ftrP5A781Vq85dgBQJNwYgBS4nuUV1LQM2fvVdFMNR4h5TrWhRR11111uMFuZTAsNgpdK8DiK11111TB9zym113GTvtvqfD1111114A4TTfFfmZoWyvpcjDBtTZCdWFSUWcRKYfEC3Y17hqaXZ3dWz11111111111111111111111111111111111111111AfZ113SEBTEspU3a").unwrap(),
         expected_counterparty_node_id: None,
@@ -736,7 +736,7 @@ fn test_lmdb_state() {
     let val_retrieved = database.get_bitcoin_address_secret_key(&addr).unwrap();
     assert_eq!(addr_info, val_retrieved);
     let addrs = database.get_all_bitcoin_addresses().unwrap();
-    assert!(addrs.iter().find(|(a, _)| *a == addr).is_some());
+    assert!(addrs.iter().any(|(a, _)| *a == addr));
     let key_pair = monero::KeyPair {
         spend: monero::PrivateKey::from_str(
             "77916d0cd56ed1920aef6ca56d8a41bac915b68e4c46a589e0956e27a7b77404",
@@ -759,7 +759,7 @@ fn test_lmdb_state() {
     let val_retrieved = database.get_monero_address_secret_key(&addr).unwrap();
     assert_eq!(addr_info, val_retrieved);
     let addrs = database.get_all_monero_addresses().unwrap();
-    assert!(addrs.iter().find(|(a, _)| *a == addr).is_some());
+    assert!(addrs.iter().any(|(a, _)| *a == addr));
 
     let deal_1 = Deal::from_str("Deal:Cke4ftrP5A7MgLMaQZLZUMTC6TfkqUKBu1LQM2fvVdFMNR4gmBqNCsR11111uMFuZTAsNgpdK8DiK11111TB9zym113GTvtvqfD1111114A4TTF4h53Tv4MR6eS9sdDxV5JCH9xZcKejCqKShnphqndeeD11111111111111111111111111111111111111111AfZ113XRBtrLeA3t").unwrap();
     let deal_2 = Deal::from_str("Deal:Cke4ftrP5A7Km9Kmc2UDBePio1p7wM56P1LQM2fvVdFMNR4gmBqNCsR11111uMFuZTAsNgpdK8DiK11111TB9zym113GTvtvqfD1111114A4TTF4h53Tv4MR6eS9sdDxV5JCH9xZcKejCqKShnphqndeeD11111111111111111111111111111111111111111AfZ113XRBuLWyw3M").unwrap();

--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -1119,9 +1119,9 @@ impl Runtime {
         );
 
         let address = bind_addr.address();
-        let port = bind_addr.port().ok_or(Error::Farcaster(
-            "listen requires the port to listen on".to_string(),
-        ))?;
+        let port = bind_addr
+            .port()
+            .ok_or_else(|| Error::Farcaster("listen requires the port to listen on".to_string()))?;
 
         debug!("Instantiating peerd...");
         let child = launch(

--- a/src/grpcd/runtime.rs
+++ b/src/grpcd/runtime.rs
@@ -60,6 +60,7 @@ use tonic::{transport::Server, Request as GrpcRequest, Response as GrpcResponse,
 
 use self::farcaster::*;
 
+#[allow(clippy::all)]
 pub mod farcaster {
     tonic::include_proto!("farcaster");
 }
@@ -1506,8 +1507,10 @@ impl GrpcServer {
     }
 }
 
+type IdBusMsgPair = (u64, BusMsg);
+
 pub fn run(config: ServiceConfig, grpc_port: u16, grpc_ip: String) -> Result<(), Error> {
-    let (tx_response, rx_response): (Sender<(u64, BusMsg)>, Receiver<(u64, BusMsg)>) =
+    let (tx_response, rx_response): (Sender<IdBusMsgPair>, Receiver<IdBusMsgPair>) =
         std::sync::mpsc::channel();
 
     let tx_request = ZMQ_CONTEXT.socket(zmq::PUSH)?;
@@ -1639,7 +1642,7 @@ impl Runtime {
             }) => endpoints.send_to(ServiceBus::Info, source, service_id, BusMsg::Info(request))?,
             BusMsg::Bridge(BridgeMsg::GrpcServerTerminated) => {
                 // Re-create the grpc server runtime.
-                let (tx_response, rx_response): (Sender<(u64, BusMsg)>, Receiver<(u64, BusMsg)>) =
+                let (tx_response, rx_response): (Sender<IdBusMsgPair>, Receiver<IdBusMsgPair>) =
                     std::sync::mpsc::channel();
 
                 let tx_request = ZMQ_CONTEXT.socket(zmq::PUSH)?;

--- a/src/swapd/runtime.rs
+++ b/src/swapd/runtime.rs
@@ -702,8 +702,8 @@ impl Runtime {
                 }
             }
             // Try to handle previously unhandled peer message
-            if let Some(peer_msg) = &self.unhandled_peer_message {
-                self.handle_msg(endpoints, source.clone(), peer_msg.clone())?;
+            if let Some(peer_msg) = self.unhandled_peer_message.clone() {
+                self.handle_msg(endpoints, source.clone(), peer_msg)?;
             }
             // Replay confirmation events to ensure we immediately advance through states that can be skipped
             if let Some(buy_tx_confs_req) = self.syncer_state.buy_tx_confs.clone() {

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -389,7 +389,7 @@ impl SyncerState {
                             broadcast_tx.tx.clone(),
                         ))
                         .ok()?,
-                        label.clone(),
+                        *label,
                     ))
                 } else {
                     None
@@ -457,17 +457,18 @@ impl SyncerState {
                     }
                     None => {
                         if let Some(tx) = self.broadcasted_txs.get(&txlabel) {
+                            let tx = tx.clone();
                             warn!("{} | Tx {} was re-orged or dropped from the mempool. Re-broadcasting tx", swapid.swap_id(), txlabel.label());
-                            let task = self.broadcast(tx.clone(), txlabel.clone());
-                            if let Err(_) = endpoints.send_to(
+                            let task = self.broadcast(tx, txlabel);
+                            if let Err(err) = endpoints.send_to(
                                 ServiceBus::Sync,
                                 ServiceId::Swap(self.swap_id),
                                 self.bitcoin_syncer(),
                                 BusMsg::Sync(SyncMsg::Task(task)),
                             ) {
                                 error!(
-                                    "{} | failed to send task for re-broadcasting {} transaction",
-                                    swapid, txlabel
+                                    "{} | failed to send task for re-broadcasting {} transaction: {}",
+                                    swapid, txlabel, err
                                 );
                             }
                         }

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -16,6 +16,10 @@ use crate::service::LogStyle;
 use crate::syncerd::*;
 use hex;
 
+pub type BalanceServiceIdPair = (GetAddressBalance, ServiceId);
+pub type TransactionServiceIdPair = (BroadcastTransaction, ServiceId);
+pub type GetTxServiceIdPair = (GetTx, ServiceId);
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Hash, Display)]
 #[display(Debug)]
 pub struct InternalId(u32);

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -692,7 +692,7 @@ fn bitcoin_syncer_abort_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(0),
             lifetime: blocks + 10,
-            hash: bitcoin::Txid::from_slice(&vec![0; 32]).unwrap().into(),
+            hash: bitcoin::Txid::from_slice(&[0; 32]).unwrap().into(),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -740,7 +740,7 @@ fn bitcoin_syncer_abort_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(0),
             lifetime: blocks + 10,
-            hash: bitcoin::Txid::from_slice(&vec![0; 32]).unwrap().into(),
+            hash: bitcoin::Txid::from_slice(&[0; 32]).unwrap().into(),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),
@@ -755,7 +755,7 @@ fn bitcoin_syncer_abort_test() {
         task: Task::WatchTransaction(WatchTransaction {
             id: TaskId(1),
             lifetime: blocks + 10,
-            hash: bitcoin::Txid::from_slice(&vec![0; 32]).unwrap().into(),
+            hash: bitcoin::Txid::from_slice(&[0; 32]).unwrap().into(),
             confirmation_bound: 2,
         }),
         source: SOURCE1.clone(),

--- a/tests/grpc.rs
+++ b/tests/grpc.rs
@@ -15,6 +15,7 @@ use utils::{config, fc::*};
 
 mod utils;
 
+#[allow(clippy::all)]
 pub mod farcaster {
     tonic::include_proto!("farcaster");
 }
@@ -136,7 +137,7 @@ async fn grpc_server_functional_test() {
     // Test take deal
     let take_request = TakeRequest {
         id: 5,
-        deal: deal,
+        deal,
         bitcoin_address: btc_address.to_string(),
         monero_address: xmr_address.to_string(),
     };
@@ -192,7 +193,7 @@ async fn grpc_server_functional_test() {
     let btc_address = bitcoin_rpc.get_new_address(None, None).unwrap();
     let take_request = TakeRequest {
         id: 5,
-        deal: deal,
+        deal,
         bitcoin_address: btc_address.to_string(),
         monero_address: xmr_address.to_string(),
     };

--- a/tests/large_tx_serialization.rs
+++ b/tests/large_tx_serialization.rs
@@ -11,7 +11,7 @@ fn strict_encode_test() {
     let vec_tx = hex::decode(tx).unwrap();
     assert!(vec_tx.len() > 65535);
     let val = vec![];
-    assert!(vec_tx.clone().strict_encode(val).is_err());
+    assert!(vec_tx.strict_encode(val).is_err());
     let chunks: Vec<Vec<u8>> = vec_tx.chunks(65534).map(|c| c.to_vec()).collect();
     for chunk in chunks.iter() {
         let val = vec![];

--- a/tests/monero.rs
+++ b/tests/monero.rs
@@ -387,13 +387,13 @@ async fn monero_syncer_address_test() {
         let message = rx_event.recv_multipart(0).unwrap();
         info!("received address transaction message");
         let request = misc::get_request_from_message(message);
-        assert::address_transaction(request, 1, vec![tx_id2_1.clone(), tx_id2_2.clone()]);
+        assert::address_transaction(request, 1, vec![tx_id2_1, tx_id2_2]);
 
         info!("waiting for address transaction message");
         let message = rx_event.recv_multipart(0).unwrap();
         info!("received address transaction message");
         let request = misc::get_request_from_message(message);
-        assert::address_transaction(request, 1, vec![tx_id2_1.clone(), tx_id2_2.clone()]);
+        assert::address_transaction(request, 1, vec![tx_id2_1, tx_id2_2]);
 
         let addendum_3 = AddressAddendum::Monero(XmrAddressAddendum {
             address: address2,
@@ -415,13 +415,13 @@ async fn monero_syncer_address_test() {
         let message = rx_event.recv_multipart(0).unwrap();
         info!("received address transaction message");
         let request = misc::get_request_from_message(message);
-        assert::address_transaction(request, 1, vec![tx_id2_1.clone(), tx_id2_2.clone()]);
+        assert::address_transaction(request, 1, vec![tx_id2_1, tx_id2_2]);
 
         info!("waiting for address transaction message");
         let message = rx_event.recv_multipart(0).unwrap();
         info!("received address transaction message");
         let request = misc::get_request_from_message(message);
-        assert::address_transaction(request, 1, vec![tx_id2_1.clone(), tx_id2_2.clone()]);
+        assert::address_transaction(request, 1, vec![tx_id2_1, tx_id2_2]);
 
         let (address4, view_key4) = new_address(&wallet).await;
 
@@ -460,7 +460,7 @@ async fn monero_syncer_address_test() {
             let message = rx_event.recv_multipart(0).unwrap();
             info!("received repeated address transaction message {}", i);
             let request = misc::get_request_from_message(message);
-            assert::address_transaction(request, 1, vec![tx_id4.clone()]);
+            assert::address_transaction(request, 1, vec![tx_id4]);
         }
 
         // generate an address, send Monero to it and ensure that the first transaction sent to it does not show up
@@ -508,7 +508,7 @@ async fn monero_syncer_address_test() {
         let message = rx_event.recv_multipart(0).unwrap();
         info!("received address transaction message");
         let request = misc::get_request_from_message(message);
-        assert::address_transaction(request, 2, vec![tx_id5_2.clone()]);
+        assert::address_transaction(request, 2, vec![tx_id5_2]);
 
         let tx_id5_2_3 = send_monero(&wallet, address5, 2).await;
         regtest.generate_blocks(1, address.address).await.unwrap();
@@ -516,7 +516,7 @@ async fn monero_syncer_address_test() {
         let message = rx_event.recv_multipart(0).unwrap();
         info!("received address transaction message");
         let request = misc::get_request_from_message(message);
-        assert::address_transaction(request, 2, vec![tx_id5_2_3.clone()]);
+        assert::address_transaction(request, 2, vec![tx_id5_2_3]);
 
         let (address6, view_key6) = new_address(&wallet).await;
         let addendum_6 = AddressAddendum::Monero(XmrAddressAddendum {

--- a/tests/tooling.rs
+++ b/tests/tooling.rs
@@ -8,7 +8,7 @@ mod utils;
 #[test]
 fn tooling_cfg_node_with_proto_serde() {
     let s = "---\nhost: \"localhost\"\nport: 123\nprotocol: \"http\"\n";
-    let node: NodeConfig = serde_yaml::from_str(&s).unwrap();
+    let node: NodeConfig = serde_yaml::from_str(s).unwrap();
     assert_eq!(
         node,
         NodeConfig {
@@ -33,7 +33,7 @@ fn tooling_cfg_node_with_proto_display() {
 #[test]
 fn tooling_cfg_node_without_proto_serde() {
     let s = "---\nhost: \"localhost\"\nport: 123\n";
-    let node: NodeConfig = serde_yaml::from_str(&s).unwrap();
+    let node: NodeConfig = serde_yaml::from_str(s).unwrap();
     assert_eq!(
         node,
         NodeConfig {

--- a/tests/utils/config.rs
+++ b/tests/utils/config.rs
@@ -20,7 +20,7 @@ struct FullConfig {
     compose: TestConfig,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(crate = "serde_crate")]
 pub struct TestConfig {
     pub bitcoin: BitcoinConfig,
@@ -47,7 +47,7 @@ impl TestConfig {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(crate = "serde_crate")]
 pub struct NodeConfig {
     pub host: String,
@@ -64,7 +64,7 @@ impl fmt::Display for NodeConfig {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(crate = "serde_crate")]
 pub struct BitcoinConfig {
     pub daemon: NodeConfig,
@@ -79,7 +79,7 @@ impl BitcoinConfig {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(crate = "serde_crate")]
 pub struct BitcoinAuthConfig {
     pub cookie: Option<String>,
@@ -103,7 +103,7 @@ impl BitcoinAuthConfig {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(crate = "serde_crate")]
 pub struct MoneroConfig {
     pub daemon: NodeConfig,
@@ -142,14 +142,14 @@ impl From<WalletIndex> for usize {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(crate = "serde_crate")]
 pub struct GrpcConfig {
     pub fc1: GrpcNode,
     pub fc2: GrpcNode,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(crate = "serde_crate")]
 pub struct GrpcNode {
     pub host: String,

--- a/tests/utils/fc.rs
+++ b/tests/utils/fc.rs
@@ -213,7 +213,7 @@ pub fn run(
         .to_string()
         .lines()
         .map(|line| {
-            let plain_bytes = strip_ansi_escapes::strip(&line).unwrap();
+            let plain_bytes = strip_ansi_escapes::strip(line).unwrap();
             str::from_utf8(&plain_bytes).unwrap().to_string()
         })
         .collect();
@@ -221,7 +221,7 @@ pub fn run(
         .to_string()
         .lines()
         .map(|line| {
-            let plain_bytes = strip_ansi_escapes::strip(&line).unwrap();
+            let plain_bytes = strip_ansi_escapes::strip(line).unwrap();
             str::from_utf8(&plain_bytes).unwrap().to_string()
         })
         .collect();

--- a/tests/utils/misc.rs
+++ b/tests/utils/misc.rs
@@ -13,7 +13,7 @@ pub fn get_request_from_message(message: Vec<Vec<u8>>) -> BusMsg {
     let mut transcoder = PlainTranscoder {};
     let routed_message = recv_routed(message);
     let plain_message = transcoder.decrypt(routed_message.msg).unwrap();
-    (&*unmarshaller.unmarshall(&*plain_message).unwrap()).clone()
+    (*unmarshaller.unmarshall(&*plain_message).unwrap()).clone()
 }
 
 // as taken from the rust-internet2 crate - for now we only use the message
@@ -30,7 +30,7 @@ pub fn recv_routed(message: std::vec::Vec<std::vec::Vec<u8>>) -> RoutedFrame {
         panic!("multipart message empty");
     }
     let len = msg.len();
-    if len > MAX_FRAME_SIZE as usize {
+    if len > MAX_FRAME_SIZE {
         panic!(
             "multipart message frame
 size too big"


### PR DESCRIPTION
Patches some left over clippy warnings and makes the github workflows error again if they detect a clippy or rustc linter finding.