### PR TITLE
Swapd: Simplify key manager encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "farcaster_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5b55bbe7886bd581992a38ed84cc086e77df3a6c8c6c8c14ca410a0c3e2533c"
+checksum = "9ec02a6337476139784a38ec1204000a8c6cbafd755a5b55da2d6820fa39d955"
 dependencies = [
  "amplify",
  "base58-monero",

--- a/src/swapd/swap_key_manager.rs
+++ b/src/swapd/swap_key_manager.rs
@@ -94,7 +94,7 @@ impl Decodable for WrappedEncryptedSignature {
 }
 impl_strict_encoding!(WrappedEncryptedSignature);
 
-#[derive(Display, Clone, Debug)]
+#[derive(Display, Clone, Debug, StrictEncode, StrictDecode)]
 #[display("Alice's Swap Key Manager")]
 pub struct AliceSwapKeyManager {
     pub alice: Alice,
@@ -103,41 +103,6 @@ pub struct AliceSwapKeyManager {
     pub target_bitcoin_address: bitcoin::Address,
     pub target_monero_address: monero::Address,
 }
-
-impl Encodable for AliceSwapKeyManager {
-    fn consensus_encode<W: io::Write>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let mut len = self.alice.consensus_encode(writer)?;
-        len += self.local_params.consensus_encode(writer)?;
-        len += self.key_manager.consensus_encode(writer)?;
-        len += self
-            .target_bitcoin_address
-            .as_canonical_bytes()
-            .consensus_encode(writer)?;
-        len += self
-            .target_monero_address
-            .as_canonical_bytes()
-            .consensus_encode(writer)?;
-        Ok(len)
-    }
-}
-
-impl Decodable for AliceSwapKeyManager {
-    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Self, consensus::Error> {
-        Ok(AliceSwapKeyManager {
-            alice: Decodable::consensus_decode(d)?,
-            local_params: Decodable::consensus_decode(d)?,
-            key_manager: Decodable::consensus_decode(d)?,
-            target_bitcoin_address: bitcoin::Address::from_canonical_bytes(
-                farcaster_core::unwrap_vec_ref!(d).as_ref(),
-            )?,
-            target_monero_address: monero::Address::from_canonical_bytes(
-                farcaster_core::unwrap_vec_ref!(d).as_ref(),
-            )?,
-        })
-    }
-}
-
-impl_strict_encoding!(AliceSwapKeyManager);
 
 impl AliceSwapKeyManager {
     pub fn new(

--- a/src/swapd/swap_key_manager.rs
+++ b/src/swapd/swap_key_manager.rs
@@ -104,24 +104,6 @@ pub struct AliceSwapKeyManager {
     pub target_monero_address: monero::Address,
 }
 
-impl AliceSwapKeyManager {
-    pub fn new(
-        alice: Alice,
-        local_params: Parameters,
-        key_manager: KeyManager,
-        target_bitcoin_address: bitcoin::Address,
-        target_monero_address: monero::Address,
-    ) -> Self {
-        Self {
-            alice,
-            local_params,
-            key_manager,
-            target_bitcoin_address,
-            target_monero_address,
-        }
-    }
-}
-
 #[derive(Display, Clone, Debug)]
 #[display("Bob's Swap Key Manager")]
 pub struct BobSwapKeyManager {
@@ -168,26 +150,6 @@ impl Decodable for BobSwapKeyManager {
     }
 }
 
-impl BobSwapKeyManager {
-    pub fn new(
-        bob: Bob,
-        local_params: Parameters,
-        key_manager: KeyManager,
-        funding_tx: FundingTx,
-        target_bitcoin_address: bitcoin::Address,
-        target_monero_address: monero::Address,
-    ) -> Self {
-        Self {
-            bob,
-            local_params,
-            key_manager,
-            funding_tx,
-            target_bitcoin_address,
-            target_monero_address,
-        }
-    }
-}
-
 impl_strict_encoding!(BobSwapKeyManager);
 
 impl AliceSwapKeyManager {
@@ -209,14 +171,13 @@ impl AliceSwapKeyManager {
             FeePriority::Low,
         );
         let local_params = alice.generate_parameters(&mut key_manager, &runtime.deal)?;
-        Ok(AliceSwapKeyManager::new(
+        Ok(AliceSwapKeyManager {
             alice,
             local_params,
             key_manager,
-            // None,
             target_bitcoin_address,
             target_monero_address,
-        ))
+        })
     }
 
     pub fn taker_commit(
@@ -256,13 +217,13 @@ impl AliceSwapKeyManager {
         );
         let local_params = alice.generate_parameters(&mut key_manager, &runtime.deal)?;
         runtime.log_info(format!("Loading {}", "Alice Swap Key Manager".label()));
-        Ok(AliceSwapKeyManager::new(
+        Ok(AliceSwapKeyManager {
             alice,
             local_params,
             key_manager,
             target_bitcoin_address,
             target_monero_address,
-        ))
+        })
     }
 
     pub fn maker_commit(
@@ -621,8 +582,8 @@ impl BobSwapKeyManager {
             FeePriority::Low,
         );
         let local_params = bob.generate_parameters(&mut key_manager, &runtime.deal)?;
-        let funding = create_funding(&mut key_manager, deal_parameters.network)?;
-        let funding_addr = funding.get_address()?;
+        let funding_tx = create_funding(&mut key_manager, deal_parameters.network)?;
+        let funding_addr = funding_tx.get_address()?;
         event.send_ctl_service(
             ServiceId::Database,
             CtlMsg::SetAddressSecretKey(AddressSecretKey::Bitcoin {
@@ -634,14 +595,14 @@ impl BobSwapKeyManager {
             }),
         )?;
         runtime.log_info(format!("Loading {}", "Bob's Swap Key Manager".label()));
-        Ok(BobSwapKeyManager::new(
+        Ok(BobSwapKeyManager {
             bob,
             local_params,
             key_manager,
-            funding,
+            funding_tx,
             target_bitcoin_address,
             target_monero_address,
-        ))
+        })
     }
 
     pub fn taker_commit(
@@ -685,8 +646,8 @@ impl BobSwapKeyManager {
             FeePriority::Low,
         );
         let local_params = bob.generate_parameters(&mut key_manager, &runtime.deal)?;
-        let funding = create_funding(&mut key_manager, deal_parameters.network)?;
-        let funding_addr = funding.get_address()?;
+        let funding_tx = create_funding(&mut key_manager, deal_parameters.network)?;
+        let funding_addr = funding_tx.get_address()?;
         event.send_ctl_service(
             ServiceId::Database,
             CtlMsg::SetAddressSecretKey(AddressSecretKey::Bitcoin {
@@ -698,14 +659,14 @@ impl BobSwapKeyManager {
             }),
         )?;
         runtime.log_info(format!("Loading {}", "Bob's Swap Key Manager".label()));
-        Ok(BobSwapKeyManager::new(
+        Ok(BobSwapKeyManager {
             bob,
             local_params,
             key_manager,
-            funding,
+            funding_tx,
             target_bitcoin_address,
             target_monero_address,
-        ))
+        })
     }
 
     pub fn maker_commit(


### PR DESCRIPTION
Also remove new implementations for Alice and Bob key manager.

~Once the funding tx also implements strict decoding, we can get rid of the custom coding implementation on Bob as well.~
Updated core and removed the custom encoding implementation for Bob as well.