### PR TITLE
Logs: move syncer state transitions logs to debug level

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -28,6 +28,7 @@ pub trait StateMachineExecutor<
         let event = Event::with(endpoints, runtime.identity(), source, request);
         let sm_display = sm.to_string();
         let sm_name = sm.name();
+        let sm_log_level = sm.log_level();
         if let Some(new_sm) = sm.next(event, runtime)? {
             let new_sm_display = new_sm.to_string();
             // relegate state transitions staying the same to debug
@@ -38,7 +39,8 @@ pub trait StateMachineExecutor<
                     new_sm.bright_green_bold()
                 );
             } else {
-                info!(
+                log!(
+                    new_sm.log_level(),
                     "{} state transition {} -> {}",
                     new_sm.name(),
                     sm_display.red_bold(),
@@ -47,7 +49,8 @@ pub trait StateMachineExecutor<
             }
             Ok(Some(new_sm))
         } else {
-            info!(
+            log!(
+                sm_log_level,
                 "{} state machine ended {} -> {}",
                 sm_name,
                 sm_display.red_bold(),
@@ -70,7 +73,13 @@ where
     where
         Self: Sized;
 
+    /// Return the display name of the state machine
     fn name(&self) -> String;
+
+    /// Return the log level to use for state transitions. Info by default
+    fn log_level(&self) -> log::Level {
+        log::Level::Info
+    }
 }
 
 /// Event changing state machine state, consisting of a certain P2P or RPC `request` sent from some

--- a/src/farcasterd/syncer_state_machine.rs
+++ b/src/farcasterd/syncer_state_machine.rs
@@ -90,6 +90,10 @@ impl StateMachine<Runtime, Error> for SyncerStateMachine {
     fn name(&self) -> String {
         "Syncer".to_string()
     }
+
+    fn log_level(&self) -> log::Level {
+        log::Level::Debug
+    }
 }
 
 pub struct SyncerStateMachineExecutor {}


### PR DESCRIPTION
Adds a new function that defaults to info level (same as previous behavior) and implements it with debug level for syncer state machine.

This is done to improve logs because health check task creates a lot of syncers, so a node connected with a GUI will generate a lot of noise.