### PR TITLE
Syncers: Some address balance fixes

### DIFF
--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -1235,7 +1235,7 @@ fn balance_fetcher(
                             event: Event::AddressBalance(AddressBalance {
                                 id: get_balance.id,
                                 address: Address::Bitcoin(address.clone()),
-                                balance: balance.unconfirmed.unsigned_abs(),
+                                balance: balance.unconfirmed.unsigned_abs() + balance.confirmed,
                                 err: None,
                             }),
                             source,
@@ -1244,7 +1244,7 @@ fn balance_fetcher(
                         .expect("error sending address balance event");
                     debug!(
                         "successfully retrieved balance: {} for address {}.",
-                        balance.unconfirmed.unsigned_abs(),
+                        balance.unconfirmed.unsigned_abs() + balance.confirmed,
                         address
                     );
                 }

--- a/src/syncerd/bitcoin_syncer.rs
+++ b/src/syncerd/bitcoin_syncer.rs
@@ -1261,7 +1261,7 @@ fn balance_fetcher(
                         })
                         .await
                         .expect("error sending address balance event");
-                    debug!("failed to retrieve balance for address {}: {}", address, e);
+                    warn!("failed to retrieve balance for address {}: {}", address, e);
                 }
             }
         }

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -989,14 +989,14 @@ fn balance_fetcher(
                                 id: get_balance.id,
                                 balance: 0,
                                 err: Some(
-                                    "Sent monero address balance to bitcoin syncer".to_string(),
+                                    "Sent bitcoin address balance to monero syncer".to_string(),
                                 ),
                             }),
                             source,
                         })
                         .await
                         .expect("error sending address balance event");
-                    warn!("Received monero address balance task in bitcoin syncer");
+                    warn!("Received bitcoin address balance task in monero syncer");
                     continue;
                 }
             };

--- a/src/syncerd/monero_syncer.rs
+++ b/src/syncerd/monero_syncer.rs
@@ -977,7 +977,7 @@ fn balance_fetcher(
                                 })
                                 .await
                                 .expect("error sending address balance event");
-                            debug!("failed to retrieve address balance: {}", e);
+                            warn!("failed to retrieve address balance: {}", e);
                         }
                     }
                 }


### PR DESCRIPTION
* Calculate the the bitcoin address balance by adding both the confirmed and unconfirmed values.
* Print warn (and not debug) when balance retrieval fails.
* Correct log message when sending a bitcoin address balance task to a monero syncer.