### PR TITLE
Syncer: Remove Boolean type and replace with raw type

### DIFF
--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -48,7 +48,7 @@ use crate::{
         swap_key_manager::{HandleBuyProcedureSignatureRes, HandleRefundProcedureSignaturesRes},
         syncer_client::{log_tx_created, log_tx_seen},
     },
-    syncerd::{Abort, Boolean, SweepSuccess, Task, TaskTarget, TransactionConfirmations},
+    syncerd::{Abort, SweepSuccess, Task, TaskTarget, TransactionConfirmations},
     Endpoints, Error,
 };
 use crate::{
@@ -1355,7 +1355,7 @@ fn try_bob_cancel_final_to_swap_end(
                 Some(&TxLabel::Refund) => {
                     let abort_all = Task::Abort(Abort {
                         task_target: TaskTarget::AllTasks,
-                        respond: Boolean::False,
+                        respond: false,
                     });
                     event.send_sync_service(
                         runtime.syncer_state.monero_syncer(),
@@ -1376,7 +1376,7 @@ fn try_bob_cancel_final_to_swap_end(
                 Some(&TxLabel::Punish) => {
                     let abort_all = Task::Abort(Abort {
                         task_target: TaskTarget::AllTasks,
-                        respond: Boolean::False,
+                        respond: false,
                     });
                     event.send_sync_service(
                         runtime.syncer_state.monero_syncer(),
@@ -1901,7 +1901,7 @@ fn try_alice_buy_procedure_signature_to_swap_end(
         {
             let abort_all = Task::Abort(Abort {
                 task_target: TaskTarget::AllTasks,
-                respond: Boolean::False,
+                respond: false,
             });
             event.send_sync_service(
                 runtime.syncer_state.monero_syncer(),
@@ -1972,7 +1972,7 @@ fn try_alice_canceled_to_alice_refund_or_alice_punish(
                 {
                     let abort_all = Task::Abort(Abort {
                         task_target: TaskTarget::AllTasks,
-                        respond: Boolean::False,
+                        respond: false,
                     });
                     event.send_sync_service(
                         runtime.syncer_state.monero_syncer(),
@@ -2080,7 +2080,7 @@ fn try_alice_canceled_to_alice_refund_or_alice_punish(
                         }
                         let abort_all = Task::Abort(Abort {
                             task_target: TaskTarget::AllTasks,
-                            respond: Boolean::False,
+                            respond: false,
                         });
                         event.send_sync_service(
                             runtime.syncer_state.monero_syncer(),
@@ -2153,7 +2153,7 @@ fn try_alice_refund_sweeping_to_swap_end(
             }
             let abort_all = Task::Abort(Abort {
                 task_target: TaskTarget::AllTasks,
-                respond: Boolean::False,
+                respond: false,
             });
             event.send_sync_service(
                 runtime.syncer_state.monero_syncer(),
@@ -2194,7 +2194,7 @@ fn try_bob_buy_sweeping_to_swap_end(
             }
             let abort_all = Task::Abort(Abort {
                 task_target: TaskTarget::AllTasks,
-                respond: Boolean::False,
+                respond: false,
             });
             event.send_sync_service(
                 runtime.syncer_state.monero_syncer(),

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -8,8 +8,8 @@ use crate::{
     bus::ServiceBus,
     service::{Endpoints, LogStyle},
     syncerd::{
-        Abort, AddressAddendum, Boolean, BroadcastTransaction, BtcAddressAddendum, GetTx,
-        SweepAddress, SweepAddressAddendum, SweepBitcoinAddress, SweepMoneroAddress, TaskTarget,
+        Abort, AddressAddendum, BroadcastTransaction, BtcAddressAddendum, GetTx, SweepAddress,
+        SweepAddressAddendum, SweepBitcoinAddress, SweepMoneroAddress, TaskTarget,
         TransactionBroadcasted, TxFilter, Txid, WatchAddress, WatchEstimateFee, WatchHeight,
         WatchTransaction, XmrAddressAddendum,
     },
@@ -97,7 +97,7 @@ impl SyncerState {
     pub fn abort_task(&mut self, id: TaskId) -> Task {
         Task::Abort(Abort {
             task_target: TaskTarget::TaskId(id),
-            respond: Boolean::False,
+            respond: false,
         })
     }
 
@@ -200,7 +200,7 @@ impl SyncerState {
             id,
             lifetime: self.task_lifetime(Blockchain::Bitcoin),
             addendum: AddressAddendum::Bitcoin(addendum),
-            include_tx: Boolean::True,
+            include_tx: true,
             filter,
         });
         self.tasks.tasks.insert(id, task.clone());
@@ -258,7 +258,7 @@ impl SyncerState {
             id,
             lifetime: self.task_lifetime(Blockchain::Monero),
             addendum: AddressAddendum::Monero(addendum),
-            include_tx: Boolean::False,
+            include_tx: false,
             filter: TxFilter::Incoming,
         };
         let task = Task::WatchAddress(watch_addr);

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -13,7 +13,7 @@ use crate::syncerd::runtime::SyncerdTask;
 use crate::syncerd::runtime::Synclet;
 use crate::syncerd::syncer_state::{AddressTx, BalanceServiceIdPair, TransactionServiceIdPair};
 use crate::syncerd::syncer_state::{GetTxServiceIdPair, SyncerState};
-use crate::syncerd::types::{AddressAddendum, Boolean, SweepAddressAddendum, Task};
+use crate::syncerd::types::{AddressAddendum, SweepAddressAddendum, Task};
 use crate::syncerd::BtcAddressAddendum;
 use crate::syncerd::Event;
 use crate::syncerd::FeeEstimations;
@@ -650,12 +650,8 @@ async fn run_syncerd_task_receiver(
                         },
                         Task::Abort(task) => {
                             let mut state_guard = state.lock().await;
-                            let respond = match task.respond {
-                                Boolean::True => true,
-                                Boolean::False => false,
-                            };
                             state_guard
-                                .abort(task.task_target, syncerd_task.source, respond)
+                                .abort(task.task_target, syncerd_task.source, task.respond)
                                 .await;
                             drop(state_guard);
                         }

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -15,7 +15,7 @@ use crate::syncerd::runtime::Synclet;
 use crate::syncerd::syncer_state::create_set;
 use crate::syncerd::syncer_state::AddressTx;
 use crate::syncerd::syncer_state::SyncerState;
-use crate::syncerd::types::{AddressAddendum, Boolean, SweepAddressAddendum, Task};
+use crate::syncerd::types::{AddressAddendum, SweepAddressAddendum, Task};
 use crate::syncerd::TaskTarget;
 use crate::syncerd::TransactionBroadcasted;
 use crate::syncerd::XmrAddressAddendum;
@@ -485,12 +485,8 @@ async fn run_syncerd_task_receiver(
                         },
                         Task::Abort(task) => {
                             let mut state_guard = state.lock().await;
-                            let respond = match task.respond {
-                                Boolean::True => true,
-                                Boolean::False => false,
-                            };
                             state_guard
-                                .abort(task.task_target, syncerd_task.source, respond)
+                                .abort(task.task_target, syncerd_task.source, task.respond)
                                 .await;
                         }
                         Task::BroadcastTransaction(task) => {

--- a/src/syncerd/syncer_state.rs
+++ b/src/syncerd/syncer_state.rs
@@ -955,14 +955,14 @@ async fn syncer_state_addresses() {
         id: TaskId(0),
         lifetime: 1,
         addendum: addendum.clone(),
-        include_tx: Boolean::False,
+        include_tx: false,
         filter: TxFilter::All,
     };
     let address_task_two = WatchAddress {
         id: TaskId(0),
         lifetime: 1,
         addendum: addendum.clone(),
-        include_tx: Boolean::False,
+        include_tx: false,
         filter: TxFilter::All,
     };
     let source1 = ServiceId::Syncer(Blockchain::Bitcoin, Network::Mainnet);

--- a/src/syncerd/types.rs
+++ b/src/syncerd/types.rs
@@ -136,7 +136,7 @@ pub struct SweepBitcoinAddress {
 #[display(Debug)]
 pub struct Abort {
     pub task_target: TaskTarget,
-    pub respond: Boolean,
+    pub respond: bool,
 }
 
 #[derive(Clone, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
@@ -173,7 +173,7 @@ pub struct WatchAddress {
     pub id: TaskId,
     pub lifetime: u64,
     pub addendum: AddressAddendum,
-    pub include_tx: Boolean,
+    pub include_tx: bool,
     pub filter: TxFilter,
 }
 
@@ -188,27 +188,6 @@ pub enum TxFilter {
     Incoming,
     Outgoing,
     All,
-}
-
-#[derive(Clone, Debug, Display, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(crate = "serde_crate")
-)]
-#[display(Debug)]
-pub enum Boolean {
-    True,
-    False,
-}
-
-impl From<Boolean> for bool {
-    fn from(w: Boolean) -> bool {
-        match w {
-            Boolean::True => true,
-            Boolean::False => false,
-        }
-    }
 }
 
 #[derive(Clone, Display, Debug, StrictEncode, StrictDecode, Eq, PartialEq, Hash)]

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -8,7 +8,7 @@ use farcaster_node::syncerd::bitcoin_syncer::BitcoinSyncer;
 use farcaster_node::syncerd::opts::Opts;
 use farcaster_node::syncerd::runtime::SyncerdTask;
 use farcaster_node::syncerd::types::{
-    Abort, AddressAddendum, Boolean, BroadcastTransaction, BtcAddressAddendum, GetTx, SweepAddress,
+    Abort, AddressAddendum, BroadcastTransaction, BtcAddressAddendum, GetTx, SweepAddress,
     SweepAddressAddendum, Task, WatchAddress, WatchEstimateFee, WatchHeight, WatchTransaction,
 };
 use farcaster_node::syncerd::{runtime::Synclet, TaskId, TaskTarget};
@@ -240,7 +240,7 @@ fn bitcoin_syncer_address_test() {
             id: TaskId(1),
             lifetime: blocks + 1,
             addendum: addendum_1,
-            include_tx: Boolean::True,
+            include_tx: true,
             filter: TxFilter::All,
         }),
         source: SOURCE1.clone(),
@@ -256,7 +256,7 @@ fn bitcoin_syncer_address_test() {
             id: TaskId(1),
             lifetime: blocks + 2,
             addendum: addendum_2.clone(),
-            include_tx: Boolean::True,
+            include_tx: true,
             filter: TxFilter::All,
         }),
         source: SOURCE1.clone(),
@@ -318,7 +318,7 @@ fn bitcoin_syncer_address_test() {
             id: TaskId(1),
             lifetime: blocks + 2,
             addendum: addendum_2,
-            include_tx: Boolean::True,
+            include_tx: true,
             filter: TxFilter::All,
         }),
         source: SOURCE1.clone(),
@@ -345,7 +345,7 @@ fn bitcoin_syncer_address_test() {
                 id: TaskId(i),
                 lifetime: blocks + 5,
                 addendum: addendum_4.clone(),
-                include_tx: Boolean::True,
+                include_tx: true,
                 filter: TxFilter::All,
             }),
             source: SOURCE1.clone(),
@@ -659,7 +659,7 @@ fn bitcoin_syncer_abort_test() {
     let task = SyncerdTask {
         task: Task::Abort(Abort {
             task_target: TaskTarget::TaskId(TaskId(0)),
-            respond: Boolean::True,
+            respond: true,
         }),
         source: SOURCE1.clone(),
     };
@@ -673,7 +673,7 @@ fn bitcoin_syncer_abort_test() {
     let task = SyncerdTask {
         task: Task::Abort(Abort {
             task_target: TaskTarget::TaskId(TaskId(0)),
-            respond: Boolean::True,
+            respond: true,
         }),
         source: SOURCE1.clone(),
     };
@@ -721,7 +721,7 @@ fn bitcoin_syncer_abort_test() {
     let task = SyncerdTask {
         task: Task::Abort(Abort {
             task_target: TaskTarget::AllTasks,
-            respond: Boolean::True,
+            respond: true,
         }),
         source: SOURCE1.clone(),
     };
@@ -735,7 +735,7 @@ fn bitcoin_syncer_abort_test() {
     let task = SyncerdTask {
         task: Task::Abort(Abort {
             task_target: TaskTarget::TaskId(TaskId(0)),
-            respond: Boolean::True,
+            respond: true,
         }),
         source: SOURCE1.clone(),
     };

--- a/tests/monero.rs
+++ b/tests/monero.rs
@@ -5,7 +5,7 @@ use farcaster_node::syncerd::monero_syncer::MoneroSyncer;
 use farcaster_node::syncerd::opts::Opts;
 use farcaster_node::syncerd::runtime::SyncerdTask;
 use farcaster_node::syncerd::types::{
-    Abort, AddressAddendum, Boolean, BroadcastTransaction, Task, Txid, WatchAddress, WatchHeight,
+    Abort, AddressAddendum, BroadcastTransaction, Task, Txid, WatchAddress, WatchHeight,
     WatchTransaction,
 };
 use farcaster_node::syncerd::{
@@ -333,7 +333,7 @@ async fn monero_syncer_address_test() {
                 id: TaskId(1),
                 lifetime: blocks + 1,
                 addendum: addendum_1.clone(),
-                include_tx: Boolean::True,
+                include_tx: true,
                 filter: TxFilter::Incoming,
             }),
             source: SOURCE1.clone(),
@@ -376,7 +376,7 @@ async fn monero_syncer_address_test() {
                 id: TaskId(1),
                 lifetime: blocks + 1,
                 addendum: addendum_2,
-                include_tx: Boolean::True,
+                include_tx: true,
                 filter: TxFilter::Incoming,
             }),
             source: SOURCE1.clone(),
@@ -405,7 +405,7 @@ async fn monero_syncer_address_test() {
                 id: TaskId(1),
                 lifetime: blocks + 1,
                 addendum: addendum_3,
-                include_tx: Boolean::True,
+                include_tx: true,
                 filter: TxFilter::Incoming,
             }),
             source: SOURCE1.clone(),
@@ -447,7 +447,7 @@ async fn monero_syncer_address_test() {
                     id: TaskId(i),
                     lifetime: blocks + 5,
                     addendum: addendum_4.clone(),
-                    include_tx: Boolean::True,
+                    include_tx: true,
                     filter: TxFilter::Incoming,
                 }),
                 source: SOURCE2.clone(),
@@ -487,7 +487,7 @@ async fn monero_syncer_address_test() {
                 id: TaskId(5),
                 lifetime: blocks + 5,
                 addendum: addendum_5.clone(),
-                include_tx: Boolean::True,
+                include_tx: true,
                 filter: TxFilter::Incoming,
             }),
             source: SOURCE2.clone(),
@@ -529,7 +529,7 @@ async fn monero_syncer_address_test() {
                 id: TaskId(1),
                 lifetime: blocks + 2,
                 addendum: addendum_6.clone(),
-                include_tx: Boolean::True,
+                include_tx: true,
                 filter: TxFilter::Incoming,
             }),
             source: SOURCE1.clone(),
@@ -554,7 +554,7 @@ async fn monero_syncer_address_test() {
                 id: TaskId(1),
                 lifetime: blocks + 2,
                 addendum: addendum_6,
-                include_tx: Boolean::True,
+                include_tx: true,
                 filter: TxFilter::Incoming,
             }),
             source: SOURCE1.clone(),
@@ -798,7 +798,7 @@ async fn monero_syncer_abort_test() {
     let task = SyncerdTask {
         task: Task::Abort(Abort {
             task_target: TaskTarget::TaskId(TaskId(0)),
-            respond: Boolean::True,
+            respond: true,
         }),
         source: SOURCE2.clone(),
     };
@@ -812,7 +812,7 @@ async fn monero_syncer_abort_test() {
     let task = SyncerdTask {
         task: Task::Abort(Abort {
             task_target: TaskTarget::TaskId(TaskId(0)),
-            respond: Boolean::True,
+            respond: true,
         }),
         source: SOURCE2.clone(),
     };
@@ -856,7 +856,7 @@ async fn monero_syncer_abort_test() {
     let task = SyncerdTask {
         task: Task::Abort(Abort {
             task_target: TaskTarget::AllTasks,
-            respond: Boolean::True,
+            respond: true,
         }),
         source: SOURCE2.clone(),
     };
@@ -870,7 +870,7 @@ async fn monero_syncer_abort_test() {
     let task = SyncerdTask {
         task: Task::Abort(Abort {
             task_target: TaskTarget::TaskId(TaskId(0)),
-            respond: Boolean::True,
+            respond: true,
         }),
         source: SOURCE2.clone(),
     };


### PR DESCRIPTION
This was a remnant from when we used farcaster core consensus encoding for the syncer types.