### PR TITLE
Fix(tsm): swaps restoring

### DIFF
--- a/src/farcasterd/runtime.rs
+++ b/src/farcasterd/runtime.rs
@@ -970,11 +970,7 @@ impl Runtime {
         req: &BusMsg,
         source: &ServiceId,
     ) -> Result<Option<Vec<TradeStateMachine>>, Error> {
-        // mutate `tsms` by removing all `tsm` matching the predicate and returning them
-        //
-        // we assume tsm are rather small entities and we can clone them even if
-        // we have a couple thousands of them
-        //
+        // mutate `tsms` by removing all `tsm` matching the predicate and returning them;
         // only returns an array if at least one element match predicate
         fn dummy_drain_filter<P: Fn(&TradeStateMachine) -> bool>(
             tsms: &mut Vec<TradeStateMachine>,


### PR DESCRIPTION
This PR addresses two issues:
- An `event` could affect multiple `tsms`
- When restoring swapd make sure to reuse peerd connection if in `registered_services`

d894fba40dbade85589895bd4e85f91e683f288b only changes `..request_to_tsm` and not `..request_to_ssm` as I don't see any cases where the same issue would apply. This patch would be way cleaner with stabilized `drain_filter` feature, but it's not so... I did an ugly fn :)