### PR TITLE
Fix(state report): accordant lock used arbitrating params

### DIFF
--- a/src/swapd/state_report.rs
+++ b/src/swapd/state_report.rs
@@ -54,7 +54,7 @@ impl StateReport {
             ),
             acc_locked: temp_safety.final_tx(
                 syncer_state.get_confs(TxLabel::AccLock).unwrap_or(0),
-                Blockchain::Bitcoin,
+                Blockchain::Monero,
             ),
             canceled: temp_safety.final_tx(
                 syncer_state.get_confs(TxLabel::Cancel).unwrap_or(0),


### PR DESCRIPTION
Fix the error where the accordant locked boolean was using the arbitrating finality parameters.