### PR TITLE
Swap: Add swap logging to syncer client

### DIFF
--- a/src/swapd/mod.rs
+++ b/src/swapd/mod.rs
@@ -15,7 +15,6 @@ mod temporal_safety;
 
 #[cfg(feature = "shell")]
 pub use opts::Opts;
-pub use runtime::get_swap_id;
 pub use runtime::run;
 pub use runtime::CheckpointSwapd;
 pub use state_report::StateReport;

--- a/src/swapd/swap_key_manager.rs
+++ b/src/swapd/swap_key_manager.rs
@@ -46,7 +46,7 @@ use crate::{
     Error, LogStyle, ServiceId,
 };
 
-use super::runtime::Runtime;
+use super::runtime::{Runtime, SwapLogging};
 
 pub struct HandleRefundProcedureSignaturesRes {
     pub buy_procedure_signature: BuyProcedureSignature,

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -634,10 +634,10 @@ fn attempt_transition_to_init_taker(
             // start watching block height changes
             runtime
                 .syncer_state
-                .watch_height(event.endpoints, Blockchain::Bitcoin)?;
+                .watch_height(event.endpoints, Blockchain::Bitcoin, runtime.swap_id)?;
             runtime
                 .syncer_state
-                .watch_height(event.endpoints, Blockchain::Monero)?;
+                .watch_height(event.endpoints, Blockchain::Monero, runtime.swap_id)?;
             runtime.peer_service = peerd.clone();
             if let ServiceId::Peer(0, _) = runtime.peer_service {
                 runtime.connected = false;
@@ -735,10 +735,10 @@ fn attempt_transition_to_init_maker(
             // start watching block height changes
             runtime
                 .syncer_state
-                .watch_height(event.endpoints, Blockchain::Bitcoin)?;
+                .watch_height(event.endpoints, Blockchain::Bitcoin, runtime.swap_id)?;
             runtime
                 .syncer_state
-                .watch_height(event.endpoints, Blockchain::Monero)?;
+                .watch_height(event.endpoints, Blockchain::Monero, runtime.swap_id)?;
             runtime.peer_service = peerd;
             if runtime.peer_service != ServiceId::Loopback {
                 runtime.connected = true;
@@ -2155,7 +2155,7 @@ fn attempt_transition_to_bob_reveal(
             }
 
             // start watching bitcoin fee estimate
-            runtime.syncer_state.watch_bitcoin_fee(event.endpoints)?;
+            runtime.syncer_state.watch_bitcoin_fee(event.endpoints, runtime.swap_id)?;
 
             Ok(Some(SwapStateMachine::BobReveal(BobReveal {
                 remote_params,

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -56,7 +56,7 @@ use crate::{
 };
 
 use super::{
-    runtime::Runtime,
+    runtime::{Runtime, SwapLogging},
     swap_key_manager::{
         AliceSwapKeyManager, AliceTxs, BobSwapKeyManager, BobTxs, WrappedEncryptedSignature,
     },
@@ -634,10 +634,10 @@ fn attempt_transition_to_init_taker(
             // start watching block height changes
             runtime
                 .syncer_state
-                .watch_height(event.endpoints, Blockchain::Bitcoin, runtime.swap_id)?;
+                .watch_height(event.endpoints, Blockchain::Bitcoin)?;
             runtime
                 .syncer_state
-                .watch_height(event.endpoints, Blockchain::Monero, runtime.swap_id)?;
+                .watch_height(event.endpoints, Blockchain::Monero)?;
             runtime.peer_service = peerd.clone();
             if let ServiceId::Peer(0, _) = runtime.peer_service {
                 runtime.connected = false;
@@ -735,10 +735,10 @@ fn attempt_transition_to_init_maker(
             // start watching block height changes
             runtime
                 .syncer_state
-                .watch_height(event.endpoints, Blockchain::Bitcoin, runtime.swap_id)?;
+                .watch_height(event.endpoints, Blockchain::Bitcoin)?;
             runtime
                 .syncer_state
-                .watch_height(event.endpoints, Blockchain::Monero, runtime.swap_id)?;
+                .watch_height(event.endpoints, Blockchain::Monero)?;
             runtime.peer_service = peerd;
             if runtime.peer_service != ServiceId::Loopback {
                 runtime.connected = true;
@@ -2155,7 +2155,7 @@ fn attempt_transition_to_bob_reveal(
             }
 
             // start watching bitcoin fee estimate
-            runtime.syncer_state.watch_bitcoin_fee(event.endpoints, runtime.swap_id)?;
+            runtime.syncer_state.watch_bitcoin_fee(event.endpoints)?;
 
             Ok(Some(SwapStateMachine::BobReveal(BobReveal {
                 remote_params,

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -113,7 +113,7 @@ use super::{
 ///       |_______________________|                                   |                AliceCancel
 ///       |                       |                                   |                     |
 ///       |                       V                                   |         ____________|
-///       V                   BobBuySeen                             |        |            |
+///       V                   BobBuySeen                              |        |            |
 ///   BobCancel                   |                                   |        |            |
 ///       |                       |                                   |        |            |
 ///       |                       V                                   |        V            |

--- a/src/swapd/syncer_client.rs
+++ b/src/swapd/syncer_client.rs
@@ -36,7 +36,6 @@ pub struct SyncerTasks {
     pub retrieving_txs: HashMap<TaskId, TxLabel>,
     pub broadcasting_txs: HashMap<TaskId, TxLabel>,
     pub sweeping_addr: Option<TaskId>,
-    // external address: needed to subscribe for buy (bob) or refund (alice) address_txs
     pub txids: HashMap<TxLabel, bitcoin::Txid>,
     pub tasks: HashMap<TaskId, Task>,
 }


### PR DESCRIPTION
Implements the extended logging currently used in the swapd Runtime as a Trait used by both the Runtime and the syncer client.