### PR TITLE
Cli: health check ignore local by default

### DIFF
--- a/src/bus/types.rs
+++ b/src/bus/types.rs
@@ -273,8 +273,22 @@ impl FromStr for HealthCheckSelector {
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-#[display(HealthReport::to_yaml_string)]
-pub struct HealthReport {
+#[display(DefaultHealthReport::to_yaml_string)]
+pub struct DefaultHealthReport {
+    pub bitcoin_mainnet_health: Health,
+    pub bitcoin_testnet_health: Health,
+    pub monero_mainnet_health: Health,
+    pub monero_testnet_health: Health,
+}
+
+#[derive(Clone, Debug, Display, NetworkEncode, NetworkDecode)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
+#[display(CompleteHealthReport::to_yaml_string)]
+pub struct CompleteHealthReport {
     pub bitcoin_mainnet_health: Health,
     pub bitcoin_testnet_health: Health,
     pub bitcoin_local_health: Health,
@@ -296,6 +310,8 @@ pub struct ReducedHealthReport {
 }
 
 #[cfg(feature = "serde")]
-impl ToYamlString for HealthReport {}
+impl ToYamlString for DefaultHealthReport {}
+#[cfg(feature = "serde")]
+impl ToYamlString for CompleteHealthReport {}
 #[cfg(feature = "serde")]
 impl ToYamlString for ReducedHealthReport {}

--- a/src/cli/opts.rs
+++ b/src/cli/opts.rs
@@ -104,14 +104,16 @@ pub enum Command {
         select: CheckpointSelector,
     },
 
-    /// Checks the health of the syncers
+    /// Checks the health of the syncers. By default 'mainnet' and 'testnet' are checked, use the
+    /// selector to change this behavior.
     #[clap(aliases = &["hc"])]
     HealthCheck {
         #[clap(
-            default_value = "all",
+            short,
+            long,
             possible_values = &["Mainnet", "mainnet", "Testnet", "testnet", "Local", "local", "all", "All"]
         )]
-        selector: HealthCheckSelector,
+        selector: Option<HealthCheckSelector>,
     },
 
     /// Restores saved checkpoint of a swap


### PR DESCRIPTION
Closes #825

By default no `local` configuration is provided, and local is only use in automated testing envs.

```
swap-cli health-check              <  check only mainnet and testnet
swap-cli health-check -s all       <  check all
swap-cli health-check -s {net}     < check only net
```