### PR TITLE
Swapd: Include buy, refund, and punish confs in state report

### DIFF
--- a/src/swapd/state_report.rs
+++ b/src/swapd/state_report.rs
@@ -32,6 +32,9 @@ pub struct StateReport {
     pub arb_lock_confirmations: Option<u32>,
     pub acc_lock_confirmations: Option<u32>,
     pub cancel_confirmations: Option<u32>,
+    pub refund_confirmations: Option<u32>,
+    pub punish_confirmations: Option<u32>,
+    pub buy_confirmations: Option<u32>,
     pub blocks_until_cancel_possible: Option<i64>,
     pub blocks_until_punish_possible: Option<i64>,
     pub blocks_until_safe_buy: Option<u32>,
@@ -66,6 +69,9 @@ impl StateReport {
             arb_lock_confirmations: syncer_state.get_confs(TxLabel::Lock),
             acc_lock_confirmations: syncer_state.get_confs(TxLabel::AccLock),
             cancel_confirmations: syncer_state.get_confs(TxLabel::Cancel),
+            refund_confirmations: syncer_state.get_confs(TxLabel::Refund),
+            punish_confirmations: syncer_state.get_confs(TxLabel::Punish),
+            buy_confirmations: syncer_state.get_confs(TxLabel::Buy),
             blocks_until_cancel_possible: syncer_state
                 .get_confs(TxLabel::Lock)
                 .map(|confs| temp_safety.blocks_until_cancel(confs)),


### PR DESCRIPTION
This just includes the raw confirmations, but it might be easier to consume if it counts down the finality of the transactions. Do we need to include the finality parameter as well?