### PR TITLE
update shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@ let
     name = "nixos-release-24.05";
     url = "https://github.com/nixos/nixpkgs/";
     ref = "refs/heads/release-24.05";
-    rev = "9957cd48326fe8dbd52fdc50dd2502307f188b0d";
+    rev = "5a83f6f984f387d47373f6f0c43b97a64e7755c0";
   }) {
     overlays = [
       (import (builtins.fetchTarball

--- a/shell.nix
+++ b/shell.nix
@@ -1,19 +1,16 @@
 let
-  pkgs = import
-    (builtins.fetchGit {
-      name = "nixos-release-22.05";
-      url = "https://github.com/nixos/nixpkgs/";
-      ref = "refs/heads/release-22.05";
-      rev = "6ddd2d34e3701339eb01bbf1259b258adcc6156c";
-    })
-    {
-      overlays = [
-        (import (builtins.fetchTarball
-          "https://github.com/oxalica/rust-overlay/archive/master.tar.gz"))
-      ];
-    };
-in
-pkgs.mkShell {
+  pkgs = import (builtins.fetchGit {
+    name = "nixos-release-24.05";
+    url = "https://github.com/nixos/nixpkgs/";
+    ref = "refs/heads/release-24.05";
+    rev = "9957cd48326fe8dbd52fdc50dd2502307f188b0d";
+  }) {
+    overlays = [
+      (import (builtins.fetchTarball
+        "https://github.com/oxalica/rust-overlay/archive/master.tar.gz"))
+    ];
+  };
+in pkgs.mkShell {
   buildInputs = with pkgs; [
     cargo
     cargo-watch


### PR DESCRIPTION
The `shell.nix` was out of date with the latest rust toolchain required for building `main`. This now uses (close to) latest `nixpkgs` revision compatible without replacing the `zmq2` dependency.