### PR TITLE
Chore: prepare changelog for release 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Swapd: Don't add color coding to progress message by @TheCharlatan in <https://github.com/farcaster-project/farcaster-node/pull/903>
+- Farcasterd: Add delay between xmr auto-funding reattempts by @Lederstrumpf in <https://github.com/farcaster-project/farcaster-node/pull/733>
+- Swapd: Simplify key manager encoding by @TheCharlatan in <https://github.com/farcaster-project/farcaster-node/pull/906>
+- Swapd: Simplify commitment creation by @TheCharlatan in <https://github.com/farcaster-project/farcaster-node/pull/908>
+- Doc: Update diagrams by @TheCharlatan in <https://github.com/farcaster-project/farcaster-node/pull/911> and <https://github.com/farcaster-project/farcaster-node/pull/909>
+- Swapd: Some simple refactors by @TheCharlatan in <https://github.com/farcaster-project/farcaster-node/pull/913>
+- Config: Improved deal validation by @h4sh3d in <https://github.com/farcaster-project/farcaster-node/pull/910>
+- TSM: Log with SwapLogging trait by @TheCharlatan in <https://github.com/farcaster-project/farcaster-node/pull/912>
+- Chore: update core to version 0.6.4 by @h4sh3d in <https://github.com/farcaster-project/farcaster-node/pull/915>
+
 ## [0.8.2] - 2022-12-28
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "monero"
-version = "0.17.2"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afa5d322a573d345588c3255aaf3316b6a13f3b94f8e776c5ffcde237ec481d"
+checksum = "403883d12972e916dd9754cdb90c25441a9abcf435f8e09c3146de100150eeb0"
 dependencies = [
  "base58-monero",
  "curve25519-dalek",

--- a/farcasterd.toml
+++ b/farcasterd.toml
@@ -41,12 +41,12 @@ monero_rpc_wallet = "http://localhost:38084"
 [swap.bitcoin.mainnet]
 safety = 7
 finality = 6
-min_amount = "0.00001 BTC"
-max_amount = "0.01 BTC"
+min_amount = "0.00001 btc"
+max_amount = "0.01 btc"
 [swap.monero.mainnet]
 finality = 20
-min_amount = "0.001 XMR"
-max_amount = "2 XMR"
+min_amount = "0.001 xmr"
+max_amount = "2 xmr"
 
 # Swap parameter for the Bitcoin blockchain
 [swap.bitcoin.testnet]
@@ -61,18 +61,18 @@ safety = 3
 # smaller than safety.
 finality = 1
 # The minimum acceptable amount of bitcoin to trade
-min_amount = "0.00001 BTC"
+min_amount = "0.00001 btc"
 # The maximum acceptable amount of bitcoin to trade
-max_amount = "1 BTC"
+max_amount = "1 btc"
 
 # Swap parameter for the Monero blockchain
 [swap.monero.testnet]
 # Number of confirmations required to consider a transaction final
 finality = 1
 # The minimum acceptable amount of monero to trade
-min_amount = "0.001 XMR"
+min_amount = "0.001 xmr"
 # The maximum acceptable amount of monero to trade
-max_amount = "20 XMR"
+max_amount = "20 xmr"
 
 # Defines grpc options
 [grpc]


### PR DESCRIPTION
Update changelog and bump `monero` deps to allow lowercase `xmr` amount parsing.