### PR TITLE
Chore: update core to version 0.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "farcaster_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec02a6337476139784a38ec1204000a8c6cbafd755a5b55da2d6820fa39d955"
+checksum = "52916156acde2ce728f71d54ada318147f71d256897abf4fe966a3dc53f35c52"
 dependencies = [
  "amplify",
  "base58-monero",
@@ -2062,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"

--- a/src/bus/p2p.rs
+++ b/src/bus/p2p.rs
@@ -8,7 +8,7 @@ use farcaster_core::{
     protocol::message::Abort,
     swap::btcxmr::message::{
         BuyProcedureSignature, CommitAliceParameters, CommitBobParameters, CoreArbitratingSetup,
-        RefundProcedureSignatures, RevealAliceParameters, RevealBobParameters, RevealProof,
+        RefundProcedureSignatures, RevealAliceParameters, RevealBobParameters,
     },
     swap::btcxmr::Deal,
     swap::SwapId,
@@ -137,30 +137,16 @@ impl PeerMsg {
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
 pub enum Reveal {
     #[display("Alice")]
-    Alice {
-        parameters: RevealAliceParameters,
-        proof: RevealProof,
-    },
-
+    Alice(RevealAliceParameters),
     #[display("Bob")]
-    Bob {
-        parameters: RevealBobParameters,
-        proof: RevealProof,
-    },
+    Bob(RevealBobParameters),
 }
 
 impl Reveal {
     pub fn swap_id(&self) -> SwapId {
         match self {
-            Self::Alice { parameters, .. } => parameters.swap_id,
-            Self::Bob { parameters, .. } => parameters.swap_id,
-        }
-    }
-
-    pub fn validate_ids(&self) -> bool {
-        match self {
-            Self::Alice { parameters, proof } => parameters.swap_id == proof.swap_id,
-            Self::Bob { parameters, proof } => parameters.swap_id == proof.swap_id,
+            Self::Alice(p) => p.swap_id,
+            Self::Bob(p) => p.swap_id,
         }
     }
 }

--- a/src/farcasterd/trade_state_machine.rs
+++ b/src/farcasterd/trade_state_machine.rs
@@ -321,7 +321,7 @@ impl TradeStateMachine {
     }
 
     pub fn uuid(&self) -> Option<Uuid> {
-        self.deal().map(|d| d.id().0)
+        self.deal().map(|d| d.id().into())
     }
 
     pub fn trade_role(&self) -> Option<TradeRole> {

--- a/src/swapd/swap_state.rs
+++ b/src/swapd/swap_state.rs
@@ -2201,10 +2201,10 @@ fn attempt_transition_to_bob_reveal(
     mut swap_key_manager: BobSwapKeyManager,
 ) -> Result<Option<SwapStateMachine>, Error> {
     match event.request.clone() {
-        BusMsg::P2p(PeerMsg::Reveal(Reveal::Alice { parameters, proof })) => {
+        BusMsg::P2p(PeerMsg::Reveal(Reveal::Alice(parameters))) => {
             runtime.log_info("Handling reveal with swap_key_manager");
             let (bob_reveal, remote_params) =
-                swap_key_manager.handle_alice_reveals(runtime, parameters, proof, remote_commit)?;
+                swap_key_manager.handle_alice_reveals(runtime, parameters, remote_commit)?;
 
             // The swap_key_manager only returns reveal if we are Bob Maker
             if let Some(bob_reveal) = bob_reveal {
@@ -2231,10 +2231,10 @@ fn attempt_transition_to_alice_reveal(
     mut swap_key_manager: AliceSwapKeyManager,
 ) -> Result<Option<SwapStateMachine>, Error> {
     match event.request {
-        BusMsg::P2p(PeerMsg::Reveal(Reveal::Bob { parameters, proof })) => {
+        BusMsg::P2p(PeerMsg::Reveal(Reveal::Bob(parameters))) => {
             runtime.log_info("Handling reveal with swap_key_manager");
             let (alice_reveal, remote_params) =
-                swap_key_manager.handle_bob_reveals(runtime, parameters, proof, remote_commit)?;
+                swap_key_manager.handle_bob_reveals(runtime, parameters, remote_commit)?;
 
             // The swap_key_manager only returns reveal if we are Alice Maker
             if let Some(alice_reveal) = alice_reveal {


### PR DESCRIPTION
- Use `into()` to convert uuids, closes #914 
- Simplify reveal p2p message: use new merged reveal params and proof message