### PR TITLE
Revert "Ci: fix wiki branch"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.DOC_SYNC_TOKEN }} # allows us to push back to repo
-          ref: master
+          ref: main
       - name: Sync Wiki to Docs
         uses: newrelic/wiki-sync-action@main
         with:
@@ -47,4 +47,4 @@ jobs:
           token: ${{ secrets.DOC_SYNC_TOKEN }}
           gitAuthorName: ${{ env.GIT_AUTHOR_NAME }}
           gitAuthorEmail: ${{ env.GIT_AUTHOR_EMAIL }}
-          branch: master
+          branch: main


### PR DESCRIPTION
Reverts farcaster-project/farcaster-node#902

This branch is for the repo not for the wiki, this was correct. This patch was not needed and breaks the sync.