### PR TITLE
Ci: fix wiki branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.DOC_SYNC_TOKEN }} # allows us to push back to repo
-          ref: main
+          ref: master
       - name: Sync Wiki to Docs
         uses: newrelic/wiki-sync-action@main
         with:
@@ -47,4 +47,4 @@ jobs:
           token: ${{ secrets.DOC_SYNC_TOKEN }}
           gitAuthorName: ${{ env.GIT_AUTHOR_NAME }}
           gitAuthorEmail: ${{ env.GIT_AUTHOR_EMAIL }}
-          branch: main
+          branch: master


### PR DESCRIPTION
Correct wiki default branch is master.