### PR TITLE
Ci: fix ref to wiki sync action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Sync docs to wiki
-        uses: newrelic/wiki-sync-action@master
+        uses: newrelic/wiki-sync-action@main
         with:
           source: docs
           destination: wiki
@@ -40,7 +40,7 @@ jobs:
           token: ${{ secrets.DOC_SYNC_TOKEN }} # allows us to push back to repo
           ref: main
       - name: Sync Wiki to Docs
-        uses: newrelic/wiki-sync-action@master
+        uses: newrelic/wiki-sync-action@main
         with:
           source: wiki
           destination: docs


### PR DESCRIPTION
Upstream default branch as changed from `master` to `main`, warning are thrown in CI and it seems that wiki -> doc doesn't work as expected...